### PR TITLE
Make the sample script kill the process once it's done

### DIFF
--- a/sample-project/scripts/sample-script.js
+++ b/sample-project/scripts/sample-script.js
@@ -8,4 +8,9 @@ async function main() {
   console.log("Accounts:", accounts);
 }
 
-main().catch(console.error);
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/internal/cli/cli.ts
+++ b/src/internal/cli/cli.ts
@@ -144,4 +144,9 @@ async function main() {
   }
 }
 
-main().then(_ => process.exit(0));
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Rationale: This promotes being more conscious with your async processes, and let us interact with libraries that may outlive Buidler scripts, like ganache-core's provider.