### PR TITLE
Small changes to ArgumentParser

### DIFF
--- a/src/cli/ArgumentsParser.ts
+++ b/src/cli/ArgumentsParser.ts
@@ -25,13 +25,20 @@ export class ArgumentsParser {
   }
 
   public static cLAToParamName(cLA: string): string {
+    if (cLA.toLowerCase() !== cLA) {
+      throw new BuidlerError(
+        ERRORS.ARGUMENT_PARSER_PARAM_NAME_INVALID_CASING,
+        cLA
+      );
+    }
+
     const parts = cLA.slice(ArgumentsParser.PARAM_PREFIX.length).split("-");
 
     return (
       parts[0] +
       parts
         .slice(1)
-        .map(s => s[0].toUpperCase() + s.slice(1).toLowerCase())
+        .map(s => s[0].toUpperCase() + s.slice(1))
         .join("")
     );
   }
@@ -58,7 +65,7 @@ export class ArgumentsParser {
           continue;
         }
 
-        if (!this._isParamName(arg, buidlerParamDefinitions)) {
+        if (!this._isCLAParamName(arg, buidlerParamDefinitions)) {
           throw new BuidlerError(
             ERRORS.ARGUMENT_PARSER_UNRECOGNIZED_COMMAND_LINE_ARG,
             arg
@@ -72,7 +79,7 @@ export class ArgumentsParser {
           buidlerArguments
         );
       } else {
-        if (!this._isParamName(arg, buidlerParamDefinitions)) {
+        if (!this._isCLAParamName(arg, buidlerParamDefinitions)) {
           unparsedCLAs.push(arg);
           continue;
         }
@@ -128,7 +135,7 @@ export class ArgumentsParser {
         continue;
       }
 
-      if (!this._isParamName(arg, taskDefintion.paramDefinitions)) {
+      if (!this._isCLAParamName(arg, taskDefintion.paramDefinitions)) {
         throw new BuidlerError(
           ERRORS.ARGUMENT_PARSER_UNRECOGNIZED_PARAM_NAME,
           arg
@@ -182,7 +189,7 @@ export class ArgumentsParser {
     }
   }
 
-  public _isParamName(str: string, paramDefinitions: ParamDefinitionsMap) {
+  public _isCLAParamName(str: string, paramDefinitions: ParamDefinitionsMap) {
     if (!this._hasCLAParamNameFormat(str)) {
       return false;
     }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -252,6 +252,10 @@ export const ERRORS = {
   RESOLVED_IMPORTED_FILE_NOT_FOUND: {
     number: 48,
     message: 'File "%s", imported from "%s", not found.'
+  },
+  ARGUMENT_PARSER_PARAM_NAME_INVALID_CASING: {
+    number: 49,
+    message: 'Invalid param "%s". Command line params must be lowercase.'
   }
 };
 

--- a/test/cli/ArgumentsParser.ts
+++ b/test/cli/ArgumentsParser.ts
@@ -33,7 +33,7 @@ describe("ArgumentsParser", () => {
       .addParam("bleep", "useless param", 1602, int, true);
   });
 
-  it("should tranform a param name into CLA", () => {
+  it("should transform a param name into CLA", () => {
     assert.equal(
       ArgumentsParser.paramNameToCLA("showStackTraces"),
       "--show-stack-traces"
@@ -41,23 +41,28 @@ describe("ArgumentsParser", () => {
     assert.equal(ArgumentsParser.paramNameToCLA("version"), "--version");
   });
 
+  it("Should throw if a param name CLA isn't all lowercase", () => {
+    expectBuidlerError(
+      () => ArgumentsParser.cLAToParamName("--showStackTraces"),
+      ERRORS.ARGUMENT_PARSER_PARAM_NAME_INVALID_CASING
+    );
+
+    expectBuidlerError(
+      () => ArgumentsParser.cLAToParamName("--showstackTraces"),
+      ERRORS.ARGUMENT_PARSER_PARAM_NAME_INVALID_CASING
+    );
+
+    expectBuidlerError(
+      () => ArgumentsParser.cLAToParamName("--show-stack-Traces"),
+      ERRORS.ARGUMENT_PARSER_PARAM_NAME_INVALID_CASING
+    );
+  });
+
   it("should transform CLA into a param name", () => {
     assert.equal(ArgumentsParser.cLAToParamName("--run"), "run");
-    // TODO : define how much flexibility we want to offer on this
+
     assert.equal(
-      ArgumentsParser.cLAToParamName("--showStackTraces"),
-      "showStackTraces"
-    );
-    assert.equal(
-      ArgumentsParser.cLAToParamName("--showstackTraces"),
-      "showstackTraces"
-    );
-    assert.equal(
-      ArgumentsParser.cLAToParamName("--show-stack-Traces"),
-      "showStackTraces"
-    );
-    assert.equal(
-      ArgumentsParser.cLAToParamName("--show-Stack-Traces"),
+      ArgumentsParser.cLAToParamName("--show-stack-traces"),
       "showStackTraces"
     );
   });
@@ -69,27 +74,27 @@ describe("ArgumentsParser", () => {
 
   it("should detect parameter names", () => {
     assert.isTrue(
-      argumentsParser._isParamName(
-        "--show-Stack-Traces",
+      argumentsParser._isCLAParamName(
+        "--show-stack-traces",
         BUIDLER_PARAM_DEFINITIONS
       )
     );
     assert.isFalse(
-      argumentsParser._isParamName("sarasa", BUIDLER_PARAM_DEFINITIONS)
+      argumentsParser._isCLAParamName("sarasa", BUIDLER_PARAM_DEFINITIONS)
     );
     assert.isFalse(
-      argumentsParser._isParamName("--sarasa", BUIDLER_PARAM_DEFINITIONS)
+      argumentsParser._isCLAParamName("--sarasa", BUIDLER_PARAM_DEFINITIONS)
     );
   });
 
   describe("buidler arguments", () => {
     it("should parse buidler arguments with task", () => {
       const rawCLAs: string[] = [
-        "--showStackTraces",
+        "--show-stack-traces",
         "--network",
         "local",
         "compile",
-        "--taskParam"
+        "--task-param"
       ];
 
       const {
@@ -106,14 +111,14 @@ describe("ArgumentsParser", () => {
       assert.equal(buidlerArguments.network, "local");
       assert.equal(buidlerArguments.emoji, false);
       assert.equal(unparsedCLAs.length, 1);
-      assert.equal("--taskParam", unparsedCLAs[0]);
+      assert.equal("--task-param", unparsedCLAs[0]);
     });
 
     it("should parse buidler arguments after taskname", () => {
       const rawCLAs: string[] = [
         "compile",
-        "--taskParam",
-        "--showStackTraces",
+        "--task-param",
+        "--show-stack-traces",
         "--network",
         "local"
       ];
@@ -132,14 +137,14 @@ describe("ArgumentsParser", () => {
       assert.equal(buidlerArguments.network, "local");
       assert.equal(buidlerArguments.emoji, false);
       assert.equal(unparsedCLAs.length, 1);
-      assert.equal("--taskParam", unparsedCLAs[0]);
+      assert.equal("--task-param", unparsedCLAs[0]);
     });
 
     it("should fail trying to parse task arguments before taskname", () => {
       const rawCLAs: string[] = [
-        "--taskParam",
+        "--task-param",
         "compile",
-        "--showStackTraces",
+        "--show-stack-traces",
         "--network",
         "local"
       ];
@@ -157,7 +162,7 @@ describe("ArgumentsParser", () => {
 
     it("should parse a buidler argument", () => {
       const rawCLAs: string[] = [
-        "--showStackTraces",
+        "--show-stack-traces",
         "--network",
         "local",
         "compile"
@@ -188,10 +193,10 @@ describe("ArgumentsParser", () => {
 
     it("should fail trying to parse buidler with invalid argument", () => {
       const rawCLAs: string[] = [
-        "--showStackTraces",
+        "--show-stack-traces",
         "--network",
         "local",
-        "--invalidParam"
+        "--invalid-param"
       ];
       expectBuidlerError(
         () =>
@@ -206,7 +211,7 @@ describe("ArgumentsParser", () => {
 
     it("should fail trying to parse a repeated argument", () => {
       const rawCLAs: string[] = [
-        "--showStackTraces",
+        "--show-stack-traces",
         "--network",
         "local",
         "--network",
@@ -262,6 +267,7 @@ describe("ArgumentsParser", () => {
         [],
         int
       );
+
       const rawPositionalArguments = ["16", "02"];
       const positionalArguments = argumentsParser._parsePositionalParamArgs(
         rawPositionalArguments,
@@ -288,7 +294,7 @@ describe("ArgumentsParser", () => {
     });
 
     it("should fail when passing invalid parameter", () => {
-      const rawCLAs: string[] = ["--invalidParameter", "not_valid"];
+      const rawCLAs: string[] = ["--invalid-parameter", "not_valid"];
       expectBuidlerError(() => {
         argumentsParser.parseTaskArguments(taskDefinition, rawCLAs);
       }, ERRORS.ARGUMENT_PARSER_UNRECOGNIZED_PARAM_NAME);


### PR DESCRIPTION
This PR contains a few improvements to `ArgumentParser`. The main one is that it now enforces CLI param names to be lowercase. 

This decision is somewhat conservative and may change in the future, but it's also very easy to explain and to reason about.