### PR TITLE
Change test task termination

### DIFF
--- a/src/builtin-tasks/test.ts
+++ b/src/builtin-tasks/test.ts
@@ -36,10 +36,7 @@ internalTask("builtin:run-mocha-tests")
     });
 
     const failures = await runPromise;
-
-    process.on("exit", function() {
-      process.exit(failures);
-    });
+    process.exit(failures);
   });
 
 task("test", "Runs mocha tests")


### PR DESCRIPTION
This PR makes `test` task exit buidler's process passing the number of mocha failures as status number.