### PR TITLE
Import the builtin tasks definitions with static imports

### DIFF
--- a/src/core/tasks/builtin-tasks.ts
+++ b/src/core/tasks/builtin-tasks.ts
@@ -1,17 +1,7 @@
-import path from "path";
-
-import { globSync } from "../../util/glob";
-
-const extension = __filename.endsWith(".js") ? "js" : "ts";
-
-const pattern = path.join(
-  __dirname,
-  "..",
-  "..",
-  "builtin-tasks",
-  "*." + extension
-);
-
-globSync(pattern)
-  .sort()
-  .forEach((f: string) => require(f));
+import "../../builtin-tasks/clean";
+import "../../builtin-tasks/compile";
+import "../../builtin-tasks/console";
+import "../../builtin-tasks/flatten";
+import "../../builtin-tasks/help";
+import "../../builtin-tasks/run";
+import "../../builtin-tasks/test";

--- a/src/util/glob.ts
+++ b/src/util/glob.ts
@@ -2,4 +2,3 @@ import globModule from "glob";
 import util from "util";
 
 export const glob = util.promisify(globModule);
-export const globSync = globModule.sync.bind(globModule);


### PR DESCRIPTION
We used to have some logic to import them dynamically. This PR removes that and imports everything statically. This will be important when we webpack/rollup the project.

There were two reasons for the dynamic imports:
1. It ensures that all of them are imported.
2. It ensures a (any) consistent order of imports.

TSLint also ensures an order, so we get (2) statically too. (1) is not enforced now, but the errors for not importing one are kind of obvious (eg: a missing task).