### PR TITLE
Encapsulate the solc selection in an internal task

### DIFF
--- a/src/builtin-tasks/task-names.ts
+++ b/src/builtin-tasks/task-names.ts
@@ -7,6 +7,7 @@ export const TASK_COMPILE_GET_SOURCE_PATHS = "compile:get-source-paths";
 export const TASK_COMPILE_GET_RESOLVED_SOURCES = "compile:get-resolved-sources";
 export const TASK_COMPILE_GET_DEPENDENCY_GRAPH = "compile:get-dependency-graph";
 export const TASK_COMPILE_GET_COMPILER_INPUT = "compile:get-compiler-input";
+export const TASK_COMPILE_RUN_COMPILER = "compile:run-compiler";
 export const TASK_COMPILE_COMPILE = "compile:compile";
 export const TASK_BUILD_ARTIFACTS = "compile:build-artifacts";
 

--- a/src/internal/solidity/compiler/compiler-input.ts
+++ b/src/internal/solidity/compiler/compiler-input.ts
@@ -1,0 +1,33 @@
+import { SolcInput, SolcOptimizerConfig } from "../../../types";
+import { DependencyGraph } from "../dependencyGraph";
+
+export function getInputFromDependencyGraph(
+  graph: DependencyGraph,
+  evmVersion: string,
+  optimizerConfig: SolcOptimizerConfig
+): SolcInput {
+  const sources: { [globalName: string]: { content: string } } = {};
+  for (const file of graph.getResolvedFiles()) {
+    sources[file.globalName] = {
+      content: file.content
+    };
+  }
+
+  return {
+    language: "Solidity",
+    sources,
+    settings: {
+      evmVersion,
+      metadata: {
+        useLiteralContent: true
+      },
+      optimizer: optimizerConfig,
+      outputSelection: {
+        "*": {
+          "*": ["evm.bytecode.object", "abi"],
+          "": ["ast"]
+        }
+      }
+    }
+  };
+}

