### PR TITLE
Change default gasMultiplier to 1

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -248,7 +248,7 @@ The `networks` config field is an optional object where network names map to obj
 - `from`: The address to use as default sender. If not present the first account of the node is used.
 - `gas`: Its value should be `"auto"` or a number. If a number is used, it will be the gas limit used by default in every transaction. If `"auto"` is used, the gas limit will be automatically estimated. Default value: `"auto"`.
 - `gasPrice`: Its value should be `"auto"` or a number. This parameter behaves like `gas`. Default value: `"auto"`.
-- `gasMultiplier`: A number used to multiply the results of gas estimation to give it some slack due to the uncertenty of the estimation process. Default: `1.25`.
+- `gasMultiplier`: A number used to multiply the results of gas estimation to give it some slack due to the uncertenty of the estimation process. Default: `1`.
 - `accounts`: This field controls which accounts Buidler uses. It can use the node's accounts (by setting it to `"remote"`), a list of local accounts (by setting it to an array of hex-encoded private keys), or use an HD Wallet (see below). Default value: `"remote"`.
 
 ##### HD Wallet config
@@ -332,7 +332,7 @@ If you are still in doubt, these can be helpful:
 - Rule of thumb #1: Buidler MUST be a peer dependency.
 - Rule of thumb #2: If your plugin P depends on another plugin P2, P2 should be a peer dependency of P, and P2's peer dependencies should be peer dependencies of P.
 - Rule of thumb #3: If you have a non-Buidler dependency that your users may `require()`, it should be a peer dependency.
-- Rule of thumb #4: Every `peerDependency` should also be a `devDependency`. 
+- Rule of thumb #4: Every `peerDependency` should also be a `devDependency`.
 
 Also, if you depend on a Buidler plugin written in TypeScript, you should add it's main `.d.ts` to the `include` array of `tsconfig.json`.
 

--- a/packages/buidler-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/buidler-core/src/internal/core/providers/gas-providers.ts
@@ -3,6 +3,7 @@ import { IEthereumProvider } from "../../../types";
 import { numberToRpcQuantity, rpcQuantityToNumber } from "./provider-utils";
 import { wrapSend } from "./wrapper";
 
+const DEFAULT_GAS_MULTIPLIER = 1;
 export const GANACHE_GAS_MULTIPLIER = 2;
 
 export function createFixedGasProvider(
@@ -51,7 +52,7 @@ export function createFixedGasPriceProvider(
 
 export function createAutomaticGasProvider(
   provider: IEthereumProvider,
-  gasMultiplier: number = 1.25
+  gasMultiplier: number = DEFAULT_GAS_MULTIPLIER
 ) {
   return wrapSend(provider, async (method, params) => {
     if (method === "eth_sendTransaction") {

--- a/packages/buidler-core/test/internal/core/providers/construction.ts
+++ b/packages/buidler-core/test/internal/core/providers/construction.ts
@@ -3,6 +3,7 @@ import Tx from "ethereumjs-tx";
 import { HttpProvider } from "web3x/providers";
 import { bufferToHex } from "web3x/utils";
 
+import { DEFAULT_GAS_MULTIPLIER } from "../../../../../buidler-truffle5/src/constants";
 import { ERRORS } from "../../../../src/internal/core/errors";
 import { createLocalAccountsProvider } from "../../../../src/internal/core/providers/accounts";
 import {
@@ -162,7 +163,6 @@ describe("Base providers wrapping", () => {
   });
 
   describe("Gas wrapping", () => {
-    const DEFAULT_GAS_MULTIPLIER = 1.25;
     const OTHER_GAS_MULTIPLIER = 1.337;
 
     beforeEach(() => {

--- a/packages/buidler-core/test/internal/core/providers/gas-providers.ts
+++ b/packages/buidler-core/test/internal/core/providers/gas-providers.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 
+import { DEFAULT_GAS_MULTIPLIER } from "../../../../../buidler-truffle5/src/constants";
 import {
   createAutomaticGasPriceProvider,
   createAutomaticGasProvider,
@@ -69,7 +70,10 @@ describe("createAutomaticGasProvider", () => {
       }
     ]);
 
-    assert.isAbove(rpcQuantityToNumber(tx.gas), FIXED_GAS_LIMIT);
+    assert.equal(
+      rpcQuantityToNumber(tx.gas),
+      FIXED_GAS_LIMIT * DEFAULT_GAS_MULTIPLIER
+    );
   });
 
   it("Shouldn't replace the provided gas", async () => {

--- a/packages/buidler-truffle5/src/constants.ts
+++ b/packages/buidler-truffle5/src/constants.ts
@@ -1,2 +1,3 @@
-// This should be 1.25, but that doesn't work right, so we use 2
-export const DEFAULT_GAS_MULTIPLIER = 2;
+// This should be 1.25 to match truffle-contract's doc, but as Buidler already
+// multiplies Ganache's estimations, we set 1 here.
+export const DEFAULT_GAS_MULTIPLIER = 1;


### PR DESCRIPTION
Now that we duplicate Ganache's gas estimations we can change the default `gasMultiplier` to 1, so we don't (1) multiply ganache estimations even further, (2) multiply estimations from well-behaving nodes.