### PR TITLE
Enable source-maps support in buidler/register

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -6,6 +6,9 @@ import { Environment } from "./internal/core/runtime-environment";
 const globalAsAny = global as any;
 
 if (globalAsAny.env === undefined) {
+  // tslint:disable-next-line no-var-requires
+  require("source-map-support/register");
+
   const buidlerArguments = getEnvBuidlerArguments(
     BUIDLER_PARAM_DEFINITIONS,
     process.env


### PR DESCRIPTION
The idea behind `buidler/register` is that it initializes the Buidler environment and injects it, as if a module that loads it were executed within a `task`. So we enable `source-maps` support in `buidler/register`, to better mimic what happens when executing tasks.