### PR TITLE
More lint rules, mostly about naming

### DIFF
--- a/config/tslint/tslint.json
+++ b/config/tslint/tslint.json
@@ -4,6 +4,7 @@
     "tslint-plugin-prettier",
     "tslint-config-prettier"
   ],
+  "rulesDirectory": ["tslint-consistent-codestyle"],
   "rules": {
     "prettier": true,
     "object-literal-sort-keys": false,
@@ -35,6 +36,24 @@
     "no-inferred-empty-object-type": true,
     "no-misused-new": true,
     "restrict-plus-operands": true,
-    "use-isnan": true
+    "use-isnan": true,
+    "curly": true,
+    "no-unnecessary-else": true,
+    "naming-convention": [
+      true,
+      {
+        "type": "member",
+        "modifiers": "private",
+        "leadingUnderscore": "require"
+      },
+      {
+        "type": "member",
+        "modifiers": "protected",
+        "leadingUnderscore": "require"
+      },
+      { "type": "type", "format": "PascalCase" },
+      { "type": "genericTypeParameter", "suffix": "T" },
+      { "type": "enumMember", "format": "PascalCase" }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,46 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fimbul/bifrost": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.17.0.tgz",
+      "integrity": "sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==",
+      "dev": true,
+      "requires": {
+        "@fimbul/ymir": "^0.17.0",
+        "get-caller-file": "^2.0.0",
+        "tslib": "^1.8.1",
+        "tsutils": "^3.5.0"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
+          "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@fimbul/ymir": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/ymir/-/ymir-0.17.0.tgz",
+      "integrity": "sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==",
+      "dev": true,
+      "requires": {
+        "inversify": "^5.0.0",
+        "reflect-metadata": "^0.1.12",
+        "tslib": "^1.8.1"
+      }
+    },
     "@lerna/add": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.3.tgz",
@@ -3784,6 +3824,12 @@
         }
       }
     },
+    "inversify": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
+      "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==",
+      "dev": true
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -6618,6 +6664,12 @@
         "strip-indent": "^2.0.0"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7454,6 +7506,17 @@
       "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
       "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
       "dev": true
+    },
+    "tslint-consistent-codestyle": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.1.tgz",
+      "integrity": "sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==",
+      "dev": true,
+      "requires": {
+        "@fimbul/bifrost": "^0.17.0",
+        "tslib": "^1.7.1",
+        "tsutils": "^2.29.0"
+      }
     },
     "tslint-plugin-prettier": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ts-node": "^8.0.3",
     "tslint": "^5.14.0",
     "tslint-config-prettier": "^1.18.0",
+    "tslint-consistent-codestyle": "^1.15.1",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.3.4000"
   },

