### PR TITLE
Finish the Buidler process after running the main task

### DIFF
--- a/src/internal/cli/cli.ts
+++ b/src/internal/cli/cli.ts
@@ -139,10 +139,9 @@ async function main() {
         "For more info run buidler again with --show-stack-traces."
       );
     }
+
+    process.exit(1);
   }
 }
 
-main().catch(error => {
-  console.error(error);
-  process.exit(1);
-});
+main().then(_ => process.exit(0));


### PR DESCRIPTION
Calling `process.exit` after running the main task will help us spot bugs where something outlives it.