### PR TITLE
Fix bug in test task

### DIFF
--- a/src/builtin-tasks/test.ts
+++ b/src/builtin-tasks/test.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import util from "util";
 
 import { internalTask, task } from "../internal/core/config/config-env";
 import { glob } from "../internal/util/glob";
@@ -30,10 +31,14 @@ internalTask("builtin:run-mocha-tests")
     const mocha = new Mocha(config.mocha);
     testFiles.forEach(file => mocha.addFile(file));
 
-    mocha.run((failures: number) => {
-      process.on("exit", function() {
-        process.exit(failures);
-      });
+    const runPromise = new Promise<number>((resolve, _) => {
+      mocha.run(resolve);
+    });
+
+    const failures = await runPromise;
+
+    process.on("exit", function() {
+      process.exit(failures);
     });
   });
 


### PR DESCRIPTION
We weren't waiting for mocha to complete, as we were just passing it a callback and returning from the "test" task.

This resulted in lots of bugs, as the environment is removed before the tests finished.

This PR promisifies mocha before running it, and awaits it.