### PR TITLE
Fix various bugs in runtime environment

### DIFF
--- a/test/core/runtime-environment.ts
+++ b/test/core/runtime-environment.ts
@@ -88,4 +88,24 @@ describe("BuidlerRuntimeEnvironment", () => {
     const localEnv = new BuidlerRuntimeEnvironment(config, args, tasks);
     assert.equal(await localEnv.run("example"), 28);
   });
+
+  it("Should preserve the injected env after running a sub-task", async () => {
+    dsl.task(
+      "with-subtask",
+      "description",
+      async ({}, { run, config: theConfig }, runSuper) => {
+        const globalAsAny = global as any;
+        assert.equal(globalAsAny.config, theConfig);
+        assert.isDefined(globalAsAny.config);
+        assert.equal(globalAsAny.runSuper, runSuper);
+
+        await run("example");
+
+        assert.equal(globalAsAny.config, theConfig);
+        assert.equal(globalAsAny.runSuper, runSuper);
+      }
+    );
+
+    await env.run("with-subtask");
+  });
 });


### PR DESCRIPTION
Bugs fixed:

1. If a subtask was run the injected values were lost
2. BLACKLISTED_PROPERTIES was being injected
3. runSuper was always removed if a subtask was run
4. tasks completion was not awaited, leading to all sort of errors.