### PR TITLE
Add JSON argument type

### DIFF
--- a/src/internal/core/errors.ts
+++ b/src/internal/core/errors.ts
@@ -235,6 +235,10 @@ export const ERRORS = {
     PARAM_NAME_INVALID_CASING: {
       number: 310,
       message: 'Invalid param "%s". Command line params must be lowercase.'
+    },
+    INVALID_JSON_ARGUMENT: {
+      number: 311,
+      message: 'Error parsing JSON value for argument "%s": %s'
     }
   },
   RESOLVER: {

--- a/src/internal/core/params/argumentTypes.ts
+++ b/src/internal/core/params/argumentTypes.ts
@@ -110,7 +110,7 @@ export const float: ArgumentType<number> = {
  * Accepts a path to a readable file..
  * @throws BDLR302
  */
-export let inputFile: ArgumentType<string> = {
+export const inputFile: ArgumentType<string> = {
   name: "inputFile",
   parse(argName: string, strValue: string): string {
     try {
@@ -134,5 +134,21 @@ export let inputFile: ArgumentType<string> = {
     }
 
     return strValue;
+  }
+};
+
+export const json: ArgumentType<any> = {
+  name: "json",
+  parse(argName: string, strValue: string): any {
+    try {
+      return JSON.parse(strValue);
+    } catch (error) {
+      throw new BuidlerError(
+        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT,
+        error,
+        argName,
+        error.message
+      );
+    }
   }
 };

--- a/test/internal/core/params/argumentTypes.ts
+++ b/test/internal/core/params/argumentTypes.ts
@@ -254,4 +254,39 @@ describe("argumentTypes", () => {
       );
     });
   });
+
+  describe("JSON type", () => {
+    it("Should fail if the argument isn't JSON", () => {
+      expectBuidlerError(
+        () => types.json.parse("j", "a"),
+        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT
+      );
+
+      expectBuidlerError(
+        () => types.json.parse("j", "{a:1"),
+        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT
+      );
+
+      expectBuidlerError(
+        () => types.json.parse("j", "[1],"),
+        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT
+      );
+    });
+
+    it("Should parse an object successfully", () => {
+      assert.deepEqual(types.json.parse("j", '{"a":1}'), { a: 1 });
+    });
+
+    it("Should parse a number", () => {
+      assert.deepEqual(types.json.parse("j", "123"), 123);
+    });
+
+    it("Should parse a list", () => {
+      assert.deepEqual(types.json.parse("j", "[1,2]"), [1, 2]);
+    });
+
+    it("Should parse a string", () => {
+      assert.deepEqual(types.json.parse("j", '"a"'), "a");
+    });
+  });
 });


### PR DESCRIPTION
This PR just adds an argument type for JSON.

This arg type is mostly useful for internal tasks, as a way to pass an arbitrary kind of data.