### PR TITLE
Define a clear set of rules about how to import dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,30 @@ We keep our dependencies versions in sync between the different projects.
 Running `node scripts/check-dependencies.js` from the root folder checks that every project specifies the same versions
 of each dependency. It will print an error if the versions get out of sync. 
 
+## Performance and dependencies loading
+
+Buidler and its plugins are optimized for keeping startup time low. 
+
+This is done by selectively requiring dependencies when needed using `import` or `require` following this criteria:
+
+1. If something is only imported for its type, and NOT its value, use a top-level `import ... from "mod""` 
+1. If a module is in the least below, use a top-level `import ... from "mod""`.
+3. Otherwise, use `await import` or `require` locally in the functions that use it.
+  3.1. If the function is sync, use node's `require`
+  3.2. If the function is an async, use `await import`
+
+Note that these rules don't apply to tests. You can always use top-level imports there.
+
+### Essential modules
+
+This is a list of the modules that always get loaded during startup:
+
+* `fs`
+* `path`
+* `util`
+* `find-up`
+* `fs-extra`
+* `semver`
+* `deepmerge`
+* `source-map-support/register`
+ 

--- a/packages/buidler-core/src/builtin-tasks/clean.ts
+++ b/packages/buidler-core/src/builtin-tasks/clean.ts
@@ -1,3 +1,5 @@
+import fsExtra from "fs-extra";
+
 import { task } from "../internal/core/config/config-env";
 
 import { TASK_CLEAN } from "./task-names";
@@ -6,8 +8,7 @@ task(
   TASK_CLEAN,
   "Clears the cache and deletes all artifacts",
   async (_, { config }) => {
-    const fs = await import("fs-extra");
-    await fs.remove(config.paths.cache);
-    await fs.remove(config.paths.artifacts);
+    await fsExtra.remove(config.paths.cache);
+    await fsExtra.remove(config.paths.artifacts);
   }
 );

--- a/packages/buidler-core/src/builtin-tasks/compile.ts
+++ b/packages/buidler-core/src/builtin-tasks/compile.ts
@@ -1,4 +1,5 @@
 import colors from "ansi-colors";
