### PR TITLE
Use solidity-extract-imports instead of a full parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buidler",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7929,10 +7929,10 @@
         }
       }
     },
-    "solidity-parser-antlr": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.11.tgz",
-      "integrity": "sha512-9Fnd58I0WTeRIqJQPNxnrO3699gkIiPBkN3MGdLN1WfNVbbbMIo9qTB1UdCYIU7OGx5xKUTUNH6tqudg4wFiUw=="
+    "solidity-extract-imports": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/solidity-extract-imports/-/solidity-extract-imports-0.1.2.tgz",
+      "integrity": "sha512-uz+l9UWs8dSNuzGjxVwHqIueqM6a9ZxauQKyZ4mA67izQjPBV9DnrqtBXLHlSQYvxdDUHtCg/xnGcUT5O2x6uA=="
     },
     "sort-keys": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ora": "^2.1.0",
     "repl.history": "^0.1.4",
     "solc": "^0.4.21",
-    "solidity-parser-antlr": "^0.2.11",
+    "solidity-extract-imports": "^0.1.2",
     "truffle-contract": "^3.0.5",
     "tsort": "0.0.1",
     "web3": "^0.20.6"

--- a/src/solidity/imports.js
+++ b/src/solidity/imports.js
@@ -1,18 +1,10 @@
 "use strict";
 
 const importLazy = require("import-lazy")(require);
-const parser = importLazy("solidity-parser-antlr");
+const extract = importLazy("solidity-extract-imports");
 
 function getImports(resolvedFile) {
-  const ast = parser.parse(resolvedFile.content, { tolerant: true });
-
-  const importedFiles = [];
-
-  parser.visit(ast, {
-    ImportDirective: node => importedFiles.push(node.path)
-  });
-
-  return importedFiles;
+  return extract(resolvedFile.content)
 }
 
 module.exports = { getImports };


### PR DESCRIPTION
On a quick benchmark, this provides between one and two orders of magnitude speed improvement in extracting imports from source files.