### PR TITLE
Add node version validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
@@ -18929,10 +18935,9 @@
       "optional": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "buidler": "dist/src/cli/cli.js",
     "builder": "dist/src/cli/cli-with-a-typo.js"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "scripts": {
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
@@ -40,6 +43,7 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.38",
     "@types/ora": "^1.3.4",
+    "@types/semver": "^5.5.0",
     "codecov": "^3.1.0",
     "dotenv": "^6.1.0",
     "ganache-cli": "^6.1.6",
@@ -73,6 +77,7 @@
     "mocha": "^5.1.1",
     "ora": "^2.1.0",
     "repl.history": "^0.1.4",
+    "semver": "^5.6.0",
     "solc": "0.5.1",
     "solidity-parser-antlr": "^0.2.12",
     "source-map-support": "^0.5.9",

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -252,6 +252,10 @@ export const ERRORS = {
   RESOLVED_IMPORTED_FILE_NOT_FOUND: {
     number: 48,
     message: 'File "%s", imported from "%s", not found.'
+  },
+  INVALID_NODE_VERSION: {
+    number: 50,
+    message: "Buidler doesn't support your node version. It should be %s."
   }
 };
 

--- a/src/util/packageInfo.ts
+++ b/src/util/packageInfo.ts
@@ -21,6 +21,9 @@ export async function getPackageRoot(): Promise<string> {
 export interface PackageJson {
   name: string;
   version: string;
+  engines: {
+    node: string;
+  };
 }
 
 export async function getPackageJson(): Promise<PackageJson> {


### PR DESCRIPTION
This PR validates the node version and fails with a clear message if it doesn't meet Buidler's requirements. 

This is important as we aren't supporting old version. We should define a policy for this in the future. 