### PR TITLE
Let solidity choose the default evm version

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -274,7 +274,7 @@ The `solc` config field is an optional object which can contain the following ke
 
 - `version`: The solc version to use. We recommend always setting this field. Default value: `"0.5.8"`.
 - `optimizer`: An object with `enabled` and `runs` keys. Default value: `{ enabled: false, runs: 200 }`.
-- `evmVersion`: A string controlling the target evm version. One of `"homestead"`, `"tangerineWhistle"`, `"spuriousDragon"`, `"byzantium"`, `"constantinople"`, and `"petersburg"`. Default value: `"petersburg"`.
+- `evmVersion`: A string controlling the target evm version. One of `"homestead"`, `"tangerineWhistle"`, `"spuriousDragon"`, `"byzantium"`, `"constantinople"`, and `"petersburg"`. Default value: managed by Solidity. Please, consult its documentation.
 
 ##### Path configuration
 

--- a/packages/buidler-core/src/builtin-tasks/compile.ts
+++ b/packages/buidler-core/src/builtin-tasks/compile.ts
@@ -57,8 +57,8 @@ export default function() {
     const dependencyGraph = await run(TASK_COMPILE_GET_DEPENDENCY_GRAPH);
     return getInputFromDependencyGraph(
       dependencyGraph,
-      config.solc.evmVersion,
-      config.solc.optimizer
+      config.solc.optimizer,
+      config.solc.evmVersion
     );
   });
 

--- a/packages/buidler-core/src/internal/core/config/default-config.ts
+++ b/packages/buidler-core/src/internal/core/config/default-config.ts
@@ -6,8 +6,7 @@ const defaultConfig: BuidlerConfig = {
     optimizer: {
       enabled: false,
       runs: 200
-    },
-    evmVersion: "petersburg"
+    }
   },
   networks: {
     develop: {

--- a/packages/buidler-core/src/internal/solidity/compiler/compiler-input.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/compiler-input.ts
@@ -3,8 +3,8 @@ import { DependencyGraph } from "../dependencyGraph";
 
 export function getInputFromDependencyGraph(
   graph: DependencyGraph,
-  evmVersion: string,
-  optimizerConfig: SolcOptimizerConfig
+  optimizerConfig: SolcOptimizerConfig,
+  evmVersion?: string
 ): SolcInput {
   const sources: { [globalName: string]: { content: string } } = {};
   for (const file of graph.getResolvedFiles()) {
@@ -13,11 +13,10 @@ export function getInputFromDependencyGraph(
     };
   }
 
-  return {
+  const input: SolcInput = {
     language: "Solidity",
     sources,
     settings: {
-      evmVersion,
       metadata: {
         useLiteralContent: true
       },
@@ -30,4 +29,10 @@ export function getInputFromDependencyGraph(
       }
     }
   };
+
+  if (evmVersion !== undefined) {
+    input.settings.evmVersion = evmVersion;
+  }
+
+  return input;
 }

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -86,7 +86,7 @@ type EVMVersion =
 export interface SolcConfig {
   version: string;
   optimizer: SolcOptimizerConfig;
-  evmVersion: EVMVersion;
+  evmVersion?: EVMVersion;
 }
 
 export interface SolcOptimizerConfig {
@@ -99,7 +99,7 @@ export interface SolcInput {
     metadata: { useLiteralContent: boolean };
     optimizer: SolcOptimizerConfig;
     outputSelection: { "*": { "": string[]; "*": string[] } };
-    evmVersion: string;
+    evmVersion?: string;
   };
   sources: { [p: string]: { content: string } };
   language: string;

--- a/packages/buidler-core/test/helpers/compiler.ts
+++ b/packages/buidler-core/test/helpers/compiler.ts
@@ -1,7 +1,3 @@
 export function getLocalCompilerVersion(): string {
   return require("solc/package.json").version;
 }
-
-export function getDefaultEvmVersion(): string {
-  return "petersburg";
-}

--- a/packages/buidler-core/test/internal/core/config/config-resolution.ts
+++ b/packages/buidler-core/test/internal/core/config/config-resolution.ts
@@ -26,7 +26,7 @@ describe("Config resolution", () => {
         const config = loadConfigAndTasks();
         assert.equal(config.solc.version, getLocalCompilerVersion());
         assert.containsAllKeys(config.networks, ["auto", "develop"]);
-        assert.equal(config.solc.evmVersion, "petersburg");
+        assert.isUndefined(config.solc.evmVersion);
       });
     });
 

--- a/packages/buidler-core/test/internal/solidity/compiler/compiler-input.ts
+++ b/packages/buidler-core/test/internal/solidity/compiler/compiler-input.ts
@@ -6,7 +6,7 @@ import {
   ResolvedFile,
   Resolver
 } from "../../../../src/internal/solidity/resolver";
-import { getDefaultEvmVersion } from "../../../helpers/compiler";
+import { SolcInput } from "../../../../src/types";
 
 describe("compiler-input module", function() {
   it("Should construct the right input for a dependency graph", async () => {
@@ -23,14 +23,13 @@ describe("compiler-input module", function() {
     const path2 = "/fake/absolute/path2";
     const content2 = "THE CONTENT2";
 
-    const expectedInput = {
+    const expectedInput: SolcInput = {
       language: "Solidity",
       sources: {
         [globalName1]: { content: content1 },
         [globalName2]: { content: content2 }
       },
       settings: {
-        evmVersion: getDefaultEvmVersion(),
         metadata: {
           useLiteralContent: true
         },
@@ -54,10 +53,20 @@ describe("compiler-input module", function() {
 
     const input = getInputFromDependencyGraph(
       graph,
-      getDefaultEvmVersion(),
-      optimizerConfig
+      optimizerConfig,
+      undefined
     );
 
     assert.deepEqual(input, expectedInput);
+
+    const inputWithEvmVersion = getInputFromDependencyGraph(
+      graph,
+      optimizerConfig,
+      "byzantium"
+    );
+
+    expectedInput.settings.evmVersion = "byzantium";
+
+    assert.deepEqual(inputWithEvmVersion, expectedInput);
   });
 });


### PR DESCRIPTION
This is an alternative solution to #271

We just let solidity choose the default evm version. This is easier to maintain, and can't result in version errors.