--- a/src/internal/solidity/compiler/index.ts
+++ b/src/internal/solidity/compiler/index.ts
@@ -1,6 +1,3 @@
-import { SolcOptimizerConfig } from "../../../types";
-import { DependencyGraph } from "../dependencyGraph";
-
 import { CompilerDownloader } from "./downloader";
 
 export class Compiler {
@@ -14,7 +11,6 @@ export class Compiler {
   constructor(
     private readonly version: string,
     private readonly compilersDir: string,
-    private readonly optimizerConfig: SolcOptimizerConfig,
     compilerDownloader?: CompilerDownloader
   ) {
     this.localSolcVersion = Compiler.getLocalSolcVersion();
@@ -27,33 +23,6 @@ export class Compiler {
         this.localSolcVersion
       );
     }
-  }
-
-  public getInputFromDependencyGraph(graph: DependencyGraph) {
-    const sources: { [globalName: string]: { content: string } } = {};
-    for (const file of graph.getResolvedFiles()) {
-      sources[file.globalName] = {
-        content: file.content
-      };
-    }
-
-    return {
-      language: "Solidity",
-      sources,
-      settings: {
-        evmVersion: "byzantium",
-        metadata: {
-          useLiteralContent: true
-        },
-        optimizer: this.optimizerConfig,
-        outputSelection: {
-          "*": {
-            "*": ["evm.bytecode.object", "abi"],
-            "": ["ast"]
-          }
-        }
-      }
-    };
   }
 
   public async compile(input: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,17 @@ export interface SolcOptimizerConfig {
   runs: number;
 }
 
+export interface SolcInput {
+  settings: {
+    metadata: { useLiteralContent: boolean };
+    optimizer: SolcOptimizerConfig;
+    outputSelection: { "*": { "": string[]; "*": string[] } };
+    evmVersion: string;
+  };
+  sources: { [p: string]: { content: string } };
+  language: string;
+}
+
 export interface BuidlerConfig {
   networks?: Networks;
   paths?: Omit<Partial<ProjectPaths>, "configFile">;

--- a/test/helpers/compiler.ts
+++ b/test/helpers/compiler.ts
@@ -1,3 +1,7 @@
 export function getLocalCompilerVersion(): string {
   return require("solc/package.json").version;
 }
+
+export function getDefaultEvmVersion(): string {
+  return "petersburg";
+}

--- a/test/internal/solidity/compiler/compiler-input.ts
+++ b/test/internal/solidity/compiler/compiler-input.ts
@@ -1,0 +1,63 @@
+import { assert } from "chai";
+
+import { getInputFromDependencyGraph } from "../../../../src/internal/solidity/compiler/compiler-input";
+import { DependencyGraph } from "../../../../src/internal/solidity/dependencyGraph";
+import {
+  ResolvedFile,
+  Resolver
+} from "../../../../src/internal/solidity/resolver";
+import { getDefaultEvmVersion } from "../../../helpers/compiler";
+
+describe("compiler-input module", function() {
+  it("Should construct the right input for a dependency graph", async () => {
+    const optimizerConfig = {
+      runs: 200,
+      enabled: false
+    };
+
+    const globalName1 = "the/global/name.sol";
+    const path1 = "/fake/absolute/path";
+    const content1 = "THE CONTENT1";
+
+    const globalName2 = "the/global/name2.sol";
+    const path2 = "/fake/absolute/path2";
+    const content2 = "THE CONTENT2";
+
+    const expectedInput = {
+      language: "Solidity",
+      sources: {
+        [globalName1]: { content: content1 },
+        [globalName2]: { content: content2 }
+      },
+      settings: {
+        evmVersion: getDefaultEvmVersion(),
+        metadata: {
+          useLiteralContent: true
+        },
+        optimizer: optimizerConfig,
+        outputSelection: {
+          "*": {
+            "*": ["evm.bytecode.object", "abi"],
+            "": ["ast"]
+          }
+        }
+      }
+    };
+
+    const graph = await DependencyGraph.createFromResolvedFiles(
+      new Resolver("."),
+      [
+        new ResolvedFile(globalName1, path1, content1, new Date()),
+        new ResolvedFile(globalName2, path2, content2, new Date())
+      ]
+    );
+
+    const input = getInputFromDependencyGraph(
+      graph,
+      getDefaultEvmVersion(),
+      optimizerConfig
+    );
+
+    assert.deepEqual(input, expectedInput);
+  });
+});

--- a/test/internal/solidity/compiler/index.ts
+++ b/test/internal/solidity/compiler/index.ts
@@ -2,11 +2,6 @@ import { assert } from "chai";
 
 import { Compiler } from "../../../../src/internal/solidity/compiler";
 import { CompilerDownloader } from "../../../../src/internal/solidity/compiler/downloader";
-import { DependencyGraph } from "../../../../src/internal/solidity/dependencyGraph";
-import {
-  ResolvedFile,
-  Resolver
-} from "../../../../src/internal/solidity/resolver";
 import { SolcOptimizerConfig } from "../../../../src/types";
 import { getLocalCompilerVersion } from "../../../helpers/compiler";
 
@@ -66,7 +61,6 @@ contract A {}
     const compiler = new Compiler(
       getLocalCompilerVersion(),
       __dirname,
-      optimizerConfig,
       downloader
     );
 
@@ -114,7 +108,6 @@ contract A {}
     const compiler = new Compiler(
       getLocalCompilerVersion(),
       __dirname,
-      optimizerConfig,
       downloader
     );
 
@@ -123,62 +116,11 @@ contract A {}
     assert.isNotEmpty(output.errors);
   });
 
-  it("Should construct the right input for a dependency graph", async () => {
-    const globalName1 = "the/global/name.sol";
-    const path1 = "/fake/absolute/path";
-    const content1 = "THE CONTENT1";
-
-    const globalName2 = "the/global/name2.sol";
-    const path2 = "/fake/absolute/path2";
-    const content2 = "THE CONTENT2";
-
-    const expectedInput = {
-      language: "Solidity",
-      sources: {
-        [globalName1]: { content: content1 },
-        [globalName2]: { content: content2 }
-      },
-      settings: {
-        evmVersion: "byzantium",
-        metadata: {
-          useLiteralContent: true
-        },
-        optimizer: optimizerConfig,
-        outputSelection: {
-          "*": {
-            "*": ["evm.bytecode.object", "abi"],
-            "": ["ast"]
-          }
-        }
-      }
-    };
-
-    const graph = await DependencyGraph.createFromResolvedFiles(
-      new Resolver("."),
-      [
-        new ResolvedFile(globalName1, path1, content1, new Date()),
-        new ResolvedFile(globalName2, path2, content2, new Date())
-      ]
-    );
-
-    const compiler = new Compiler(
-      getLocalCompilerVersion(),
-      __dirname,
-      optimizerConfig,
-      downloader
-    );
-
-    const input = compiler.getInputFromDependencyGraph(graph);
-
-    assert.deepEqual(input, expectedInput);
-  });
-
   describe("Compiler version selection", () => {
     it("Shouldn't use the downloader if the local version is used", async () => {
       const compiler = new Compiler(
         getLocalCompilerVersion(),
         __dirname,
-        optimizerConfig,
         downloader
       );
 
@@ -192,12 +134,7 @@ contract A {}
     });
 
     it("Should call the downloader otherwise", async () => {
-      const compiler = new Compiler(
-        "0.5.0",
-        __dirname,
-        optimizerConfig,
-        downloader
-      );
+      const compiler = new Compiler("0.5.0", __dirname, downloader);
 
       await compiler.getSolc();
 


### PR DESCRIPTION
This PR makes changing the compiler almost trivial. Now anyone can override 'compile:run-compiler' (which takes the standard solc JSON input and returns the standard solc JSON output) and use another version of solc. A possible use of this is to run solc in Docker.

Depends on #188 