### PR TITLE
Simplify ts-node setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-TS_NODE_FILES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - yarn
 
 script:
-  - yarn test
+  - yarn coverage
   - codecov
   - yarn lint
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "lint:fix": "prettier --write 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' && NODE_OPTIONS=\"-r ts-node/register\" tslint --fix --config tslint.json --project tsconfig.json --rules-dir ./tslint",
     "lint": "NODE_OPTIONS=\"-r ts-node/register\" tslint --config tslint.json --project tsconfig.json --rules-dir ./tslint",
-    "test": "nyc mocha",
+    "test": "mocha",
+    "coverage": "nyc mocha",
     "buidl": "tsc --p tsconfig.prod.json",
     "build": "tsc --p tsconfig.prod.json",
     "watch": "tsc -w --p tsconfig.prod.json",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/node": "^8.10.38",
     "@types/semver": "^5.5.0",
     "chai": "^4.2.0",
-    "dotenv": "^6.2.0",
     "ganache-cli": "^6.1.6",
     "nyc": "^13.1.0",
     "prettier": "^1.15.3",

--- a/src/internal/@types/deepmerge/index.d.ts
+++ b/src/internal/@types/deepmerge/index.d.ts
@@ -1,0 +1,1 @@
+declare module "deepmerge";

--- a/src/internal/@types/deepmerge/index.d.ts
+++ b/src/internal/@types/deepmerge/index.d.ts
@@ -1,1 +1,0 @@
-declare module "deepmerge";

--- a/src/internal/@types/ethereumjs-tx/index.d.ts
+++ b/src/internal/@types/ethereumjs-tx/index.d.ts
@@ -1,0 +1,1 @@
+declare module "ethereumjs-tx";

--- a/src/internal/@types/ethereumjs-util/index.d.ts
+++ b/src/internal/@types/ethereumjs-util/index.d.ts
@@ -1,0 +1,1 @@
+declare module "ethereumjs-util";

--- a/src/internal/@types/not-typed.d.ts
+++ b/src/internal/@types/not-typed.d.ts
@@ -1,4 +1,0 @@
-declare module "solc/wrapper";
-declare module "ethereumjs-util";
-declare module "deepmerge";
-declare module "ethereumjs-tx";

--- a/src/internal/@types/solc/index.d.ts
+++ b/src/internal/@types/solc/index.d.ts
@@ -1,0 +1,2 @@
+declare module "solc";
+declare module "solc/wrapper";

--- a/src/internal/core/config/config-resolution.ts
+++ b/src/internal/core/config/config-resolution.ts
@@ -12,10 +12,10 @@ import { fromEntries } from "../../util/lang";
 function mergeUserAndDefaultConfigs(
   defaultConfig: BuidlerConfig,
   userConfig: BuidlerConfig
-) {
+): Partial<ResolvedBuidlerConfig> {
   return deepmerge(defaultConfig, userConfig, {
     arrayMerge: (destination: any[], source: any[]) => source
-  });
+  }) as any;
 }
 
 /**
@@ -33,14 +33,15 @@ export function resolveConfig(
   defaultConfig: BuidlerConfig,
   userConfig: BuidlerConfig
 ): ResolvedBuidlerConfig {
-  const config: ResolvedBuidlerConfig = mergeUserAndDefaultConfigs(
-    defaultConfig,
-    userConfig
-  );
+  const config = mergeUserAndDefaultConfigs(defaultConfig, userConfig);
 
-  config.paths = resolveProjectPaths(userConfigPath, userConfig.paths);
+  const paths = resolveProjectPaths(userConfigPath, userConfig.paths);
 
-  return config;
+  return {
+    paths,
+    networks: config.networks!,
+    solc: config.solc!
+  };
 }
 
 function resolvePathFrom(

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---require dotenv/config
 --require ts-node/register
 --require source-map-support/register
 --recursive test/**/*.ts --exclude test/fixture-projects/**/*.ts --exclude test/fixture-projects/**/*.js --exclude test/helpers/**/*.ts

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -6,7 +6,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types", "./src/internal/@types"]
   },
   "include": ["./src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,11 +995,6 @@ dom-walk@^0.1.0:
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
   integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
 
-dotenv@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
-  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
-
 download@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/download/-/download-7.1.0.tgz#9059aa9d70b503ee76a132897be6dec8e5587233"


### PR DESCRIPTION
This PR simplifies how we use `ts-node`.

Previously, we were using `dotenv` to set the `TS_NODE_FILES` env to `true`. This is not really necessary, makes things slower, and complicates our planned migration to a monorepo.

Instead of using that, we now define non-typed modules in a per-folder way, and set `typeRoots` in `tsconfigs.json`.

This PR also optimizes the testing setup a little further by separating `yarn test` form `yarn coverage`.