### PR TITLE
Replace overload for overridden

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -140,10 +140,10 @@ export const ERRORS = {
       message:
         'Could not set param "%s" for task "%s" because it is mandatory and it was added after an optional positional param.'
     },
-    OVERLOAD_NO_PARAMS: {
+    OVERRIDE_NO_PARAMS: {
       number: 204,
       message:
-        'Redefinition of task "%s" failed. You can\'t change param definitions in an overloaded task.'
+        'Redefinition of task "%s" failed. You can\'t change param definitions in an overridden task.'
     },
     ACTION_NOT_SET: {
       number: 205,
@@ -152,7 +152,7 @@ export const ERRORS = {
     RUNSUPER_NOT_AVAILABLE: {
       number: 206,
       message:
-        'Tried to call runSupper from a non-overloaded definition of task "%s"'
+        'Tried to call runSupper from a non-overridden definition of task "%s"'
     },
     DEFAULT_VALUE_WRONG_TYPE: {
       number: 207,

--- a/src/core/runtime-environment.ts
+++ b/src/core/runtime-environment.ts
@@ -14,7 +14,7 @@ import { lazyObject } from "../util/lazy";
 import { BuidlerError, ERRORS } from "./errors";
 import { createProvider } from "./providers/construction";
 import { IEthereumProvider } from "./providers/ethereum";
-import { OverloadedTaskDefinition } from "./tasks/task-definitions";
+import { OverriddenTaskDefinition } from "./tasks/task-definitions";
 
 export class Environment implements BuidlerRuntimeEnvironment {
   private static readonly BLACKLISTED_PROPERTIES: string[] = [
@@ -84,7 +84,7 @@ export class Environment implements BuidlerRuntimeEnvironment {
   ) {
     let runSuper: RunSuperFunction<TaskArguments>;
 
-    if (taskDefinition instanceof OverloadedTaskDefinition) {
+    if (taskDefinition instanceof OverriddenTaskDefinition) {
       runSuper = async (_taskArguments = taskArguments) =>
         this.runTaskDefinition(
           taskDefinition.parentTaskDefinition,

--- a/src/core/tasks/dsl.ts
+++ b/src/core/tasks/dsl.ts
@@ -6,7 +6,7 @@ import {
 } from "../../types";
 
 import {
-  OverloadedTaskDefinition,
+  OverriddenTaskDefinition,
   SimpleTaskDefinition
 } from "./task-definitions";
 
@@ -62,7 +62,7 @@ export class TasksDSL {
     let taskDefinition: TaskDefinition;
 
     if (parentTaskDefinition !== undefined) {
-      taskDefinition = new OverloadedTaskDefinition(
+      taskDefinition = new OverriddenTaskDefinition(
         parentTaskDefinition,
         isInternal
       );

--- a/src/core/tasks/task-definitions.ts
+++ b/src/core/tasks/task-definitions.ts
@@ -321,7 +321,7 @@ export class SimpleTaskDefinition implements TaskDefinition {
   }
 }
 
-export class OverloadedTaskDefinition implements TaskDefinition {
+export class OverriddenTaskDefinition implements TaskDefinition {
   private _description?: string;
   private _action?: ActionType<TaskArguments>;
 
@@ -379,7 +379,7 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     type?: types.ArgumentType<T>,
     isOptional?: boolean
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addOptionalParam<T>(
@@ -388,7 +388,7 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     defaultValue?: T,
     type?: types.ArgumentType<T>
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addPositionalParam<T>(
@@ -398,7 +398,7 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     type?: types.ArgumentType<T>,
     isOptional?: boolean
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addOptionalPositionalParam<T>(
@@ -407,7 +407,7 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     defaultValue?: T,
     type?: types.ArgumentType<T>
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addVariadicPositionalParam<T>(
@@ -417,7 +417,7 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     type?: types.ArgumentType<T>,
     isOptional?: boolean
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addOptionalVariadicPositionalParam<T>(
@@ -426,16 +426,16 @@ export class OverloadedTaskDefinition implements TaskDefinition {
     defaultValue?: T[],
     type?: types.ArgumentType<T>
   ): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
   public addFlag(name: string, description?: string): this {
-    return this._throwNoParamsOverloadError();
+    return this._throwNoParamsOverrideError();
   }
 
-  public _throwNoParamsOverloadError(): never {
+  public _throwNoParamsOverrideError(): never {
     throw new BuidlerError(
-      ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS,
+      ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS,
       this.name
     );
   }

--- a/test/core/runtime-environment.ts
+++ b/test/core/runtime-environment.ts
@@ -86,7 +86,7 @@ describe("Environment", () => {
       assert.isUndefined(globalAsAny.env);
     });
 
-    it("should run overloaded task correctly", async () => {
+    it("should run overridden task correctly", async () => {
       dsl.task("example", "description", async ret => {
         return 28;
       });

--- a/test/core/tasks/dsl.ts
+++ b/test/core/tasks/dsl.ts
@@ -51,7 +51,7 @@ describe("TasksDSL", () => {
     );
   });
 
-  it("should overload task", () => {
+  it("should override task", () => {
     const action = async () => {};
 
     const builtin = dsl.task("compile", "built-in", action);

--- a/test/core/tasks/task-definitions.ts
+++ b/test/core/tasks/task-definitions.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { ERRORS } from "../../../src/core/errors";
 import * as types from "../../../src/core/params/argumentTypes";
 import {
-  OverloadedTaskDefinition,
+  OverriddenTaskDefinition,
   SimpleTaskDefinition
 } from "../../../src/core/tasks/task-definitions";
 import {
@@ -731,9 +731,9 @@ describe("SimpleTaskDefinition", () => {
   });
 });
 
-describe("OverloadedTaskDefinition", () => {
+describe("OverriddenTaskDefinition", () => {
   let parentTask: SimpleTaskDefinition;
-  let overloadedTask: OverloadedTaskDefinition;
+  let overriddenTask: OverriddenTaskDefinition;
 
   beforeEach("init tasks", () => {
     parentTask = new SimpleTaskDefinition("t")
@@ -741,157 +741,157 @@ describe("OverloadedTaskDefinition", () => {
       .addFlag("f")
       .addPositionalParam("pp", "positional param");
 
-    overloadedTask = new OverloadedTaskDefinition(parentTask, true);
+    overriddenTask = new OverriddenTaskDefinition(parentTask, true);
   });
 
   describe("construction", () => {
     it("should have the right name", () => {
-      assert.equal(overloadedTask.name, "t");
+      assert.equal(overriddenTask.name, "t");
     });
 
     it("should set isInternal", () => {
-      assert.isTrue(overloadedTask.isInternal);
+      assert.isTrue(overriddenTask.isInternal);
     });
 
     it("should set the parent task", () => {
-      assert.equal(overloadedTask.parentTaskDefinition, parentTask);
+      assert.equal(overriddenTask.parentTaskDefinition, parentTask);
     });
   });
 
   describe("inherited properties", () => {
     it("should return the parent's name", () => {
-      assert.equal(overloadedTask.name, parentTask.name);
+      assert.equal(overriddenTask.name, parentTask.name);
     });
 
     it("should return the parent's action", () => {
-      assert.equal(overloadedTask.action, parentTask.action);
+      assert.equal(overriddenTask.action, parentTask.action);
     });
 
     it("should return the parent's description", () => {
-      assert.equal(overloadedTask.description, parentTask.description);
+      assert.equal(overriddenTask.description, parentTask.description);
     });
 
     it("should return the parent's param definitions", () => {
       assert.equal(
-        overloadedTask.paramDefinitions,
+        overriddenTask.paramDefinitions,
         parentTask.paramDefinitions
       );
     });
 
     it("should return the parent's positional param definitions", () => {
       assert.equal(
-        overloadedTask.positionalParamDefinitions,
+        overriddenTask.positionalParamDefinitions,
         parentTask.positionalParamDefinitions
       );
     });
 
     it("should work with more than one level of chaining", () => {
-      const overloadedAgain = new OverloadedTaskDefinition(
-        overloadedTask,
+      const overriddenAgain = new OverriddenTaskDefinition(
+        overriddenTask,
         false
       );
-      assert.equal(overloadedAgain.isInternal, false);
-      assert.equal(overloadedAgain.name, parentTask.name);
-      assert.equal(overloadedAgain.action, parentTask.action);
-      assert.equal(overloadedAgain.description, parentTask.description);
+      assert.equal(overriddenAgain.isInternal, false);
+      assert.equal(overriddenAgain.name, parentTask.name);
+      assert.equal(overriddenAgain.action, parentTask.action);
+      assert.equal(overriddenAgain.description, parentTask.description);
       assert.equal(
-        overloadedAgain.paramDefinitions,
+        overriddenAgain.paramDefinitions,
         parentTask.paramDefinitions
       );
       assert.equal(
-        overloadedAgain.positionalParamDefinitions,
+        overriddenAgain.positionalParamDefinitions,
         parentTask.positionalParamDefinitions
       );
     });
 
     it("should return overridden actions", () => {
-      assert.equal(overloadedTask.action, parentTask.action);
+      assert.equal(overriddenTask.action, parentTask.action);
 
       const action2 = async () => 1;
-      overloadedTask.setAction(action2);
+      overriddenTask.setAction(action2);
 
-      assert.equal(overloadedTask.action, action2);
+      assert.equal(overriddenTask.action, action2);
 
       const action3 = async () => 1;
-      overloadedTask.setAction(action3);
+      overriddenTask.setAction(action3);
 
-      assert.equal(overloadedTask.action, action3);
+      assert.equal(overriddenTask.action, action3);
 
-      const overloadedAgain = new OverloadedTaskDefinition(overloadedTask);
-      assert.equal(overloadedAgain.action, action3);
+      const overriddenAgain = new OverriddenTaskDefinition(overriddenTask);
+      assert.equal(overriddenAgain.action, action3);
 
       const action4 = async () => 1;
-      overloadedAgain.setAction(action4);
+      overriddenAgain.setAction(action4);
 
-      assert.equal(overloadedTask.action, action3);
-      assert.equal(overloadedAgain.action, action4);
+      assert.equal(overriddenTask.action, action3);
+      assert.equal(overriddenAgain.action, action4);
     });
 
     it("should return overridden descriptions", () => {
-      assert.equal(overloadedTask.description, parentTask.description);
+      assert.equal(overriddenTask.description, parentTask.description);
 
-      overloadedTask.setDescription("d2");
-      assert.equal(overloadedTask.description, "d2");
+      overriddenTask.setDescription("d2");
+      assert.equal(overriddenTask.description, "d2");
 
-      overloadedTask.setDescription("d3");
-      assert.equal(overloadedTask.description, "d3");
+      overriddenTask.setDescription("d3");
+      assert.equal(overriddenTask.description, "d3");
 
-      const overloadedAgain = new OverloadedTaskDefinition(overloadedTask);
-      assert.equal(overloadedTask.description, "d3");
+      const overriddenAgain = new OverriddenTaskDefinition(overriddenTask);
+      assert.equal(overriddenTask.description, "d3");
 
-      overloadedAgain.setDescription("d4");
-      assert.equal(overloadedTask.description, "d3");
-      assert.equal(overloadedAgain.description, "d4");
+      overriddenAgain.setDescription("d4");
+      assert.equal(overriddenTask.description, "d3");
+      assert.equal(overriddenAgain.description, "d4");
     });
   });
 
   describe("Param definitions are forbidden", () => {
     it("should throw if addParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addOptionalParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addOptionalParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addOptionalParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addFlag is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addFlag("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addFlag("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addPositionalParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addPositionalParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addPositionalParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addOptionalPositionalParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addOptionalPositionalParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addOptionalPositionalParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addVariadicPositionalParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addVariadicPositionalParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addVariadicPositionalParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
 
     it("should throw if addOptionalVariadicPositionalParam is called", () => {
       expectBuidlerError(
-        () => overloadedTask.addOptionalVariadicPositionalParam("p"),
-        ERRORS.TASK_DEFINITIONS.OVERLOAD_NO_PARAMS
+        () => overriddenTask.addOptionalVariadicPositionalParam("p"),
+        ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS
       );
     });
   });


### PR DESCRIPTION
This PR replaces the use of "overload" for "override" as it was wrong. It also fixes a typo in a filename.