### PR TITLE
[buidler-core] Fix type exported by Buidler library

### DIFF
--- a/packages/buidler-core/src/internal/lib/buidler-lib.ts
+++ b/packages/buidler-core/src/internal/lib/buidler-lib.ts
@@ -5,7 +5,7 @@ import { BUIDLER_PARAM_DEFINITIONS } from "../core/params/buidler-params";
 import { getEnvBuidlerArguments } from "../core/params/env-variables";
 import { Environment } from "../core/runtime-environment";
 
-let env: BuidlerRuntimeEnvironment | undefined;
+let env: BuidlerRuntimeEnvironment;
 
 if (!BuidlerContext.isCreated()) {
   BuidlerContext.createBuidlerContext();


### PR DESCRIPTION
We were exporting `BuidlerRuntimeEnvironment | undefined`. This PR changes it to `BuidlerRuntimeEnvironment`.