### PR TITLE
Update solc and its default evm target

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lodash": "^4.17.11",
     "mocha": "^5.1.1",
     "semver": "^5.6.0",
-    "solc": "0.5.3",
+    "solc": "0.5.5",
     "solidity-parser-antlr": "^0.3.3",
     "source-map-support": "^0.5.9",
     "ts-essentials": "^1.0.2",

--- a/src/internal/core/config/default-config.ts
+++ b/src/internal/core/config/default-config.ts
@@ -7,7 +7,7 @@ const defaultConfig: BuidlerConfig = {
       enabled: false,
       runs: 200
     },
-    evmVersion: "byzantium"
+    evmVersion: "petersburg"
   },
   networks: {
     develop: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,8 @@ type EVMVersion =
   | "tangerineWhistle"
   | "spuriousDragon"
   | "byzantium"
-  | "constantinople";
+  | "constantinople"
+  | "petersburg";
 
 export interface SolcConfig {
   version: string;

--- a/test/internal/core/config/config-resolution.ts
+++ b/test/internal/core/config/config-resolution.ts
@@ -15,7 +15,7 @@ describe("Config resolution", () => {
         const [config, _] = loadConfigAndTasks();
         assert.equal(config.solc.version, getLocalCompilerVersion());
         assert.containsAllKeys(config.networks, ["auto", "develop"]);
-        assert.equal(config.solc.evmVersion, "byzantium");
+        assert.equal(config.solc.evmVersion, "petersburg");
       });
     });
 

--- a/test/internal/solidity/compiler/downloader.ts
+++ b/test/internal/solidity/compiler/downloader.ts
@@ -26,14 +26,14 @@ describe("Compiler downloader", function() {
 
   before(function() {
     localCompilerBuild = {
-      path: "soljson-v0.5.3+commit.10d17f24.js",
-      version: "0.5.3",
-      build: "commit.10d17f24",
-      longVersion: "0.5.3+commit.10d17f24",
+      path: "soljson-v0.5.5+commit.47a71e8f.js",
+      version: "0.5.5",
+      build: "commit.47a71e8f",
+      longVersion: "0.5.5+commit.47a71e8f",
       keccak256:
-        "0xd8d79f6a3c2bb4f74a26dad18b99b8368051574415758c872f41e2c8235c68a8",
+        "0x7dab358bfe745766bf640e78799beb84646a856717b773eb36c08d274f24fd21",
       urls: [
-        "bzzr://b703170cfd59ffa43d30147ab4727b3f8a193becf701b473d2b99d4f7eb667bc"
+        "bzzr://b1d6cee21ac31939a391b84c465160725699c5baf3b7ab74f27f45ecc91387ad"
       ]
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,10 +3138,10 @@ simple-get@^2.7.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-solc@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.3.tgz#bb6d4e8e785b8b3ac0e6d096b9213bf2d0ca15b6"
-  integrity sha512-H9apkutqTa+zEF1T13q5fvAC0aMcbdg6JkUiGXObTJuZydq6Z6EgjI1OS9MGz0y3z4c0Vp1Ww2waEq0jMRm/Rw==
+solc@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.5.tgz#bdedd988e1a958f48bb8d84df5414f0ae9f62764"
+  integrity sha512-eh24ieiUC/M0tQPvK/YtORXzW4QNinFzDmF9Nj7/zXlxD06pLz4cnWExz7mzAmiI7f5xFfXlitLbLn2w3U6niw==
   dependencies:
     command-exists "^1.2.8"
     fs-extra "^0.30.0"


### PR DESCRIPTION
This PR updates the default version of solc to 0.5.5 and changes its default evm target setting to `"petersburg"`.