--- a/packages/buidler-core/src/internal/cli/HelpPrinter.ts
+++ b/packages/buidler-core/src/internal/cli/HelpPrinter.ts
@@ -10,28 +10,28 @@ import { ArgumentsParser } from "./ArgumentsParser";
 
 export class HelpPrinter {
   constructor(
-    private readonly programName: string,
-    private readonly executableName: string,
-    private readonly version: string,
-    private readonly buidlerParamDefinitions: BuidlerParamDefinitions,
-    private readonly tasks: TasksMap
+    private readonly _programName: string,
+    private readonly _executableName: string,
+    private readonly _version: string,
+    private readonly _buidlerParamDefinitions: BuidlerParamDefinitions,
+    private readonly _tasks: TasksMap
   ) {}
 
   public printGlobalHelp(includeInternalTasks = false) {
-    console.log(`${this.programName} version ${this.version}\n`);
+    console.log(`${this._programName} version ${this._version}\n`);
 
     console.log(
-      `Usage: ${this.executableName} [GLOBAL OPTIONS] <TASK> [TASK OPTIONS]\n`
+      `Usage: ${this._executableName} [GLOBAL OPTIONS] <TASK> [TASK OPTIONS]\n`
     );
 
     console.log("GLOBAL OPTIONS:\n");
 
-    this._printParamDetails(this.buidlerParamDefinitions);
+    this._printParamDetails(this._buidlerParamDefinitions);
 
     console.log("\n\nAVAILABLE TASKS:\n");
 
     const tasksToShow: TasksMap = {};
-    for (const [taskName, taskDefinition] of Object.entries(this.tasks)) {
+    for (const [taskName, taskDefinition] of Object.entries(this._tasks)) {
       if (includeInternalTasks || !taskDefinition.isInternal) {
         tasksToShow[taskName] = taskDefinition;
       }
@@ -43,8 +43,8 @@ export class HelpPrinter {
 
     for (const name of Object.keys(tasksToShow).sort()) {
       const description =
-        this.tasks[name].description !== undefined
-          ? this.tasks[name].description
+        this._tasks[name].description !== undefined
+          ? this._tasks[name].description
           : "";
       console.log(`  ${name.padEnd(nameLength)}\t${description}`);
     }
@@ -53,13 +53,13 @@ export class HelpPrinter {
 
     console.log(
       `To get help for a specific task run: ${
-        this.executableName
+        this._executableName
       } help [task]\n`
     );
   }
 
   public printTaskHelp(taskName: string) {
-    const taskDefinition = this.tasks[taskName];
+    const taskDefinition = this._tasks[taskName];
 
     if (taskDefinition === undefined) {
       throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, taskName);
@@ -70,10 +70,10 @@ export class HelpPrinter {
         ? taskDefinition.description
         : "";
 
-    console.log(`${this.programName} version ${this.version}\n`);
+    console.log(`${this._programName} version ${this._version}\n`);
 
     console.log(
-      `Usage: ${this.executableName} [GLOBAL OPTIONS] ${
+      `Usage: ${this._executableName} [GLOBAL OPTIONS] ${
         taskDefinition.name
       }${this._getParamsList(
         taskDefinition.paramDefinitions
@@ -102,7 +102,7 @@ export class HelpPrinter {
 
     console.log(`${taskDefinition.name}: ${description}\n`);
 
-    console.log(`For global options help run: ${this.executableName} help\n`);
+    console.log(`For global options help run: ${this._executableName} help\n`);
   }
 
   public _getParamValueDescription<T>(paramDefinition: ParamDefinition<T>) {

--- a/packages/buidler-core/src/internal/core/config/extenders.ts
+++ b/packages/buidler-core/src/internal/core/config/extenders.ts
@@ -1,13 +1,13 @@
 import { EnvironmentExtender } from "../../../types";
 
 export class ExtenderManager {
-  private readonly extenders: EnvironmentExtender[] = [];
+  private readonly _extenders: EnvironmentExtender[] = [];
 
   public add(extender: EnvironmentExtender) {
-    this.extenders.push(extender);
+    this._extenders.push(extender);
   }
 
   public getExtenders(): EnvironmentExtender[] {
-    return this.extenders;
+    return this._extenders;
   }
 }

--- a/packages/buidler-core/src/internal/core/tasks/dsl.ts
+++ b/packages/buidler-core/src/internal/core/tasks/dsl.ts
@@ -15,7 +15,7 @@ import {
  * for creating and overriding tasks.
  */
 export class TasksDSL {
-  private readonly tasks: TasksMap = {};
+  private readonly _tasks: TasksMap = {};
 
   /**
    * Creates a task, overrdining any previous task with the same name.
@@ -54,7 +54,7 @@ export class TasksDSL {
     descriptionOrAction?: string | ActionType<ArgsT>,
     action?: ActionType<ArgsT>
   ): TaskDefinition {
-    return this.addTask(name, descriptionOrAction, action, false);
+    return this._addTask(name, descriptionOrAction, action, false);
   }
 
   /**
@@ -94,7 +94,7 @@ export class TasksDSL {
     descriptionOrAction?: string | ActionType<ArgsT>,
     action?: ActionType<ArgsT>
   ): TaskDefinition {
-    return this.addTask(name, descriptionOrAction, action, true);
+    return this._addTask(name, descriptionOrAction, action, true);
   }
 
   /**
@@ -103,16 +103,16 @@ export class TasksDSL {
    * @returns The tasks container.
    */
   public getTaskDefinitions(): TasksMap {
-    return this.tasks;
+    return this._tasks;
   }
 
-  private addTask<ArgT extends TaskArguments>(
+  private _addTask<ArgT extends TaskArguments>(
     name: string,
     descriptionOrAction?: string | ActionType<ArgT>,
     action?: ActionType<ArgT>,
     isInternal?: boolean
   ) {
-    const parentTaskDefinition = this.tasks[name];
+    const parentTaskDefinition = this._tasks[name];
 
     let taskDefinition: TaskDefinition;
 
@@ -138,7 +138,7 @@ export class TasksDSL {
       taskDefinition.setAction(action);
     }
 
-    this.tasks[name] = taskDefinition;
+    this._tasks[name] = taskDefinition;
     return taskDefinition;
   }
 }

--- a/packages/buidler-core/src/internal/core/tasks/task-definitions.ts
+++ b/packages/buidler-core/src/internal/core/tasks/task-definitions.ts
@@ -276,7 +276,7 @@ export class SimpleTaskDefinition implements TaskDefinition {
     }
 
     if (type === undefined) {
-      if (defaultValue !== undefined && !this.isStringArray(defaultValue)) {
+      if (defaultValue !== undefined && !this._isStringArray(defaultValue)) {
         throw new BuidlerError(
           ERRORS.TASK_DEFINITIONS.DEFAULT_VALUE_WRONG_TYPE,
           name,
@@ -447,7 +447,7 @@ export class SimpleTaskDefinition implements TaskDefinition {
     }
   }
 
-  private isStringArray(values: any): values is string[] {
+  private _isStringArray(values: any): values is string[] {
     return Array.isArray(values) && values.every(v => typeof v === "string");
   }
 }

--- a/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
@@ -37,17 +37,31 @@ async function downloadFile(
 }
 
 export class CompilerDownloader {
+  private readonly _compilersDir: string;
+  private readonly _localSolcVersion: string;
+  private readonly _download: (
+    url: string,
+    destinationFile: string
+  ) => Promise<void>;
+
   constructor(
-    private readonly compilersDir: string,
-    private readonly localSolcVersion: string,
-    private readonly download = downloadFile
-  ) {}
+    readonly compilersDir: string,
+    readonly localSolcVersion: string,
+    readonly download = downloadFile
+  ) {
+    this._compilersDir = compilersDir;
+    this._localSolcVersion = localSolcVersion;
+    this._download = download;
+  }
 
   public async getDownloadedCompilerPath(version: string): Promise<string> {
     const compilerBuild = await this.getCompilerBuild(version);
-    const downloadedFilePath = path.join(this.compilersDir, compilerBuild.path);
+    const downloadedFilePath = path.join(
+      this._compilersDir,
+      compilerBuild.path
+    );
 
-    if (!(await this.fileExists(downloadedFilePath))) {
+    if (!(await this._fileExists(downloadedFilePath))) {
       await this.downloadCompiler(compilerBuild, downloadedFilePath);
     }
 
@@ -90,7 +104,7 @@ export class CompilerDownloader {
   }
 
   public getCompilersListPath() {
-    return path.join(this.compilersDir, "list.json");
+    return path.join(this._compilersDir, "list.json");
   }
 
   public async compilersListExists() {
@@ -100,12 +114,12 @@ export class CompilerDownloader {
 
   public async downloadCompilersList() {
     try {
-      await this.download(COMPILERS_LIST_URL, this.getCompilersListPath());
+      await this._download(COMPILERS_LIST_URL, this.getCompilersListPath());
     } catch (error) {
       throw new BuidlerError(
         ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
         error,
-        this.localSolcVersion
+        this._localSolcVersion
       );
     }
   }
@@ -119,13 +133,13 @@ export class CompilerDownloader {
     const compilerUrl = COMPILER_FILES_DIR_URL + compilerBuild.path;
 
     try {
-      await this.download(compilerUrl, downloadedFilePath);
+      await this._download(compilerUrl, downloadedFilePath);
     } catch (error) {
       throw new BuidlerError(
         ERRORS.SOLC.DOWNLOAD_FAILED,
         error,
         compilerBuild.version,
-        this.localSolcVersion
+        this._localSolcVersion
       );
     }
   }
@@ -149,12 +163,12 @@ export class CompilerDownloader {
       throw new BuidlerError(
         ERRORS.SOLC.INVALID_DOWNLOAD,
         compilerBuild.version,
-        this.localSolcVersion
+        this._localSolcVersion
       );
     }
   }
 
-  private async fileExists(filePath: string) {
+  private async _fileExists(filePath: string) {
     const fsExtra = await import("fs-extra");
     return fsExtra.pathExists(filePath);
   }

--- a/packages/buidler-core/src/internal/solidity/dependencyGraph.ts
+++ b/packages/buidler-core/src/internal/solidity/dependencyGraph.ts
@@ -9,7 +9,7 @@ export class DependencyGraph {
     const graph = new DependencyGraph();
 
     for (const resolvedFile of resolvedFiles) {
-      await graph.addDependenciesFrom(resolver, resolvedFile);
+      await graph._addDependenciesFrom(resolver, resolvedFile);
     }
 
     return graph;
@@ -20,7 +20,7 @@ export class DependencyGraph {
     Set<ResolvedFile>
   >();
 
-  private readonly visitedFiles = new Set<string>();
+  private readonly _visitedFiles = new Set<string>();
 
   private constructor() {}
 
@@ -28,12 +28,12 @@ export class DependencyGraph {
     return Array.from(this.dependenciesPerFile.keys());
   }
 
-  private async addDependenciesFrom(resolver: Resolver, file: ResolvedFile) {
-    if (this.visitedFiles.has(file.absolutePath)) {
+  private async _addDependenciesFrom(resolver: Resolver, file: ResolvedFile) {
+    if (this._visitedFiles.has(file.absolutePath)) {
       return;
     }
 
-    this.visitedFiles.add(file.absolutePath);
+    this._visitedFiles.add(file.absolutePath);
 
     const dependencies = new Set();
     this.dependenciesPerFile.set(file, dependencies);
@@ -44,7 +44,7 @@ export class DependencyGraph {
       const dependency = await resolver.resolveImport(file, imp);
       dependencies.add(dependency);
 
-      await this.addDependenciesFrom(resolver, dependency);
+      await this._addDependenciesFrom(resolver, dependency);
     }
   }
 }

--- a/packages/buidler-core/src/internal/solidity/resolver.ts
+++ b/packages/buidler-core/src/internal/solidity/resolver.ts
@@ -44,7 +44,11 @@ export class ResolvedFile {
 }
 
 export class Resolver {
-  constructor(private readonly projectRoot: string) {}
+  private readonly _projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this._projectRoot = projectRoot;
+  }
 
   public async resolveProjectSourceFile(
     pathToResolve: string
@@ -57,7 +61,7 @@ export class Resolver {
 
     const absolutePath = await fsExtra.realpath(pathToResolve);
 
-    if (!absolutePath.startsWith(this.projectRoot)) {
+    if (!absolutePath.startsWith(this._projectRoot)) {
       throw new BuidlerError(
         ERRORS.RESOLVER.FILE_OUTSIDE_PROJECT,
         pathToResolve
@@ -71,7 +75,7 @@ export class Resolver {
       );
     }
 
-    const globalName = absolutePath.slice(this.projectRoot.length + 1);
+    const globalName = absolutePath.slice(this._projectRoot.length + 1);
 
     return this._resolveFile(globalName, absolutePath);
   }
@@ -209,7 +213,7 @@ export class Resolver {
 
   public _resolveFromProjectRoot(fileName: string) {
     return require.resolve(fileName, {
-      paths: [this.projectRoot]
+      paths: [this._projectRoot]
     });
   }
 
@@ -219,8 +223,8 @@ export class Resolver {
         0,
         globalName.indexOf("/", globalName.indexOf("/") + 1)
       );
-    } else {
-      return globalName.slice(0, globalName.indexOf("/"));
     }
+
+    return globalName.slice(0, globalName.indexOf("/"));
   }
 }

--- a/packages/buidler-ethers/src/ethers-provider-wrapper.ts
+++ b/packages/buidler-ethers/src/ethers-provider-wrapper.ts
@@ -2,12 +2,15 @@ import { IEthereumProvider } from "@nomiclabs/buidler/types";
 import { JsonRpcProvider } from "ethers/providers";
 
 export class EthersProviderWrapper extends JsonRpcProvider {
-  constructor(private readonly buidlerProvider: IEthereumProvider) {
+  private readonly _buidlerProvider: IEthereumProvider;
+
+  constructor(buidlerProvider: IEthereumProvider) {
     super();
+    this._buidlerProvider = buidlerProvider;
   }
 
   public async send(method: string, params: any): Promise<any> {
-    const result = await this.buidlerProvider.send(method, params);
+    const result = await this._buidlerProvider.send(method, params);
 
     // We replicate ethers' behavior.
     this.emit("debug", {

--- a/packages/buidler-truffle4/src/artifacts.ts
+++ b/packages/buidler-truffle4/src/artifacts.ts
@@ -8,15 +8,21 @@ import { LazyTruffleContractProvisioner } from "./provisioner";
 import { TruffleContract, TruffleContractInstance } from "./types";
 
 export class TruffleEnvironmentArtifacts {
+  private readonly _artifactsPath: string;
+  private readonly _provisioner: LazyTruffleContractProvisioner;
+
   constructor(
-    private readonly artifactsPath: string,
-    private readonly provisioner: LazyTruffleContractProvisioner
-  ) {}
+    artifactsPath: string,
+    provisioner: LazyTruffleContractProvisioner
+  ) {
+    this._provisioner = provisioner;
+    this._artifactsPath = artifactsPath;
+  }
 
   public require(contractPath: string): any {
-    const name = this.getContractNameFromPath(contractPath);
+    const name = this._getContractNameFromPath(contractPath);
 
-    return this.getTruffleContract(name);
+    return this._getTruffleContract(name);
   }
 
   public contractNeedsLinking(Contract: TruffleContract) {
@@ -66,7 +72,7 @@ export class TruffleEnvironmentArtifacts {
     }
 
     const destinationArtifact = readArtifactSync(
-      this.artifactsPath,
+      this._artifactsPath,
       destination.contractName
     );
 
@@ -139,7 +145,7 @@ export class TruffleEnvironmentArtifacts {
     destination.link(libraryAddresses);
   }
 
-  private getContractNameFromPath(contractPath: string) {
+  private _getContractNameFromPath(contractPath: string) {
     const basename = path.basename(contractPath);
 
     const lastDotIndex = basename.lastIndexOf(".");
@@ -150,11 +156,11 @@ export class TruffleEnvironmentArtifacts {
     return basename.slice(0, lastDotIndex);
   }
 
-  private getTruffleContract(contractName: string): TruffleContract {
-    const artifact = readArtifactSync(this.artifactsPath, contractName);
+  private _getTruffleContract(contractName: string): TruffleContract {
+    const artifact = readArtifactSync(this._artifactsPath, contractName);
     const TruffleContractFactory = require("truffle-contract");
     const Contract = TruffleContractFactory(artifact);
 
-    return this.provisioner.provision(Contract, this);
+    return this._provisioner.provision(Contract, this);
   }
 }

--- a/packages/buidler-truffle5/src/artifacts.ts
+++ b/packages/buidler-truffle5/src/artifacts.ts
@@ -8,15 +8,21 @@ import { LazyTruffleContractProvisioner } from "./provisioner";
 import { TruffleContract, TruffleContractInstance } from "./types";
 
 export class TruffleEnvironmentArtifacts {
+  private readonly _artifactsPath: string;
+  private readonly _provisioner: LazyTruffleContractProvisioner;
+
   constructor(
-    private readonly artifactsPath: string,
-    private readonly provisioner: LazyTruffleContractProvisioner
-  ) {}
+    artifactsPath: string,
+    provisioner: LazyTruffleContractProvisioner
+  ) {
+    this._provisioner = provisioner;
+    this._artifactsPath = artifactsPath;
+  }
 
   public require(contractPath: string): any {
-    const name = this.getContractNameFromPath(contractPath);
+    const name = this._getContractNameFromPath(contractPath);
 
-    return this.getTruffleContract(name);
+    return this._getTruffleContract(name);
   }
 
   public contractNeedsLinking(Contract: TruffleContract) {
@@ -66,7 +72,7 @@ export class TruffleEnvironmentArtifacts {
     }
 
     const destinationArtifact = readArtifactSync(
-      this.artifactsPath,
+      this._artifactsPath,
       destination.contractName
     );
 
@@ -139,7 +145,7 @@ export class TruffleEnvironmentArtifacts {
     destination.link(libraryAddresses);
   }
 
-  private getContractNameFromPath(contractPath: string) {
+  private _getContractNameFromPath(contractPath: string) {
     const basename = path.basename(contractPath);
 
     const lastDotIndex = basename.lastIndexOf(".");
@@ -150,11 +156,11 @@ export class TruffleEnvironmentArtifacts {
     return basename.slice(0, lastDotIndex);
   }
 
-  private getTruffleContract(contractName: string): TruffleContract {
-    const artifact = readArtifactSync(this.artifactsPath, contractName);
+  private _getTruffleContract(contractName: string): TruffleContract {
+    const artifact = readArtifactSync(this._artifactsPath, contractName);
     const TruffleContractFactory = require("truffle-contract");
     const Contract = TruffleContractFactory(artifact);
 
-    return this.provisioner.provision(Contract, this);
+    return this._provisioner.provision(Contract, this);
   }
 }

--- a/packages/buidler-truffle5/src/provisioner.ts
+++ b/packages/buidler-truffle5/src/provisioner.ts
@@ -1,10 +1,14 @@
 import { Linker, TruffleContract } from "./types";
 
 export class LazyTruffleContractProvisioner {
-  constructor(private readonly web3: any) {}
+  private readonly _web3: any;
+
+  constructor(web3: any) {
+    this._web3 = web3;
+  }
 
   public provision(Contract: TruffleContract, linker: Linker) {
-    Contract.setProvider(this.web3.currentProvider);
+    Contract.setProvider(this._web3.currentProvider);
 
     const originalLink = Contract.link;
     Contract.link = (...args: any[]) => {
@@ -19,12 +23,12 @@ export class LazyTruffleContractProvisioner {
       originalLink.apply(Contract, args);
     };
 
-    this.hookCloneCalls(Contract, linker);
+    this._hookCloneCalls(Contract, linker);
 
     return Contract;
   }
 
-  private hookCloneCalls(Contract: TruffleContract, linker: Linker) {
+  private _hookCloneCalls(Contract: TruffleContract, linker: Linker) {
     const originalClone = Contract.clone;
 
     Contract.clone = (...args: any[]) => {

--- a/packages/buidler-web3-legacy/src/web3-provider-adapter.ts
+++ b/packages/buidler-web3-legacy/src/web3-provider-adapter.ts
@@ -25,12 +25,16 @@ export interface JsonRpcError extends Error {
 }
 
 export class Web3HTTPProviderAdapter {
-  constructor(private readonly provider: IEthereumProvider) {
+  private readonly _provider: IEthereumProvider;
+
+  constructor(provider: IEthereumProvider) {
+    this._provider = provider;
+
     // We bind everything here becase some test suits breack otherwise
     this.sendAsync = this.sendAsync.bind(this) as any;
     this.send = this.send.bind(this) as any;
     this.isConnected = this.isConnected.bind(this) as any;
-    this.sendJsonRpcRequest = this.sendJsonRpcRequest.bind(this) as any;
+    this._sendJsonRpcRequest = this._sendJsonRpcRequest.bind(this) as any;
   }
 
   public send(payload: any) {
@@ -52,7 +56,7 @@ export class Web3HTTPProviderAdapter {
     callback: (error: Error | null, response?: any) => void
   ): void {
     if (!Array.isArray(payload)) {
-      util.callbackify(() => this.sendJsonRpcRequest(payload))(callback);
+      util.callbackify(() => this._sendJsonRpcRequest(payload))(callback);
       return;
     }
 
@@ -60,7 +64,7 @@ export class Web3HTTPProviderAdapter {
       const responses: JsonRpcResponse[] = [];
 
       for (const request of payload) {
-        const response = await this.sendJsonRpcRequest(request);
+        const response = await this._sendJsonRpcRequest(request);
 
         responses.push(response);
 
@@ -77,7 +81,7 @@ export class Web3HTTPProviderAdapter {
     return true;
   }
 
-  private async sendJsonRpcRequest(
+  private async _sendJsonRpcRequest(
     request: JsonRpcRequest
   ): Promise<JsonRpcResponse> {
     const response: JsonRpcResponse = {
@@ -86,7 +90,7 @@ export class Web3HTTPProviderAdapter {
     };
 
     try {
-      const result = await this.provider.send(request.method, request.params);
+      const result = await this._provider.send(request.method, request.params);
       response.result = result;
     } catch (error) {
       response.error = {

--- a/packages/buidler-web3/src/web3-provider-adapter.ts
+++ b/packages/buidler-web3/src/web3-provider-adapter.ts
@@ -24,11 +24,14 @@ export interface JsonRpcError extends Error {
 }
 
 export class Web3HTTPProviderAdapter {
-  constructor(private readonly provider: IEthereumProvider) {
+  private readonly _provider: IEthereumProvider;
+
+  constructor(provider: IEthereumProvider) {
+    this._provider = provider;
     // We bind everything here because some test suits break otherwise
     this.send = this.send.bind(this) as any;
     this.isConnected = this.isConnected.bind(this) as any;
-    this.sendJsonRpcRequest = this.sendJsonRpcRequest.bind(this) as any;
+    this._sendJsonRpcRequest = this._sendJsonRpcRequest.bind(this) as any;
   }
 
   public send(
@@ -44,7 +47,7 @@ export class Web3HTTPProviderAdapter {
     callback: (error: Error | null, response?: any) => void
   ): void {
     if (!Array.isArray(payload)) {
-      util.callbackify(() => this.sendJsonRpcRequest(payload))(callback);
+      util.callbackify(() => this._sendJsonRpcRequest(payload))(callback);
       return;
     }
 
@@ -52,7 +55,7 @@ export class Web3HTTPProviderAdapter {
       const responses: JsonRpcResponse[] = [];
 
       for (const request of payload) {
-        const response = await this.sendJsonRpcRequest(request);
+        const response = await this._sendJsonRpcRequest(request);
 
         responses.push(response);
 
@@ -69,7 +72,7 @@ export class Web3HTTPProviderAdapter {
     return true;
   }
 
-  private async sendJsonRpcRequest(
+  private async _sendJsonRpcRequest(
     request: JsonRpcRequest
   ): Promise<JsonRpcResponse> {
     const response: JsonRpcResponse = {
@@ -78,7 +81,7 @@ export class Web3HTTPProviderAdapter {
     };
 
     try {
-      const result = await this.provider.send(request.method, request.params);
+      const result = await this._provider.send(request.method, request.params);
       response.result = result;
     } catch (error) {
       response.error = {


### PR DESCRIPTION
This PR adds some more lint rules. 

The most important one is that it forces private fields/methods to start with an underscore. This is important for javascript users, as they can't distinguish between private and public fields (that's a TS thing) and they'd consider everything public otherwise.