### PR TITLE
Create runScriptWithBuidler in script runner module

### DIFF
--- a/src/builtin-tasks/console.ts
+++ b/src/builtin-tasks/console.ts
@@ -1,5 +1,5 @@
 import { task } from "../internal/core/config/config-env";
-import { runScript } from "../internal/util/scripts-runner";
+import { runScriptWithBuidler } from "../internal/util/scripts-runner";
 
 import { TASK_CONSOLE } from "./task-names";
 
@@ -17,13 +17,13 @@ task(TASK_CONSOLE, "Opens a buidler console")
     await fsExtra.ensureDir(config.paths.cache);
     const historyFile = path.join(config.paths.cache, "console-history.txt");
 
-    const nodeArgs = ["--require", __dirname + "/../register"];
+    const nodeArgs = [];
     if (semver.gte(process.version, "10.0.0")) {
       nodeArgs.push("--experimental-repl-await");
     }
 
     // Running the script "" is like running `node`, so this starts the repl
-    await runScript("", [], nodeArgs, {
+    await runScriptWithBuidler("", [], nodeArgs, {
       NODE_REPL_HISTORY: historyFile
     });
   });

--- a/src/builtin-tasks/run.ts
+++ b/src/builtin-tasks/run.ts
@@ -1,6 +1,6 @@
 import { task } from "../internal/core/config/config-env";
 import { BuidlerError, ERRORS } from "../internal/core/errors";
-import { runScript } from "../internal/util/scripts-runner";
+import { runScriptWithBuidler } from "../internal/util/scripts-runner";
 
 import { TASK_COMPILE, TASK_RUN } from "./task-names";
 
@@ -26,11 +26,7 @@ task(TASK_RUN, "Runs a user-defined script after compiling the project")
       }
 
       try {
-        const statusCode = await runScript(
-          script,
-          [],
-          ["--require", __dirname + "/../register"]
-        );
+        const statusCode = await runScriptWithBuidler(script);
         process.exit(statusCode);
       } catch (error) {
         throw new BuidlerError(

--- a/src/internal/util/scripts-runner.ts
+++ b/src/internal/util/scripts-runner.ts
@@ -24,6 +24,20 @@ export async function runScript(
   });
 }
 
+export async function runScriptWithBuidler(
+  scriptPath: string,
+  scriptArgs: string[] = [],
+  extraNodeArgs: string[] = [],
+  extraEnvVars: { [name: string]: string } = {}
+): Promise<number> {
+  return runScript(
+    scriptPath,
+    scriptArgs,
+    [...extraNodeArgs, "--require", __dirname + "/../../register"],
+    extraEnvVars
+  );
+}
+
 function getTsNodeArgsIfNeeded() {
   if (!__filename.endsWith(".ts")) {
     return [];

--- a/test/internal/util/scripts-runner.ts
+++ b/test/internal/util/scripts-runner.ts
@@ -1,17 +1,16 @@
 import { assert } from "chai";
 
-import { runScript } from "../../../src/internal/util/scripts-runner";
+import {
+  runScript,
+  runScriptWithBuidler
+} from "../../../src/internal/util/scripts-runner";
 import { useFixtureProject } from "../../helpers/project";
 
 describe("Scripts runner", () => {
   useFixtureProject("project-with-scripts");
 
   it("Should load buidler/register successfully", async () => {
-    const statusCode = await runScript(
-      "./successful-script.js",
-      [],
-      ["--require", __dirname + "/../../../src/register"]
-    );
+    const statusCode = await runScriptWithBuidler("./successful-script.js");
     assert.equal(statusCode, 0);
 
     // We check here that the script is correctly testing this:


### PR DESCRIPTION
We always passed `buidler/register` to the script runner, so that's abstracted now.