### PR TITLE
Split development and prod ts config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,6 @@
 /coverage
 /\.nyc_output
 
-# Generated config-export files
-/config.d.ts
-/config.d.ts.map
-/config.js
-/config.js.map
-
 #Below is Github's node gitignore template
 
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,19 @@
 /coverage
 /\.nyc_output
 
+# TSC prod output. This has to be in sync with the to directories in ./src, and with npm script prod:clean
+
+/*.js
+/*.js.map
+/*.d.ts
+/*.d.ts.map
+/builtin-tasks
+/cli
+/core
+/lib
+/solidity
+/util
+
 #Below is Github's node gitignore template
 
 # Logs

--- a/config.ts
+++ b/config.ts
@@ -1,2 +1,0 @@
-export * from "./dist/src/core/config/config-env";
-export { BuidlerConfig } from "./dist/src/types";

--- a/package.json
+++ b/package.json
@@ -31,8 +31,12 @@
     "fix": "prettier --write 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' && tslint --fix --config tslint.json --project tsconfig.json",
     "lint": "tslint --config tslint.json --project tsconfig.json",
     "test": "nyc mocha",
-    "build": "tsc",
-    "watch": "tsc -w"
+    "dev:build": "tsc",
+    "dev:watch": "tsc -w",
+    "dev:clean": "rm -rf dist",
+    "prod:build": "tsc --p tsconfig.prod.json",
+    "prod:watch": "tsc -w --p tsconfig.prod.json",
+    "prod:clean": "rm -rf builtin-tasks cli core lib solidity util *.d.ts *.map *.js"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "fix": "prettier --write 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' && tslint --fix --config tslint.json --project tsconfig.json",
     "lint": "tslint --config tslint.json --project tsconfig.json",
     "test": "nyc mocha",
-    "build": "tsc && tsc --sourceMap --declarationMap --declaration config.ts",
-    "watch": "npm run build && tsc -w"
+    "build": "tsc",
+    "watch": "tsc -w"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export * from "./core/config/config-env";
+export { BuidlerConfig } from "./types";

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,60 +1,8 @@
 {
+  "extends": "./tsconfig.common",
   "compilerOptions": {
-    /* Basic Options */
-    "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-    "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                        /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                       /* Redirect output structure to the directory. */
-    // "rootDir": "",                         /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    "rootDirs": ["./src", "./test"],          /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */,
+    "outDir": "./dist",
+    "rootDirs": ["./src", "./test"]
   },
-  "exclude": ["sample-project", "dist", "node_modules", "./config.*"]
+  "include": ["./test", "./src/**/*.ts"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.common",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "."
+  },
+  "exclude": ["./node_modules"]
+}


### PR DESCRIPTION
The goal of this PR is to compile the production version into the root folder of the npm package. This way plugin authors can extend types using `declare module "buidler/types" {...}` instead of `declare module "buidler/dist/src/types" {...}`.