### PR TITLE
Multiple improvements to the providers

### DIFF
--- a/src/core/providers/ethereum.ts
+++ b/src/core/providers/ethereum.ts
@@ -1,30 +1,59 @@
 import { EventEmitter } from "events";
 import { promisify } from "util";
-import { JsonRPCResponse, Provider } from "web3x/providers";
+import { Provider } from "web3x/providers";
 import { toPayload } from "web3x/request-manager/jsonrpc";
 
-export class EthereumProvider extends EventEmitter
-  implements IEthereumProvider {
-  private readonly _provider: Provider;
-  constructor(provider: Provider) {
-    super();
-    this._provider = provider;
-  }
+import { FixedJsonRPCResponse } from "../../types";
 
-  public async send(method: string, params?: any[]): Promise<any> {
-    const payload = toPayload(method, params);
-
-    const promisifiedSend = promisify(this._provider.send.bind(this._provider));
-
-    const response: JsonRPCResponse = await promisifiedSend(payload);
-    if (response.error === undefined) {
-      return response.result;
-    } else {
-      throw Error(response.error);
-    }
-  }
-}
 export interface IEthereumProvider extends EventEmitter {
   send(method: string, params?: any[]): Promise<any>;
   on(type: string, listener: (result: any) => void): this;
+}
+
+class EthereumProviderError extends Error {
+  constructor(
+    public readonly message: string,
+    public readonly code: number,
+    public readonly data: any
+  ) {
+    super(message);
+  }
+}
+
+export class EthereumProvider extends EventEmitter
+  implements IEthereumProvider {
+  constructor(private readonly provider: Provider) {
+    super();
+  }
+
+  public async send(method: string, params?: any[]): Promise<any> {
+    if (method === "eth_requestAccounts") {
+      throw new Error("'eth_requestAccounts' is not yet supported");
+    }
+
+    const payload = toPayload(method, params);
+
+    const promisifiedSend = promisify(this.provider.send.bind(this.provider));
+
+    const response = (await promisifiedSend(payload)) as FixedJsonRPCResponse;
+
+    if (response.error === undefined) {
+      return response.result;
+    } else {
+      const error = response.error;
+
+      throw new EthereumProviderError(error.message, error.code, error.data);
+    }
+  }
+
+  public on(event: string | symbol, listener: (...args: any[]) => void): this {
+    throw new Error("Event listeners are not yet supported");
+  }
+
+  public once(
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ): this {
+    throw new Error("Event listeners are not yet supported");
+  }
 }

--- a/src/core/providers/web3x-ethereum.ts
+++ b/src/core/providers/web3x-ethereum.ts
@@ -1,27 +1,32 @@
+import { callbackify } from "util";
 import { Callback, JsonRPCRequest, Provider } from "web3x/providers";
 
 import { IEthereumProvider } from "./ethereum";
 
 export class EthereumWeb3xProvider implements Provider {
-  private readonly _provider: IEthereumProvider;
+  constructor(private readonly provider: IEthereumProvider) {}
 
-  constructor(provider: IEthereumProvider) {
-    this._provider = provider;
-  }
-
-  public send(payload: JsonRPCRequest, callback: Callback): any {
-    this._provider.send(payload.method, payload.params).then(
-      response => {
-        callback(undefined, {
-          result: response,
+  public send(request: JsonRPCRequest, callback: Callback): any {
+    callbackify((payload: JsonRPCRequest) =>
+      this.provider.send(payload.method, payload.params).then(
+        response => ({
           jsonrpc: payload.jsonrpc,
-          id: payload.id
-        });
-      },
-      error => {
-        callback(error, undefined);
-      }
-    );
+          id: payload.id,
+          result: response
+        }),
+        error => ({
+          jsonrpc: payload.jsonrpc,
+          id: payload.id,
+          error: {
+            message: error.message,
+            code: error.code,
+            data: error.data
+          }
+        })
+      )
+    )(request, callback as any);
+    // TODO: Remove the any form the above statement once this is fixed:
+    // https://github.com/xf00f/web3x/issues/13
   }
 
   public disconnect() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,3 +85,16 @@ export type GlobalWithBuidlerRuntimeEnvironment = NodeJS.Global & {
 export interface ResolvedFilesMap {
   [globalName: string]: ResolvedFile;
 }
+
+// TODO: This should go away once this gets fixed:
+// https://github.com/xf00f/web3x/issues/13
+export interface FixedJsonRPCResponse {
+  jsonrpc: string;
+  id: number;
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+}

--- a/test/core/providers/ethereum.ts
+++ b/test/core/providers/ethereum.ts
@@ -81,4 +81,18 @@ describe("ethereum provider", () => {
         assert.equal(response, params);
       });
   });
+
+  it("Should throw when someone tries to attack an event listener", () => {
+    assert.throw(() => ethereum.on("notification", () => {}));
+    assert.throw(() => ethereum.once("notification", () => {}));
+  });
+
+  it("Should throw when someone tries to unlock accounts", async () => {
+    try {
+      await ethereum.send("eth_requestAccounts");
+      assert.fail("Should have thrown");
+    } catch (err) {
+      assert.isDefined(err);
+    }
+  });
 });

--- a/test/core/providers/web3x-ethereum.ts
+++ b/test/core/providers/web3x-ethereum.ts
@@ -6,6 +6,7 @@ import { toPayload } from "web3x/request-manager/jsonrpc";
 
 import { IEthereumProvider } from "../../../src/core/providers/ethereum";
 import { EthereumWeb3xProvider } from "../../../src/core/providers/web3x-ethereum";
+import { FixedJsonRPCResponse } from "../../../src/types";
 
 class MockedEthereumProvider extends EventEmitter implements IEthereumProvider {
   constructor() {
@@ -25,14 +26,12 @@ class MockedEthereumProvider extends EventEmitter implements IEthereumProvider {
       }
     });
   }
-
-  public disconnect() {}
 }
 
 describe("web3x ethereum provider", () => {
   let ethereum: MockedEthereumProvider;
   let wrapper: EthereumWeb3xProvider;
-  let wrapperSend: (payload: JsonRPCRequest) => Promise<JsonRPCResponse>;
+  let wrapperSend: (payload: JsonRPCRequest) => Promise<FixedJsonRPCResponse>;
 
   beforeEach(() => {
     ethereum = new MockedEthereumProvider();
@@ -48,22 +47,17 @@ describe("web3x ethereum provider", () => {
 
   it("should return an error", async () => {
     const payload = toPayload("bleep");
-    try {
-      await wrapperSend(payload);
-      assert.fail("This should have thrown");
-    } catch (err) {
-      assert.equal(err!.message, "Method not found");
-    }
+    const response = await wrapperSend(payload);
+    assert.equal(response.error!.message, "Method not found");
   });
 
-  it("response should contains an error", async () => {
+  it("response should contain an error", async () => {
     const payload = toPayload("fail_method");
-    try {
-      await wrapperSend(payload);
-      assert.fail("This should have thrown");
-    } catch (err) {
-      assert.equal(err!.message, "do not meet the requirements");
-    }
+
+    const response = (await wrapperSend(payload)) as FixedJsonRPCResponse;
+
+    assert.isDefined(response.error);
+    assert.equal(response.error!.message, "do not meet the requirements");
   });
 
   it("should keep payload unchanged", async () => {


### PR DESCRIPTION
1. Temporarily fix of a web3x typing
2. Properly convert promises to callback based apis, resulting in unhandled errors not being lost.
3. Throw errors on some unsupported methods of EthereumProvider
4. Fix some error handling
5. Fix some tests
