### PR TITLE
 Rename the Buidler Runtime Environment's provider to `ethereum`

### DIFF
--- a/sample-project/buidler.config.js
+++ b/sample-project/buidler.config.js
@@ -1,7 +1,7 @@
-task("accounts", "Prints a list of the available accounts", async taskArgs => {
-     const accounts = await env.provider.send("eth_accounts");
+task("accounts", "Prints a list of the available accounts", async () => {
+  const accounts = await ethereum.send("eth_accounts");
 
-     console.log("Accounts:", accounts);
-  });
+  console.log("Accounts:", accounts);
+});
 
 module.exports = {};

--- a/sample-project/scripts/sample-script.js
+++ b/sample-project/scripts/sample-script.js
@@ -1,9 +1,10 @@
+// We require the Buidler Runtime Environment explicitly here. This is optional.
 const env = require("@nomiclabs/buidler");
 
 async function main() {
   await env.run("compile");
 
-  const accounts = await env.provider.send("eth_accounts");
+  const accounts = await env.ethereum.send("eth_accounts");
 
   console.log("Accounts:", accounts);
 }

--- a/sample-project/test/sample-test.js
+++ b/sample-project/test/sample-test.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 
 describe("Ethereum provider", function() {
   it("Should return the accounts", async function() {
-    const accounts = await provider.send("eth_accounts");
+    const accounts = await ethereum.send("eth_accounts");
     assert(accounts.length !== 0, "No account was returned");
   });
 });

--- a/src/internal/core/runtime-environment.ts
+++ b/src/internal/core/runtime-environment.ts
@@ -22,7 +22,7 @@ export class Environment implements BuidlerRuntimeEnvironment {
     "runTaskDefinition"
   ];
 
-  public provider: IEthereumProvider;
+  public ethereum: IEthereumProvider;
 
   constructor(
     public readonly config: ResolvedBuidlerConfig,
@@ -30,7 +30,7 @@ export class Environment implements BuidlerRuntimeEnvironment {
     public readonly tasks: TasksMap,
     private readonly extenders: EnvironmentExtender[] = []
   ) {
-    this.provider = lazyObject(() =>
+    this.ethereum = lazyObject(() =>
       createProvider(buidlerArguments.network, config.networks)
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,7 +226,7 @@ export type ActionType<ArgsT extends TaskArguments> = (
 export type IEthereumProvider = EthereumProvider;
 
 export interface BuidlerRuntimeEnvironment {
-  readonly provider: IEthereumProvider;
+  readonly ethereum: IEthereumProvider;
   readonly config: ResolvedBuidlerConfig;
   readonly buidlerArguments: BuidlerArguments;
   readonly tasks: TasksMap;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-// tslint:disable-next-line no-implicit-dependencies
 import { DeepPartial, Omit } from "ts-essentials";
 import { EthereumProvider } from "web3x/providers";
 

--- a/test/internal/core/runtime-environment.ts
+++ b/test/internal/core/runtime-environment.ts
@@ -65,7 +65,7 @@ describe("Environment", () => {
     it("should create an environment", () => {
       assert.deepEqual(env.config, config);
       assert.isDefined(env.tasks);
-      assert.isDefined(env.provider);
+      assert.isDefined(env.ethereum);
     });
 
     it("should run a task correctly", async () => {


### PR DESCRIPTION
The [EIP1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md) suggests naming the provider `ethereum`. We do so to avoid unnecessary differences with the standard.