### PR TITLE
Remove the added EventEmitter from the EIP-1193 interface

### DIFF
--- a/src/core/providers/accounts.ts
+++ b/src/core/providers/accounts.ts
@@ -4,9 +4,9 @@ import { Account } from "web3x/account";
 import { Tx } from "web3x/eth";
 import { bufferToHex } from "web3x/utils";
 
+import { IEthereumProvider } from "../../types";
 import { BuidlerError, ERRORS } from "../errors";
 
-import { IEthereumProvider } from "../../types";
 import { wrapSend } from "./wrapper";
 
 const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;

--- a/src/core/providers/accounts.ts
+++ b/src/core/providers/accounts.ts
@@ -6,7 +6,7 @@ import { bufferToHex } from "web3x/utils";
 
 import { BuidlerError, ERRORS } from "../errors";
 
-import { IEthereumProvider } from "./ethereum";
+import { IEthereumProvider } from "../../types";
 import { wrapSend } from "./wrapper";
 
 const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;

--- a/src/core/providers/construction.ts
+++ b/src/core/providers/construction.ts
@@ -6,7 +6,7 @@ import {
 } from "../../types";
 import { BuidlerError, ERRORS } from "../errors";
 
-import { IEthereumProvider } from "./ethereum";
+import { IEthereumProvider } from "../../types";
 
 export function isHDAccountsConfig(
   accounts?: NetworkConfigAccounts
@@ -39,12 +39,9 @@ export function createProvider(
 
   const { HttpProvider } = require("web3x/providers");
 
-  const baseProvider = new HttpProvider(
-    netConfig.url || "http://localhost:8545"
-  );
+  const url = netConfig.url || "http://localhost:8545";
 
-  // TODO: This may break, the base provider is not an IEthereumProvider
-  const provider: IEthereumProvider = baseProvider as any;
+  const provider: IEthereumProvider = new HttpProvider(url);
 
   return wrapEthereumProvider(provider, netConfig);
 }

--- a/src/core/providers/construction.ts
+++ b/src/core/providers/construction.ts
@@ -1,12 +1,11 @@
 import {
   HDAccountsConfig,
   HttpNetworkConfig,
+  IEthereumProvider,
   NetworkConfigAccounts,
   Networks
 } from "../../types";
 import { BuidlerError, ERRORS } from "../errors";
-
-import { IEthereumProvider } from "../../types";
 
 export function isHDAccountsConfig(
   accounts?: NetworkConfigAccounts

--- a/src/core/providers/ethereum.ts
+++ b/src/core/providers/ethereum.ts
@@ -1,6 +1,0 @@
-import { EventEmitter } from "events";
-import { EthereumProvider } from "web3x/providers";
-
-// TODO: This may not be the correct interface, see
-// https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640/31?u=alcuadrado
-export type IEthereumProvider = EthereumProvider & EventEmitter;

--- a/src/core/providers/gas-providers.ts
+++ b/src/core/providers/gas-providers.ts
@@ -1,4 +1,4 @@
-import { IEthereumProvider } from "./ethereum";
+import { IEthereumProvider } from "../../types";
 import { wrapSend } from "./wrapper";
 
 export function createFixedGasProvider(

--- a/src/core/providers/gas-providers.ts
+++ b/src/core/providers/gas-providers.ts
@@ -1,4 +1,5 @@
 import { IEthereumProvider } from "../../types";
+
 import { wrapSend } from "./wrapper";
 
 export function createFixedGasProvider(

--- a/src/core/providers/network.ts
+++ b/src/core/providers/network.ts
@@ -1,8 +1,8 @@
 import { Tx } from "web3x/eth";
 
+import { IEthereumProvider } from "../../types";
 import { BuidlerError, ERRORS } from "../errors";
 
-import { IEthereumProvider } from "../../types";
 import { wrapSend } from "./wrapper";
 
 export function createNetworkProvider(

--- a/src/core/providers/network.ts
+++ b/src/core/providers/network.ts
@@ -2,7 +2,7 @@ import { Tx } from "web3x/eth";
 
 import { BuidlerError, ERRORS } from "../errors";
 
-import { IEthereumProvider } from "./ethereum";
+import { IEthereumProvider } from "../../types";
 import { wrapSend } from "./wrapper";
 
 export function createNetworkProvider(

--- a/src/core/providers/wrapper.ts
+++ b/src/core/providers/wrapper.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from "lodash";
 
-import { IEthereumProvider } from "./ethereum";
+import { IEthereumProvider } from "../../types";
 
 export function wrapSend(
   provider: IEthereumProvider,

--- a/src/core/runtime-environment.ts
+++ b/src/core/runtime-environment.ts
@@ -2,6 +2,7 @@ import {
   BuidlerArguments,
   BuidlerRuntimeEnvironment,
   EnvironmentExtender,
+  IEthereumProvider,
   ResolvedBuidlerConfig,
   RunSuperFunction,
   RunTaskFunction,
@@ -13,7 +14,6 @@ import { lazyObject } from "../util/lazy";
 
 import { BuidlerError, ERRORS } from "./errors";
 import { createProvider } from "./providers/construction";
-import { IEthereumProvider } from "../types";
 import { OverriddenTaskDefinition } from "./tasks/task-definitions";
 
 export class Environment implements BuidlerRuntimeEnvironment {

--- a/src/core/runtime-environment.ts
+++ b/src/core/runtime-environment.ts
@@ -13,7 +13,7 @@ import { lazyObject } from "../util/lazy";
 
 import { BuidlerError, ERRORS } from "./errors";
 import { createProvider } from "./providers/construction";
-import { IEthereumProvider } from "./providers/ethereum";
+import { IEthereumProvider } from "../types";
 import { OverriddenTaskDefinition } from "./tasks/task-definitions";
 
 export class Environment implements BuidlerRuntimeEnvironment {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { DeepPartial, Omit } from "ts-essentials";
+import { EthereumProvider } from "web3x/providers";
 
 import * as types from "./core/params/argumentTypes";
-import { IEthereumProvider } from "./core/providers/ethereum";
 
 export interface GanacheOptions {
   gasLimit?: number;
@@ -211,6 +211,10 @@ export type ActionType<ArgsT extends TaskArguments> = (
   env: BuidlerRuntimeEnvironment,
   runSuper: RunSuperFunction<ArgsT>
 ) => Promise<any>;
+
+// TODO: This may not be the correct interface, see
+// https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640/31?u=alcuadrado
+export type IEthereumProvider = EthereumProvider;
 
 export interface BuidlerRuntimeEnvironment {
   readonly provider: IEthereumProvider;

--- a/test/core/providers/accounts.ts
+++ b/test/core/providers/accounts.ts
@@ -8,8 +8,8 @@ import {
   createLocalAccountsProvider,
   createSenderProvider
 } from "../../../src/core/providers/accounts";
-import { IEthereumProvider } from "../../../src/types";
 import { wrapSend } from "../../../src/core/providers/wrapper";
+import { IEthereumProvider } from "../../../src/types";
 import {
   expectBuidlerError,
   expectBuidlerErrorAsync,

--- a/test/core/providers/accounts.ts
+++ b/test/core/providers/accounts.ts
@@ -8,7 +8,7 @@ import {
   createLocalAccountsProvider,
   createSenderProvider
 } from "../../../src/core/providers/accounts";
-import { IEthereumProvider } from "../../../src/core/providers/ethereum";
+import { IEthereumProvider } from "../../../src/types";
 import { wrapSend } from "../../../src/core/providers/wrapper";
 import {
   expectBuidlerError,

--- a/test/core/providers/construction.ts
+++ b/test/core/providers/construction.ts
@@ -10,11 +10,11 @@ import {
   isHDAccountsConfig,
   wrapEthereumProvider
 } from "../../../src/core/providers/construction";
-import { IEthereumProvider } from "../../../src/types";
 import {
   createFixedGasPriceProvider,
   createFixedGasProvider
 } from "../../../src/core/providers/gas-providers";
+import { IEthereumProvider } from "../../../src/types";
 import {
   expectBuidlerError,
   expectBuidlerErrorAsync,

--- a/test/core/providers/construction.ts
+++ b/test/core/providers/construction.ts
@@ -10,7 +10,7 @@ import {
   isHDAccountsConfig,
   wrapEthereumProvider
 } from "../../../src/core/providers/construction";
-import { IEthereumProvider } from "../../../src/core/providers/ethereum";
+import { IEthereumProvider } from "../../../src/types";
 import {
   createFixedGasPriceProvider,
   createFixedGasProvider

--- a/test/core/providers/gas-providers.ts
+++ b/test/core/providers/gas-providers.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { IEthereumProvider } from "../../../src/core/providers/ethereum";
+import { IEthereumProvider } from "../../../src/types";
 import {
   createAutomaticGasPriceProvider,
   createAutomaticGasProvider,

--- a/test/core/providers/gas-providers.ts
+++ b/test/core/providers/gas-providers.ts
@@ -1,12 +1,12 @@
 import { assert } from "chai";
 
-import { IEthereumProvider } from "../../../src/types";
 import {
   createAutomaticGasPriceProvider,
   createAutomaticGasProvider,
   createFixedGasPriceProvider,
   createFixedGasProvider
 } from "../../../src/core/providers/gas-providers";
+import { IEthereumProvider } from "../../../src/types";
 
 import { ParamsReturningProvider } from "./mocks";
 

--- a/test/core/providers/mocks.ts
+++ b/test/core/providers/mocks.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 
-import { IEthereumProvider } from "../../../src/core/providers/ethereum";
+import { IEthereumProvider } from "../../../src/types";
 
 export class MethodReturningProvider extends EventEmitter
   implements IEthereumProvider {

--- a/test/core/providers/network.ts
+++ b/test/core/providers/network.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import { Tx } from "web3x/eth";
 
 import { ERRORS } from "../../../src/core/errors";
-import { IEthereumProvider } from "../../../src/core/providers/ethereum";
+import { IEthereumProvider } from "../../../src/types";
 import { createNetworkProvider } from "../../../src/core/providers/network";
 import { expectBuidlerErrorAsync } from "../../helpers/errors";
 

--- a/test/core/providers/network.ts
+++ b/test/core/providers/network.ts
@@ -2,8 +2,8 @@ import { assert } from "chai";
 import { Tx } from "web3x/eth";
 
 import { ERRORS } from "../../../src/core/errors";
-import { IEthereumProvider } from "../../../src/types";
 import { createNetworkProvider } from "../../../src/core/providers/network";
+import { IEthereumProvider } from "../../../src/types";
 import { expectBuidlerErrorAsync } from "../../helpers/errors";
 
 import { CountProvider } from "./mocks";

--- a/test/core/providers/wrapper.ts
+++ b/test/core/providers/wrapper.ts
@@ -16,11 +16,8 @@ describe("wrapSend", () => {
   it("Should forward everything except for send", async () => {
     const wrapped = wrapSend(methodReturningProvider, async () => 123);
 
-    wrapped.addListener("a", () => {});
-    assert.equal(methodReturningProvider.listenerCount("a"), 1);
-
-    wrapped.setMaxListeners(1234);
-    assert.equal(methodReturningProvider.getMaxListeners(), 1234);
+    wrapped.on("notification", () => {});
+    assert.equal(methodReturningProvider.listenerCount("notification"), 1);
   });
 
   it("Should forward send", async () => {
@@ -47,7 +44,7 @@ describe("wrapSend", () => {
       return params;
     });
 
-    const returnedParams = await wrapped.send("a", sentParams);
+    const returnedParams = await wrapped.send("notification", sentParams);
 
     assert.notEqual(returnedParams, sentParams);
     assert.deepEqual(returnedParams, [{ asd: true }, 123]);
@@ -60,13 +57,9 @@ describe("wrapSend", () => {
       async (name, params) => params
     );
 
-    assert.equal(wrapped.on("a", () => {}), wrapped);
-    assert.equal(wrapped.once("a", () => {}), wrapped);
-    assert.equal(wrapped.addListener("a", () => {}), wrapped);
-    assert.equal(wrapped.prependListener("a", () => {}), wrapped);
-    assert.equal(wrapped.prependOnceListener("a", () => {}), wrapped);
-    assert.equal(wrapped.removeListener("a", () => {}), wrapped);
-    assert.equal(wrapped.removeAllListeners("a"), wrapped);
+    assert.equal(wrapped.on("notification", () => {}), wrapped);
+    assert.equal(wrapped.removeListener("notification", () => {}), wrapped);
+    assert.equal(wrapped.removeAllListeners("notification"), wrapped);
   });
 
   it("Should return undefined if the property is not present in the original provider", () => {
@@ -76,15 +69,5 @@ describe("wrapSend", () => {
     );
 
     assert.isUndefined((wrapped as any).asd);
-  });
-
-  it("Shouldn't affect functions that don't return `this`", () => {
-    const wrapped = wrapSend(
-      methodReturningProvider,
-      async (name, params) => params
-    );
-
-    wrapped.setMaxListeners(100);
-    assert.equal(wrapped.getMaxListeners(), 100);
   });
 });


### PR DESCRIPTION
It's still not clear how the EIP-1193 provider interface will relate to Node.JS's EventEmitter. We remove the latter for now.