### PR TITLE
Add gas multiplier to automatic estimation

### DIFF
--- a/src/internal/core/providers/construction.ts
+++ b/src/internal/core/providers/construction.ts
@@ -85,7 +85,7 @@ export function wrapEthereumProvider(
   provider = createSenderProvider(provider, netConfig.from);
 
   if (netConfig.gas === undefined || netConfig.gas === "auto") {
-    provider = createAutomaticGasProvider(provider);
+    provider = createAutomaticGasProvider(provider, netConfig.gasMultiplier);
   } else {
     provider = createFixedGasProvider(provider, netConfig.gas);
   }

--- a/src/internal/core/providers/gas-providers.ts
+++ b/src/internal/core/providers/gas-providers.ts
@@ -42,12 +42,16 @@ export function createFixedGasPriceProvider(
   });
 }
 
-export function createAutomaticGasProvider(provider: IEthereumProvider) {
+export function createAutomaticGasProvider(
+  provider: IEthereumProvider,
+  gasMultiplier: number = 1.25
+) {
   return wrapSend(provider, async (method, params) => {
     if (method === "eth_sendTransaction") {
       const tx = params[0];
       if (tx !== undefined && tx.gas === undefined) {
-        tx.gas = await provider.send("eth_estimateGas", params);
+        const gas = await provider.send("eth_estimateGas", params);
+        tx.gas = Math.floor(gas * gasMultiplier);
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ interface CommonNetworkConfig {
   from?: string;
   gas?: "auto" | number;
   gasPrice?: "auto" | number;
+  gasMultiplier?: number;
 }
 
 interface AutoNetworkAccount {

--- a/test/internal/core/providers/construction.ts
+++ b/test/internal/core/providers/construction.ts
@@ -159,6 +159,9 @@ describe("Base providers wrapping", () => {
   });
 
   describe("Gas wrapping", () => {
+    const DEFAULT_GAS_MULTIPLIER = 1.25;
+    const OTHER_GAS_MULTIPLIER = 1.337;
+
     beforeEach(() => {
       baseProvider = createFixedGasProvider(baseProvider, 123);
     });
@@ -172,7 +175,7 @@ describe("Base providers wrapping", () => {
       const [tx] = await provider.send("eth_sendTransaction", [
         { from: "0x0" }
       ]);
-      assert.equal(tx.gas, 123);
+      assert.equal(tx.gas, Math.floor(123 * DEFAULT_GAS_MULTIPLIER));
     });
 
     it("Should wrap with an auto gas provider if undefined is used", async () => {
@@ -183,7 +186,19 @@ describe("Base providers wrapping", () => {
       const [tx] = await provider.send("eth_sendTransaction", [
         { from: "0x0" }
       ]);
-      assert.equal(tx.gas, 123);
+      assert.equal(tx.gas, Math.floor(123 * DEFAULT_GAS_MULTIPLIER));
+    });
+
+    it("Should use the gasMultiplier", async () => {
+      const provider = wrapEthereumProvider(baseProvider, {
+        url: "",
+        gasMultiplier: OTHER_GAS_MULTIPLIER
+      });
+
+      const [tx] = await provider.send("eth_sendTransaction", [
+        { from: "0x0" }
+      ]);
+      assert.equal(tx.gas, Math.floor(123 * OTHER_GAS_MULTIPLIER));
     });
 
     it("Should wrap with a fixed gas provider if a number is used", async () => {


### PR DESCRIPTION
Estimating gas is not an exact process. The amount from gas actually needed can differed from the one that your node estimated, which results in out of gas errors.

This PR tries to remedy that by multiplying the estimation by a user-configurable multiplier, copying what other libraries/frameworks do.

A new field is added to the config in this PR. Now each network's config can have an optional `gasMultiplier` field. If provided, it must be a number. If not present, it defaults to `1.25`.