### PR TITLE
Updated constructor on Greeter.sol to remove deprecated warning.

### DIFF
--- a/sample-project/contracts/Greeter.sol
+++ b/sample-project/contracts/Greeter.sol
@@ -4,7 +4,7 @@ contract Greeter {
 
     string greeting;
 
-    function Greeter(string _greeting) public {
+    constructor(string _greeting) public {
         greeting = _greeting;
     }
 


### PR DESCRIPTION
Sample project compilation issues a warning due to deprecated usage of constructor over Greeter.sol.