### PR TITLE
Show proxied objects in the console instead of the proxies themselves.

### DIFF
--- a/src/internal/util/console.ts
+++ b/src/internal/util/console.ts
@@ -1,0 +1,21 @@
+export function isNodeCalledWithoutAScript() {
+  const script = process.argv[1];
+  return script === undefined || script.trim() === "";
+}
+
+/**
+ * Starting at node 10, proxies are shown in the console by default, instead
+ * of actually inspecting them. This makes all our lazy loading efforts wicked,
+ * so we disable it ni buidler/register.
+ */
+export function disableReplWriterShowProxy() {
+  const repl = require("repl");
+
+  if (repl.writer.options) {
+    Object.defineProperty(repl.writer.options, "showProxy", {
+      value: false,
+      writable: false,
+      configurable: false
+    });
+  }
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -2,12 +2,20 @@ import { loadConfigAndTasks } from "./internal/core/config/config-loading";
 import { BUIDLER_PARAM_DEFINITIONS } from "./internal/core/params/buidler-params";
 import { getEnvBuidlerArguments } from "./internal/core/params/env-variables";
 import { Environment } from "./internal/core/runtime-environment";
+import {
+  disableReplWriterShowProxy,
+  isNodeCalledWithoutAScript
+} from "./internal/util/console";
 
 const globalAsAny = global as any;
 
 if (globalAsAny.env === undefined) {
   // tslint:disable-next-line no-var-requires
   require("source-map-support/register");
+
+  if (isNodeCalledWithoutAScript()) {
+    disableReplWriterShowProxy();
+  }
 
   const buidlerArguments = getEnvBuidlerArguments(
     BUIDLER_PARAM_DEFINITIONS,


### PR DESCRIPTION
Starting from Node 10, when an expression evaluates to a proxy, the console shows the proxy itself, not the proxied value.

This makes all our lazy-loaded objects confusing, so we disable this feature in buidler/register.