### PR TITLE
Fix TS types resolution on tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4337,6 +4337,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==",
+      "dev": true
+    },
     "download": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^10.12.7",
     "@types/ora": "^1.3.4",
     "codecov": "^3.1.0",
+    "dotenv": "^6.1.0",
     "ganache-cli": "^6.1.6",
     "nyc": "^13.1.0",
     "prettier": "^1.10.2",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+--require dotenv/config
 --require ts-node/register
 --require source-map-support/register
 --recursive test/**/*.ts

--- a/test/solidity/compiler.ts
+++ b/test/solidity/compiler.ts
@@ -1,0 +1,7 @@
+import { Compiler } from "../../src/solidity/compiler";
+
+describe("Compiler", () => {
+  it("DELETE ME", () => {
+    new Compiler("a", "a", { enabled: false, runs: 23 });
+  });
+});


### PR DESCRIPTION
TS-node ignores some parts of tsconfig.json by default. That behaviour
can be disabled with a flag or env variabler.

I installed dotenv and add it to mocha.opts. This way the env var is
defined however you run your tests (with/without npm, in travis, from
your IDE/editor, etc).