+import fsExtra from "fs-extra";
 import path from "path";
 
 import {
@@ -114,7 +115,6 @@ internalTask(TASK_BUILD_ARTIFACTS, async (_, { config, run }) => {
     return;
   }
 
-  const fsExtra = await import("fs-extra");
   await fsExtra.ensureDir(config.paths.artifacts);
   let numberOfContracts = 0;
 

--- a/packages/buidler-core/src/builtin-tasks/console.ts
+++ b/packages/buidler-core/src/builtin-tasks/console.ts
@@ -1,3 +1,7 @@
+import fsExtra from "fs-extra";
+import * as path from "path";
+import * as semver from "semver";
+
 import { task } from "../internal/core/config/config-env";
 import { runScriptWithBuidler } from "../internal/util/scripts-runner";
 
@@ -6,10 +10,6 @@ import { TASK_CONSOLE } from "./task-names";
 task(TASK_CONSOLE, "Opens a buidler console")
   .addFlag("noCompile", "Don't compile before running this task")
   .setAction(async ({ noCompile }: { noCompile: boolean }, { config, run }) => {
-    const path = await import("path");
-    const fsExtra = await import("fs-extra");
-    const semver = await import("semver");
-
     if (!noCompile) {
       await run("compile");
     }

--- a/packages/buidler-core/src/builtin-tasks/run.ts
+++ b/packages/buidler-core/src/builtin-tasks/run.ts
@@ -1,3 +1,5 @@
+import fsExtra from "fs-extra";
+
 import { task } from "../internal/core/config/config-env";
 import { BuidlerError, ERRORS } from "../internal/core/errors";
 import { runScriptWithBuidler } from "../internal/util/scripts-runner";
@@ -15,8 +17,6 @@ task(TASK_RUN, "Runs a user-defined script after compiling the project")
       { script, noCompile }: { script: string; noCompile: boolean },
       { run }
     ) => {
-      const fsExtra = await import("fs-extra");
-
       if (!(await fsExtra.pathExists(script))) {
         throw new BuidlerError(ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND, script);
       }

--- a/packages/buidler-core/src/builtin-tasks/utils/cache.ts
+++ b/packages/buidler-core/src/builtin-tasks/utils/cache.ts
@@ -1,3 +1,4 @@
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { glob } from "../../internal/util/glob";
@@ -6,7 +7,6 @@ import { ProjectPaths } from "../../types";
 const LAST_CONFIG_USED_FILENAME = "path-to-last-config-used.txt";
 
 async function getModificationDate(file: string): Promise<Date> {
-  const fsExtra = await import("fs-extra");
   const stat = await fsExtra.stat(file);
   return new Date(stat.mtime);
 }
@@ -50,7 +50,6 @@ function getPathToCachedLastConfigPath(paths: ProjectPaths) {
 async function getLastUsedConfig(
   paths: ProjectPaths
 ): Promise<string | undefined> {
-  const fsExtra = await import("fs-extra");
   const pathToLastConfigUsed = getPathToCachedLastConfigPath(paths);
 
   if (!(await fsExtra.pathExists(pathToLastConfigUsed))) {
@@ -61,7 +60,6 @@ async function getLastUsedConfig(
 }
 
 async function saveLastConfigUsed(paths: ProjectPaths) {
-  const fsExtra = await import("fs-extra");
   const pathToLastConfigUsed = getPathToCachedLastConfigPath(paths);
 
   await fsExtra.ensureDir(path.dirname(pathToLastConfigUsed));

--- a/packages/buidler-core/src/internal/artifacts.ts
+++ b/packages/buidler-core/src/internal/artifacts.ts
@@ -1,3 +1,4 @@
+import fsExtra from "fs-extra";
 import * as path from "path";
 
 import { Artifact } from "../types";
@@ -41,7 +42,6 @@ function getArtifactPath(artifactsPath: string, contractName: string): string {
  * @param artifact the artifact to be stored.
  */
 export async function saveArtifact(artifactsPath: string, artifact: Artifact) {
-  const fsExtra = await import("fs-extra");
   await fsExtra.writeJSON(
     artifactsPath + "/" + artifact.contractName + ".json",
     artifact,
@@ -61,7 +61,6 @@ export async function readArtifact(
   artifactsPath: string,
   contractName: string
 ): Promise<Artifact> {
-  const fsExtra = require("fs-extra");
   const artifactPath = getArtifactPath(artifactsPath, contractName);
 
   if (!fsExtra.pathExistsSync(artifactPath)) {
@@ -81,7 +80,6 @@ export function readArtifactSync(
   artifactsPath: string,
   contractName: string
 ): Artifact {
-  const fsExtra = require("fs-extra");
   const artifactPath = getArtifactPath(artifactsPath, contractName);
 
   if (!fsExtra.pathExistsSync(artifactPath)) {

--- a/packages/buidler-core/src/internal/cli/project-creation.ts
+++ b/packages/buidler-core/src/internal/cli/project-creation.ts
@@ -1,4 +1,5 @@
 import colors from "ansi-colors";
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { BUIDLER_NAME } from "../constants";
@@ -12,7 +13,6 @@ const CREATE_EMPTY_BUIDLER_CONFIG_ACTION = "Create an empty buidler.config.js";
 const QUIT_ACTION = "Quit";
 
 async function removeProjectDirIfPresent(projectRoot: string, dirName: string) {
-  const fsExtra = await import("fs-extra");
   const dirPath = path.join(projectRoot, dirName);
   if (await fsExtra.pathExists(dirPath)) {
     await fsExtra.remove(dirPath);
@@ -51,7 +51,6 @@ async function printWelcomeMessage() {
 }
 
 async function copySampleProject(projectRoot: string) {
-  const fsExtra = await import("fs-extra");
   const packageRoot = await getPackageRoot();
 
   await fsExtra.ensureDir(projectRoot);
@@ -64,7 +63,6 @@ async function copySampleProject(projectRoot: string) {
 }
 
 async function addGitIgnore(projectRoot: string) {
-  const fsExtra = await import("fs-extra");
   const gitIgnorePath = path.join(projectRoot, ".gitignore");
 
   let content = await getRecommendedGitIgnore();
@@ -78,7 +76,6 @@ async function addGitIgnore(projectRoot: string) {
 }
 
 async function addGitAttributes(projectRoot: string) {
-  const fsExtra = await import("fs-extra");
   const gitAttributesPath = path.join(projectRoot, ".gitattributes");
   let content = "*.sol linguist-language=Solidity";
 
@@ -114,7 +111,6 @@ function printSuggestedPlugins() {
 }
 
 async function writeEmptyBuidlerConfig() {
-  const fsExtra = await import("fs-extra");
   return fsExtra.writeFile(
     "buidler.config.js",
     "module.exports = {};\n",

--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import fsExtra from "fs-extra";
+
 import { BuidlerError, ERRORS } from "../errors";
 
 /**
@@ -120,8 +123,6 @@ export const inputFile: ArgumentType<string> = {
   name: "inputFile",
   parse(argName: string, strValue: string): string {
     try {
-      const fs = require("fs");
-      const fsExtra = require("fs-extra");
       fs.accessSync(strValue, fsExtra.constants.R_OK);
       const stats = fs.lstatSync(strValue);
 

--- a/packages/buidler-core/src/internal/core/project-structure.ts
+++ b/packages/buidler-core/src/internal/core/project-structure.ts
@@ -1,11 +1,11 @@
 import findUp from "find-up";
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { getPackageRoot } from "../util/packageInfo";
 
 import { BuidlerError, ERRORS } from "./errors";
 import { isTypescriptSupported } from "./typescript-support";
-
 const JS_CONFIG_FILENAME = "buidler.config.js";
 const TS_CONFIG_FILENAME = "buidler.config.ts";
 
@@ -33,7 +33,6 @@ export function getUserConfigPath() {
 }
 
 export async function getRecommendedGitIgnore() {
-  const fsExtra = await import("fs-extra");
   const packageRoot = await getPackageRoot();
   const gitIgnorePath = path.join(packageRoot, "recommended-gitignore.txt");
 

--- a/packages/buidler-core/src/internal/core/providers/accounts.ts
+++ b/packages/buidler-core/src/internal/core/providers/accounts.ts
@@ -1,5 +1,3 @@
-import Transaction from "ethereumjs-tx";
-import { bufferToHex, toBuffer } from "ethereumjs-util";
 import { Account } from "web3x/account";
 import { Tx } from "web3x/eth";
 
@@ -14,6 +12,7 @@ export function createLocalAccountsProvider(
   provider: IEthereumProvider,
   privateKeys: string[]
 ) {
+  const { bufferToHex, toBuffer } = require("ethereumjs-util");
   const accounts: Account[] = privateKeys.map(pkString =>
     Account.fromPrivate(toBuffer(pkString))
   );
@@ -82,7 +81,7 @@ export function createLocalAccountsProvider(
         throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, tx.from);
       }
 
-      // TODO: Remove ethereumjs-tx dependencies in favor of web3x.
+      const { default: Transaction } = await import("ethereumjs-tx");
       const transaction = new Transaction(tx);
       transaction.sign(account.privateKey);
 
@@ -116,6 +115,8 @@ export function createHDWalletProvider(
       Account.createFromMnemonicAndPath(mnemonic, hdpath + i.toString())
     );
   }
+
+  const { bufferToHex } = require("ethereumjs-util");
 
   return createLocalAccountsProvider(
     provider,

--- a/packages/buidler-core/src/internal/core/providers/wrapper.ts
+++ b/packages/buidler-core/src/internal/core/providers/wrapper.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from "lodash";
-
 import { IEthereumProvider } from "../../../types";
 
 export function wrapSend(
@@ -9,6 +7,7 @@ export function wrapSend(
   return new Proxy(provider, {
     get(target: IEthereumProvider, p: PropertyKey, receiver: any): any {
       if (p === "send") {
+        const { cloneDeep } = require("lodash");
         return (method: string, params: any[] = []) =>
           sendWrapper(method, cloneDeep(params));
       }

--- a/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
@@ -1,3 +1,4 @@
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { BuidlerError, ERRORS } from "../../core/errors";
@@ -78,7 +79,6 @@ export class CompilerDownloader {
 
     // We may need to re-download the compilers list.
     if (compilerBuildPath === undefined && compilersListExisted) {
-      const fsExtra = await import("fs-extra");
       await fsExtra.unlink(this.getCompilersListPath());
 
       list = await this.getCompilersList();
@@ -99,7 +99,6 @@ export class CompilerDownloader {
       await this.downloadCompilersList();
     }
 
-    const fsExtra = await import("fs-extra");
     return fsExtra.readJson(this.getCompilersListPath());
   }
 
@@ -108,7 +107,6 @@ export class CompilerDownloader {
   }
 
   public async compilersListExists() {
-    const fsExtra = await import("fs-extra");
     return fsExtra.pathExists(this.getCompilersListPath());
   }
 
@@ -148,7 +146,6 @@ export class CompilerDownloader {
     compilerBuild: CompilerBuild,
     downloadedFilePath: string
   ) {
-    const fsExtra = await import("fs-extra");
     const ethereumjsUtil = await import("ethereumjs-util");
 
     const expectedKeccak256 = compilerBuild.keccak256;
@@ -169,7 +166,6 @@ export class CompilerDownloader {
   }
 
   private async _fileExists(filePath: string) {
-    const fsExtra = await import("fs-extra");
     return fsExtra.pathExists(filePath);
   }
 }

--- a/packages/buidler-core/src/internal/solidity/compiler/index.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/index.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+
 import { CompilerDownloader } from "./downloader";
 
 export class Compiler {
@@ -75,7 +77,6 @@ export class Compiler {
       module: NodeJS.Module,
       filename: string
     ) {
-      const fs = require("fs");
       const content = fs.readFileSync(filename, "utf8");
       Object.getPrototypeOf(module)._compile.call(module, content, filename);
     };

--- a/packages/buidler-core/src/internal/solidity/resolver.ts
+++ b/packages/buidler-core/src/internal/solidity/resolver.ts
@@ -1,3 +1,4 @@
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { BuidlerError, ERRORS } from "../core/errors";
@@ -53,8 +54,6 @@ export class Resolver {
   public async resolveProjectSourceFile(
     pathToResolve: string
   ): Promise<ResolvedFile> {
-    const fsExtra = await import("fs-extra");
-
     if (!(await fsExtra.pathExists(pathToResolve))) {
       throw new BuidlerError(ERRORS.RESOLVER.FILE_NOT_FOUND, pathToResolve);
     }
@@ -83,8 +82,6 @@ export class Resolver {
   public async resolveLibrarySourceFile(
     globalName: string
   ): Promise<ResolvedFile> {
-    const fsExtra = await import("fs-extra");
-
     const libraryName = this._getLibraryName(globalName);
 
     let packagePath;
@@ -192,7 +189,6 @@ export class Resolver {
     libraryName?: string,
     libraryVersion?: string
   ): Promise<ResolvedFile> {
-    const fsExtra = await import("fs-extra");
     const content = await fsExtra.readFile(absolutePath, { encoding: "utf8" });
     const stats = await fsExtra.stat(absolutePath);
     const lastModificationDate = new Date(stats.mtime);

--- a/packages/buidler-core/src/internal/util/glob.ts
+++ b/packages/buidler-core/src/internal/util/glob.ts
@@ -1,6 +1,10 @@
-import globModule from "glob";
 import util from "util";
 
-export const glob = util.promisify(globModule);
+export async function glob(pattern: string): Promise<string[]> {
+  const { default: globModule } = await import("glob");
+  return util.promisify(globModule)(pattern);
+}
 
-export const globSync = globModule.sync;
+export function globSync(pattern: string): string[] {
+  return require("glob").sync(pattern);
+}

--- a/packages/buidler-core/src/internal/util/packageInfo.ts
+++ b/packages/buidler-core/src/internal/util/packageInfo.ts
@@ -1,4 +1,5 @@
 import findup from "find-up";
+import fsExtra from "fs-extra";
 import path from "path";
 
 async function getPackageJsonPath(): Promise<string> {
@@ -24,8 +25,6 @@ function findClosestPackageJson(file: string): string | null {
 }
 
 export async function getPackageJson(): Promise<PackageJson> {
-  const fsExtra = await import("fs-extra");
   const root = await getPackageRoot();
-
   return fsExtra.readJSON(root + "/package.json");
 }

--- a/packages/buidler-core/src/internal/util/scripts-runner.ts
+++ b/packages/buidler-core/src/internal/util/scripts-runner.ts
@@ -1,11 +1,11 @@
-import { fork } from "child_process";
-
 export async function runScript(
   scriptPath: string,
   scriptArgs: string[] = [],
   extraNodeArgs: string[] = [],
   extraEnvVars: { [name: string]: string } = {}
 ): Promise<number> {
+  const { fork } = await import("child_process");
+
   return new Promise((resolve, reject) => {
     const nodeArgs = [
       ...process.execArgv,

--- a/packages/buidler-ethers/src/index.ts
+++ b/packages/buidler-ethers/src/index.ts
@@ -1,14 +1,17 @@
 import { extendEnvironment } from "@nomiclabs/buidler/config";
 import { lazyObject, readArtifact } from "@nomiclabs/buidler/plugins";
 import { BuidlerRuntimeEnvironment } from "@nomiclabs/buidler/types";
-import { ContractFactory, ethers, Signer } from "ethers";
+import { ContractFactory, Signer } from "ethers";
 
 import { EthersProviderWrapper } from "./ethers-provider-wrapper";
 
 extendEnvironment((env: BuidlerRuntimeEnvironment) => {
   env.ethers = {
-    provider: lazyObject(() => new EthersProviderWrapper(env.ethereum)),
+    provider: lazyObject(() => {
+      return new EthersProviderWrapper(env.ethereum);
+    }),
     getContract: async (name: string): Promise<ContractFactory> => {
+      const { ethers } = await import("ethers");
       const artifact = await readArtifact(env.config.paths.artifacts, name);
       const bytecode = artifact.bytecode;
       const signers = await env.ethers.signers();

--- a/packages/buidler-solhint/src/index.ts
+++ b/packages/buidler-solhint/src/index.ts
@@ -1,5 +1,6 @@
 import { internalTask, task } from "@nomiclabs/buidler/config";
 import { BuidlerPluginError } from "@nomiclabs/buidler/internal/core/errors";
+import * as fs from "fs";
 import { join } from "path";
 
 function getDefaultConfig() {
@@ -30,7 +31,6 @@ async function hasConfigFile(rootDirectory: string) {
     "solhint.config.js"
   ];
 
-  const fs = await import("fs");
   for (const file of files) {
     if (fs.existsSync(join(rootDirectory, file))) {
       return true;

--- a/packages/buidler-solpp/src/index.ts
+++ b/packages/buidler-solpp/src/index.ts
@@ -1,6 +1,7 @@
 import { TASK_COMPILE_GET_SOURCE_PATHS } from "@nomiclabs/buidler/builtin-tasks/task-names";
 import { internalTask } from "@nomiclabs/buidler/config";
 import { ResolvedBuidlerConfig } from "@nomiclabs/buidler/types";
+import fsExtra from "fs-extra";
 import path from "path";
 
 import { SolppConfig } from "./types";
@@ -25,8 +26,6 @@ function getConfig(config: ResolvedBuidlerConfig): SolppConfig {
 }
 
 async function readFiles(filePaths: string[]): Promise<string[][]> {
-  const fsExtra = await import("fs-extra");
-
   return Promise.all(
     filePaths.map(filePath =>
       fsExtra.readFile(filePath, "utf-8").then(content => [filePath, content])
@@ -41,7 +40,6 @@ internalTask(
     { config }: { config: ResolvedBuidlerConfig }
   ) => {
     const processedPaths: string[] = [];
-    const fsExtra = await import("fs-extra");
     const solpp = await import("solpp");
     for (const [filePath, content] of files) {
       const processedFilePath = path.join(


### PR DESCRIPTION
This PR defines a clear set of rules about how to import dependencies in a performant way. 

The rules are documented in `CONTRIBUTING.md`.

Closes #198 