### PR TITLE
Add option to enable ES7 in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
     "truffle-contract": "^3.0.5",
     "tsort": "0.0.1",
     "web3": "^0.20.6"
+  },
+  "optionalDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/register": "^7.0.0"
   }
 }

--- a/recommended-babelrc.txt
+++ b/recommended-babelrc.txt
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "@babel/preset-env"
+  ],
+  plugins: [
+    '@babel/plugin-transform-runtime'
+  ]
+}

--- a/src/builtin-tasks/test.js
+++ b/src/builtin-tasks/test.js
@@ -1,6 +1,9 @@
+const importLazy = require("import-lazy")(require);
+const fs = importLazy("fs-extra");
 const path = require("path");
 const util = require("util");
 const glob = util.promisify(require("glob"));
+const { getProjectRoot } = require("../core/project-structure");
 
 internalTask("builtin:get-test-files")
   .addOptionalVariadicPositionalParam(
@@ -36,6 +39,13 @@ internalTask("builtin:run-mocha-tests")
   .setAction(async ({ testFiles }) => {
     const Mocha = require("mocha");
     const mocha = new Mocha(config.mocha);
+    if(await fs.pathExists(path.join(getProjectRoot(), ".babelrc"))) {
+      try {
+        require("@babel/register");
+      } catch (error) {
+        throw "Please install Babel or remove `.babelrc`\n `npm install -g @babel/runtime @babel/preset-env @babel/plugin-transform-runtime`";
+      }
+    }
     testFiles.forEach(file => mocha.addFile(file));
 
     mocha.run(failures => {

--- a/src/cli/project-creation.js
+++ b/src/cli/project-creation.js
@@ -4,7 +4,10 @@ const path = require("path");
 const chalk = importLazy("chalk");
 const inquirer = importLazy("inquirer");
 
-const { getRecommendedGitIgnore } = require("../core/project-structure");
+const {
+  getRecommendedGitIgnore,
+  getRecommendedBabelRc,
+} = require("../core/project-structure");
 const { emoji } = require("./emoji");
 
 async function removeProjectDirIfPresent(projectRoot, dirName) {
@@ -73,6 +76,14 @@ async function copySampleProject(projectRoot) {
   await fs.remove(path.join(projectRoot, "LICENSE.md"));
 }
 
+async function addBabelRc(projectRoot) {
+  const babelRcPath = path.join(projectRoot, ".babelrc");
+
+  let content = await getRecommendedBabelRc();
+
+  await fs.writeFile(babelRcPath, content);
+}
+
 async function addGitIgnore(projectRoot) {
   const gitIgnorePath = path.join(projectRoot, ".gitignore");
 
@@ -126,7 +137,8 @@ async function createProject() {
   const {
     projectRoot,
     shouldAddGitIgnore,
-    shouldAddGitAttributes
+    shouldAddGitAttributes,
+    shouldEnableES7,
   } = await inquirer.prompt([
     {
       name: "projectRoot",
@@ -143,7 +155,12 @@ async function createProject() {
       type: "confirm",
       message:
         "Do you want to add a .gitattributes to enable Soldity highlighting on GitHub?"
-    }
+    },
+    {
+      name: "shouldEnableES7",
+      type: "confirm",
+      message: "Do you want to enable ES7 in your tests?"
+    },
   ]);
 
   await copySampleProject(projectRoot);
@@ -154,6 +171,10 @@ async function createProject() {
 
   if (shouldAddGitAttributes) {
     await addGitAttributes(projectRoot);
+  }
+
+  if (shouldEnableES7) {
+    await addBabelRc(projectRoot);
   }
 
   console.log(chalk.cyan(`\n${emoji("✨ ")}Project created${emoji(" ✨")}`));

--- a/src/core/project-structure.js
+++ b/src/core/project-structure.js
@@ -37,9 +37,21 @@ async function getRecommendedGitIgnore() {
   return fs.readFile(gitIgnorePath, "utf-8");
 }
 
+async function getRecommendedBabelRc() {
+  const babelRcPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "recommended-babelrc.txt"
+  );
+
+  return fs.readFile(babelRcPath, "utf-8");
+}
+
 module.exports = {
   isCwdInsideProject,
   getUserConfigPath,
   getProjectRoot,
-  getRecommendedGitIgnore
+  getRecommendedGitIgnore,
+  getRecommendedBabelRc,
 };


### PR DESCRIPTION
Hey @nomiclabs! 👋

Thanks for building buidler! I’ve been look for something exactly like this!

Here’s a PR that enables ES7 support in tests. It may be more work to maintain then it’s worth (I imagine people will inevitably have issues with babel). Maybe this would be better in a wiki explaining how to enable ES7 if you need it?

Feel free to merge or close without merging.  I just needed this because in my previous setup I was using `import` and `export` syntax.

Thanks again!

Looking forward to building more with buidler!
