### PR TITLE
Buidler Beta 8

### DIFF
--- a/packages/buidler-core/package-lock.json
+++ b/packages/buidler-core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nomiclabs/buidler",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "author": "Nomic Labs SRL",
   "license": "MIT",
   "homepage": "https://buidler.dev",

--- a/packages/buidler-ethers/package-lock.json
+++ b/packages/buidler-ethers/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@nomiclabs/buidler-ethers",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@nomiclabs/buidler": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-			"integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+			"integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
 				"find-up": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"glob": "^7.1.3",
+				"io-ts": "^1.8.6",
 				"lodash": "^4.17.11",
 				"mocha": "^5.2.0",
 				"semver": "^5.6.0",
@@ -256,9 +257,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -593,9 +594,9 @@
 			"dev": true
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
 			"dev": true
 		},
 		"cookie-signature": {
@@ -1161,73 +1162,43 @@
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"body-parser": {
-					"version": "1.18.3",
-					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-					"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"content-type": "~1.0.4",
-						"debug": "2.6.9",
-						"depd": "~1.1.2",
-						"http-errors": "~1.6.3",
-						"iconv-lite": "0.4.23",
-						"on-finished": "~2.3.0",
-						"qs": "6.5.2",
-						"raw-body": "2.3.3",
-						"type-is": "~1.6.16"
-					}
-				},
-				"bytes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-					"dev": true
-				},
-				"content-disposition": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-					"dev": true
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1236,57 +1207,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-					"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"http-errors": "1.6.3",
-						"iconv-lite": "0.4.23",
-						"unpipe": "1.0.0"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-					"dev": true
 				}
 			}
 		},
@@ -1372,17 +1292,17 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
@@ -1394,12 +1314,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-					"dev": true
 				}
 			}
 		},
@@ -1444,6 +1358,12 @@
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
+		"fp-ts": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+			"integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+			"dev": true
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1478,9 +1398,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -1792,6 +1712,15 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"io-ts": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+			"integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+			"dev": true,
+			"requires": {
+				"fp-ts": "^1.0.0"
+			}
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -2109,9 +2038,9 @@
 			"dev": true
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -2264,9 +2193,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-			"integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+			"integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
 			"dev": true
 		},
 		"ms": {
@@ -2276,9 +2205,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true
 		},
 		"nano-json-stream-parser": {
@@ -2592,9 +2521,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
 			"dev": true
 		},
 		"pump": {
@@ -2789,9 +2718,9 @@
 			"dev": true
 		},
 		"secp256k1": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-			"integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -2800,7 +2729,7 @@
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.4.1",
-				"nan": "^2.13.2",
+				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			},
 			"dependencies": {
@@ -2837,9 +2766,9 @@
 			"dev": true
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -2849,12 +2778,12 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2864,44 +2793,34 @@
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
 					}
 				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"servify": {
@@ -2952,6 +2871,14 @@
 			"dev": true,
 			"requires": {
 				"nan": "2.13.2"
+			},
+			"dependencies": {
+				"nan": {
+					"version": "2.13.2",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+					"dev": true
+				}
 			}
 		},
 		"shebang-command": {
@@ -3033,9 +2960,9 @@
 			}
 		},
 		"solidity-parser-antlr": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-			"integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+			"integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
 			"dev": true
 		},
 		"sort-keys": {
@@ -3274,18 +3201,18 @@
 			}
 		},
 		"tar": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.4",
-				"minizlib": "^1.1.1",
+				"minipass": "^2.3.5",
+				"minizlib": "^1.2.1",
 				"mkdirp": "^0.5.0",
 				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.2"
+				"yallist": "^3.0.3"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3565,24 +3492,41 @@
 					"dev": true
 				},
 				"@types/node": {
-					"version": "10.14.6",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-					"integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+					"version": "10.14.8",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+					"integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-					"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
-						"get-stream": "^4.0.0",
+						"get-stream": "^5.1.0",
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^3.0.0",
-						"lowercase-keys": "^1.0.1",
-						"normalize-url": "^3.1.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
 						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+							"dev": true
+						}
 					}
 				},
 				"elliptic": {
@@ -3635,9 +3579,9 @@
 					"dev": true
 				},
 				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 					"dev": true
 				},
 				"p-cancelable": {

--- a/packages/buidler-ethers/package.json
+++ b/packages/buidler-ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-ethers",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Buidler plugin for ethers",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-ethers",
   "repository": "github:nomiclabs/buidler",
@@ -32,13 +32,13 @@
     "README.md"
   ],
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "@types/fs-extra": "^5.1.0",
     "chai": "^4.2.0",
     "ethers": "^4.0.27"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "ethers": "^4.0.27"
   }
 }

--- a/packages/buidler-solhint/package-lock.json
+++ b/packages/buidler-solhint/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-solhint",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,9 +23,9 @@
       }
     },
     "@nomiclabs/buidler": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-      "integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+      "integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
       "dev": true,
       "requires": {
         "ansi-colors": "^3.2.4",
@@ -37,6 +37,7 @@
         "find-up": "^2.1.0",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
+        "io-ts": "^1.8.6",
         "lodash": "^4.17.11",
         "mocha": "^5.2.0",
         "semver": "^5.6.0",
@@ -306,9 +307,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -697,9 +698,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
     },
     "cookie-signature": {
@@ -1395,73 +1396,43 @@
       }
     },
     "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-          "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "http-errors": "~1.6.3",
-            "iconv-lite": "0.4.23",
-            "on-finished": "~2.3.0",
-            "qs": "6.5.2",
-            "raw-body": "2.3.3",
-            "type-is": "~1.6.16"
-          }
-        },
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1471,61 +1442,10 @@
             "ms": "2.0.0"
           }
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.3",
-            "iconv-lite": "0.4.23",
-            "unpipe": "1.0.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -1646,17 +1566,17 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
@@ -1673,12 +1593,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -1739,6 +1653,12 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "fp-ts": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+      "integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+      "dev": true
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1773,9 +1693,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -2154,6 +2074,15 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "io-ts": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+      "integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+      "dev": true,
+      "requires": {
+        "fp-ts": "^1.0.0"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -2514,9 +2443,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -2689,9 +2618,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-      "integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+      "integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
       "dev": true
     },
     "ms": {
@@ -2705,9 +2634,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
     },
     "nano-json-stream-parser": {
@@ -3093,9 +3022,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
       "dev": true
     },
     "pump": {
@@ -3310,9 +3239,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "secp256k1": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-      "integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -3321,7 +3250,7 @@
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
         "elliptic": "^6.4.1",
-        "nan": "^2.13.2",
+        "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       }
     },
@@ -3351,9 +3280,9 @@
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -3363,12 +3292,12 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -3378,50 +3307,28 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
-        },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "servify": {
@@ -3472,6 +3379,14 @@
       "dev": true,
       "requires": {
         "nan": "2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true
+        }
       }
     },
     "shebang-command": {
@@ -3578,9 +3493,9 @@
       }
     },
     "solidity-parser-antlr": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-      "integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+      "integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
       "dev": true
     },
     "sort-keys": {
@@ -3856,18 +3771,18 @@
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       },
       "dependencies": {
         "yallist": {
@@ -4156,24 +4071,41 @@
           "dev": true
         },
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         },
         "cacheable-request": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-          "integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
           "dev": true,
           "requires": {
             "clone-response": "^1.0.2",
-            "get-stream": "^4.0.0",
+            "get-stream": "^5.1.0",
             "http-cache-semantics": "^4.0.0",
             "keyv": "^3.0.0",
-            "lowercase-keys": "^1.0.1",
-            "normalize-url": "^3.1.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
             "responselike": "^1.0.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "lowercase-keys": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+              "dev": true
+            }
           }
         },
         "get-stream": {
@@ -4211,9 +4143,9 @@
           "dev": true
         },
         "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+          "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
           "dev": true
         },
         "p-cancelable": {

--- a/packages/buidler-solhint/package.json
+++ b/packages/buidler-solhint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-solhint",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Buidler plugin for solhint",
   "repository": "github:nomiclabs/buidler",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-solhint",
@@ -37,12 +37,12 @@
     "solhint": "^2.0.0"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "@types/fs-extra": "^5.1.0",
     "chai": "^4.2.0",
     "fs-extra": "^7.0.1"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7"
+    "@nomiclabs/buidler": "^1.0.0-beta.8"
   }
 }

--- a/packages/buidler-solpp/package-lock.json
+++ b/packages/buidler-solpp/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@nomiclabs/buidler-solpp",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@nomiclabs/buidler": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-      "integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+      "integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
       "dev": true,
       "requires": {
         "ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
         "find-up": "^2.1.0",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
+        "io-ts": "^1.8.6",
         "lodash": "^4.17.11",
         "mocha": "^5.2.0",
         "semver": "^5.6.0",
@@ -267,9 +268,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn-str-256": {
@@ -602,9 +603,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
     },
     "cookie-signature": {
@@ -1129,73 +1130,43 @@
       }
     },
     "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-          "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "http-errors": "~1.6.3",
-            "iconv-lite": "0.4.23",
-            "on-finished": "~2.3.0",
-            "qs": "6.5.2",
-            "raw-body": "2.3.3",
-            "type-is": "~1.6.16"
-          }
-        },
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1205,61 +1176,10 @@
             "ms": "2.0.0"
           }
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.3",
-            "iconv-lite": "0.4.23",
-            "unpipe": "1.0.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -1345,17 +1265,17 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
@@ -1372,12 +1292,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -1431,6 +1345,12 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "fp-ts": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+      "integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+      "dev": true
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1464,9 +1384,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -1773,6 +1693,15 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
+    },
+    "io-ts": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+      "integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+      "dev": true,
+      "requires": {
+        "fp-ts": "^1.0.0"
+      }
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -2090,9 +2019,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -2258,9 +2187,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-      "integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+      "integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
       "dev": true
     },
     "ms": {
@@ -2598,9 +2527,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
       "dev": true
     },
     "pump": {
@@ -2828,9 +2757,9 @@
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2840,12 +2769,12 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -2855,50 +2784,28 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
-        },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "servify": {
@@ -3029,9 +2936,9 @@
       }
     },
     "solidity-parser-antlr": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-      "integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+      "integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
       "dev": true
     },
     "solpp": {
@@ -3279,18 +3186,18 @@
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       },
       "dependencies": {
         "yallist": {
@@ -3585,24 +3492,41 @@
           "dev": true
         },
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         },
         "cacheable-request": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-          "integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
           "dev": true,
           "requires": {
             "clone-response": "^1.0.2",
-            "get-stream": "^4.0.0",
+            "get-stream": "^5.1.0",
             "http-cache-semantics": "^4.0.0",
             "keyv": "^3.0.0",
-            "lowercase-keys": "^1.0.1",
-            "normalize-url": "^3.1.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
             "responselike": "^1.0.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "lowercase-keys": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+              "dev": true
+            }
           }
         },
         "get-stream": {
@@ -3640,9 +3564,9 @@
           "dev": true
         },
         "normalize-url": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+          "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
           "dev": true
         },
         "p-cancelable": {

--- a/packages/buidler-solpp/package.json
+++ b/packages/buidler-solpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-solpp",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Buidler plugin for solpp",
   "repository": "github:nomiclabs/buidler",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-solpp",
@@ -38,11 +38,11 @@
     "solpp": "^0.10.1"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "@types/fs-extra": "^5.1.0",
     "chai": "^4.2.0"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7"
+    "@nomiclabs/buidler": "^1.0.0-beta.8"
   }
 }

--- a/packages/buidler-truffle4/package-lock.json
+++ b/packages/buidler-truffle4/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@nomiclabs/buidler-truffle4",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@nomiclabs/buidler": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-			"integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+			"integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
 				"find-up": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"glob": "^7.1.3",
+				"io-ts": "^1.8.6",
 				"lodash": "^4.17.11",
 				"mocha": "^5.2.0",
 				"semver": "^5.6.0",
@@ -31,9 +32,9 @@
 			}
 		},
 		"@nomiclabs/buidler-web3-legacy": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3-legacy/-/buidler-web3-legacy-1.0.0-beta.7.tgz",
-			"integrity": "sha512-3OL6bZZpIPweqk859g+qVM+WDWyUllJ9YEKhlwsz4CCj6PaWvwM3mvXCGnrvxdUevTRwptJ+34F0z0K0HL/86g==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3-legacy/-/buidler-web3-legacy-1.0.0-beta.8.tgz",
+			"integrity": "sha512-+Cct8bL3P0Tr1R7ygn67+5rJaMNkbk7Doi7IShICIwp1flbD4qK2aaK9oMkUqIPndo8JI0/8LZxR6T09e4y4Dw==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -266,9 +267,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -611,9 +612,9 @@
 			"dev": true
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
 			"dev": true
 		},
 		"cookie-signature": {
@@ -1160,73 +1161,43 @@
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"body-parser": {
-					"version": "1.18.3",
-					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-					"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"content-type": "~1.0.4",
-						"debug": "2.6.9",
-						"depd": "~1.1.2",
-						"http-errors": "~1.6.3",
-						"iconv-lite": "0.4.23",
-						"on-finished": "~2.3.0",
-						"qs": "6.5.2",
-						"raw-body": "2.3.3",
-						"type-is": "~1.6.16"
-					}
-				},
-				"bytes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-					"dev": true
-				},
-				"content-disposition": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-					"dev": true
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1236,61 +1207,10 @@
 						"ms": "2.0.0"
 					}
 				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-					"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"http-errors": "1.6.3",
-						"iconv-lite": "0.4.23",
-						"unpipe": "1.0.0"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
 					"dev": true
 				}
 			}
@@ -1375,17 +1295,17 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
@@ -1402,12 +1322,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
 					"dev": true
 				}
 			}
@@ -1453,6 +1367,12 @@
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
+		"fp-ts": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+			"integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+			"dev": true
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1487,9 +1407,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -1827,6 +1747,15 @@
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
 		},
+		"io-ts": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+			"integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+			"dev": true,
+			"requires": {
+				"fp-ts": "^1.0.0"
+			}
+		},
 		"ipaddr.js": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -2140,9 +2069,9 @@
 			"dev": true
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -2310,9 +2239,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-			"integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+			"integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
 			"dev": true
 		},
 		"ms": {
@@ -2321,9 +2250,9 @@
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true
 		},
 		"nano-json-stream-parser": {
@@ -2645,9 +2574,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
 			"dev": true
 		},
 		"pump": {
@@ -2830,9 +2759,9 @@
 			"dev": true
 		},
 		"secp256k1": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-			"integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -2841,7 +2770,7 @@
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.4.1",
-				"nan": "^2.13.2",
+				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			},
 			"dependencies": {
@@ -2869,9 +2798,9 @@
 			"dev": true
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -2881,12 +2810,12 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2896,50 +2825,28 @@
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
 					}
-				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-					"dev": true
 				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"servify": {
@@ -2990,6 +2897,14 @@
 			"dev": true,
 			"requires": {
 				"nan": "2.13.2"
+			},
+			"dependencies": {
+				"nan": {
+					"version": "2.13.2",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+					"dev": true
+				}
 			}
 		},
 		"shebang-command": {
@@ -3071,9 +2986,9 @@
 			}
 		},
 		"solidity-parser-antlr": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-			"integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+			"integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
 			"dev": true
 		},
 		"sort-keys": {
@@ -3305,18 +3220,18 @@
 			}
 		},
 		"tar": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.4",
-				"minizlib": "^1.1.1",
+				"minipass": "^2.3.5",
+				"minizlib": "^1.2.1",
 				"mkdirp": "^0.5.0",
 				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.2"
+				"yallist": "^3.0.3"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3672,18 +3587,35 @@
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-					"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
-						"get-stream": "^4.0.0",
+						"get-stream": "^5.1.0",
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^3.0.0",
-						"lowercase-keys": "^1.0.1",
-						"normalize-url": "^3.1.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
 						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+							"dev": true
+						}
 					}
 				},
 				"get-stream": {
@@ -3721,9 +3653,9 @@
 					"dev": true
 				},
 				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 					"dev": true
 				},
 				"p-cancelable": {

--- a/packages/buidler-truffle4/package.json
+++ b/packages/buidler-truffle4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-truffle4",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Truffle 4 Buidler compatibility plugin",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-truffle4",
   "repository": "github:nomiclabs/buidler",
@@ -37,14 +37,14 @@
     "truffle-contract": "^3.0.7"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
-    "@nomiclabs/buidler-web3-legacy": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
+    "@nomiclabs/buidler-web3-legacy": "^1.0.0-beta.8",
     "@types/glob": "^7.1.1",
     "web3": "^0.20.7"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
-    "@nomiclabs/buidler-web3-legacy": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
+    "@nomiclabs/buidler-web3-legacy": "^1.0.0-beta.8",
     "web3": "^0.20.7"
   }
 }

--- a/packages/buidler-truffle5/package-lock.json
+++ b/packages/buidler-truffle5/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@nomiclabs/buidler-truffle5",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@nomiclabs/buidler": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-			"integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+			"integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
 				"find-up": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"glob": "^7.1.3",
+				"io-ts": "^1.8.6",
 				"lodash": "^4.17.11",
 				"mocha": "^5.2.0",
 				"semver": "^5.6.0",
@@ -53,9 +54,9 @@
 			}
 		},
 		"@nomiclabs/buidler-web3": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.0.0-beta.7.tgz",
-			"integrity": "sha512-VgA/M1XZVU/JL6FpyVS6b8N9H7tAzKCILmt4Y8wLWeICZlbx4nFppGWGJi/Bpiw4VdvvhInq4FwkzrJ4KIKIpg==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.0.0-beta.8.tgz",
+			"integrity": "sha512-ConceCb/qNV26HjFyWXxv0+kCmkPTpR10C6CS2aZpq6GuKybY4YO6Mks1YzhYdZWii3s/+laJzylDLpjXcwjcg==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -1510,6 +1511,12 @@
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
+		"fp-ts": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+			"integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+			"dev": true
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1540,9 +1547,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -1881,6 +1888,15 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"io-ts": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+			"integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+			"dev": true,
+			"requires": {
+				"fp-ts": "^1.0.0"
+			}
 		},
 		"ipaddr.js": {
 			"version": "1.8.0",
@@ -2948,9 +2964,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-			"integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -2959,7 +2975,7 @@
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.4.1",
-				"nan": "^2.13.2",
+				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			},
 			"dependencies": {
@@ -2979,9 +2995,9 @@
 					}
 				},
 				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 					"dev": true
 				}
 			}
@@ -3164,9 +3180,9 @@
 			}
 		},
 		"solidity-parser-antlr": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-			"integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+			"integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
 			"dev": true
 		},
 		"sort-keys": {
@@ -3991,18 +4007,35 @@
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-					"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
-						"get-stream": "^4.0.0",
+						"get-stream": "^5.1.0",
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^3.0.0",
-						"lowercase-keys": "^1.0.1",
-						"normalize-url": "^3.1.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
 						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+							"dev": true
+						}
 					}
 				},
 				"elliptic": {
@@ -4075,9 +4108,9 @@
 					}
 				},
 				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 					"dev": true
 				},
 				"p-cancelable": {
@@ -4170,18 +4203,18 @@
 					}
 				},
 				"tar": {
-					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"version": "4.4.10",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+					"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
+						"minipass": "^2.3.5",
+						"minizlib": "^1.2.1",
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"yallist": "^3.0.3"
 					}
 				},
 				"url-parse-lax": {

--- a/packages/buidler-truffle5/package.json
+++ b/packages/buidler-truffle5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-truffle5",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Truffle 5 Buidler compatibility plugin",
   "repository": "github:nomiclabs/buidler",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-truffle5",
@@ -37,15 +37,15 @@
     "truffle-contract": "^4.0.14"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
-    "@nomiclabs/buidler-web3": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
+    "@nomiclabs/buidler-web3": "^1.0.0-beta.8",
     "@types/chai": "^4.1.7",
     "@types/glob": "^7.1.1",
     "web3": "1.0.0-beta.37"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
-    "@nomiclabs/buidler-web3": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
+    "@nomiclabs/buidler-web3": "^1.0.0-beta.8",
     "web3": "1.0.0-beta.37"
   }
 }

--- a/packages/buidler-web3-legacy/package-lock.json
+++ b/packages/buidler-web3-legacy/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@nomiclabs/buidler-web3-legacy",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@nomiclabs/buidler": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-			"integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+			"integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
 				"find-up": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"glob": "^7.1.3",
+				"io-ts": "^1.8.6",
 				"lodash": "^4.17.11",
 				"mocha": "^5.2.0",
 				"semver": "^5.6.0",
@@ -61,9 +62,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.14.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-			"integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+			"version": "10.14.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+			"integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
 			"dev": true
 		},
 		"@types/ws": {
@@ -246,9 +247,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -575,9 +576,9 @@
 			"dev": true
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
 			"dev": true
 		},
 		"cookie-signature": {
@@ -1117,73 +1118,43 @@
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"body-parser": {
-					"version": "1.18.3",
-					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-					"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"content-type": "~1.0.4",
-						"debug": "2.6.9",
-						"depd": "~1.1.2",
-						"http-errors": "~1.6.3",
-						"iconv-lite": "0.4.23",
-						"on-finished": "~2.3.0",
-						"qs": "6.5.2",
-						"raw-body": "2.3.3",
-						"type-is": "~1.6.16"
-					}
-				},
-				"bytes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-					"dev": true
-				},
-				"content-disposition": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-					"dev": true
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1192,57 +1163,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-					"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-					"dev": true,
-					"requires": {
-						"bytes": "3.0.0",
-						"http-errors": "1.6.3",
-						"iconv-lite": "0.4.23",
-						"unpipe": "1.0.0"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-					"dev": true
 				}
 			}
 		},
@@ -1328,17 +1248,17 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
@@ -1350,12 +1270,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-					"dev": true
 				}
 			}
 		},
@@ -1400,6 +1314,12 @@
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
+		"fp-ts": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+			"integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+			"dev": true
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1434,9 +1354,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -1748,6 +1668,15 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"io-ts": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+			"integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+			"dev": true,
+			"requires": {
+				"fp-ts": "^1.0.0"
+			}
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -2065,9 +1994,9 @@
 			"dev": true
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -2220,9 +2149,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-			"integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+			"integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
 			"dev": true
 		},
 		"ms": {
@@ -2232,9 +2161,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true
 		},
 		"nano-json-stream-parser": {
@@ -2548,9 +2477,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
 			"dev": true
 		},
 		"pump": {
@@ -2733,9 +2662,9 @@
 			"dev": true
 		},
 		"secp256k1": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-			"integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -2744,7 +2673,7 @@
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.4.1",
-				"nan": "^2.13.2",
+				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			}
 		},
@@ -2764,9 +2693,9 @@
 			"dev": true
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -2776,12 +2705,12 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2791,44 +2720,34 @@
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
 					}
 				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"dev": true,
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": ">= 1.4.0 < 2"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-					"dev": true
-				},
-				"statuses": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"servify": {
@@ -2879,6 +2798,14 @@
 			"dev": true,
 			"requires": {
 				"nan": "2.13.2"
+			},
+			"dependencies": {
+				"nan": {
+					"version": "2.13.2",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+					"dev": true
+				}
 			}
 		},
 		"shebang-command": {
@@ -2960,9 +2887,9 @@
 			}
 		},
 		"solidity-parser-antlr": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-			"integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+			"integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
 			"dev": true
 		},
 		"sort-keys": {
@@ -3195,18 +3122,18 @@
 			}
 		},
 		"tar": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.4",
-				"minizlib": "^1.1.1",
+				"minipass": "^2.3.5",
+				"minizlib": "^1.2.1",
 				"mkdirp": "^0.5.0",
 				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.2"
+				"yallist": "^3.0.3"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3499,18 +3426,35 @@
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-					"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
-						"get-stream": "^4.0.0",
+						"get-stream": "^5.1.0",
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^3.0.0",
-						"lowercase-keys": "^1.0.1",
-						"normalize-url": "^3.1.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
 						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+							"dev": true
+						}
 					}
 				},
 				"get-stream": {
@@ -3548,9 +3492,9 @@
 					"dev": true
 				},
 				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 					"dev": true
 				},
 				"p-cancelable": {

--- a/packages/buidler-web3-legacy/package.json
+++ b/packages/buidler-web3-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-web3-legacy",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "author": "Nomic Labs SRL",
   "license": "MIT",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-web3-legacy",
@@ -33,12 +33,12 @@
     "README.md"
   ],
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "chai": "^4.2.0",
     "web3": "^0.20.7"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "web3": "^0.20.7"
   }
 }

--- a/packages/buidler-web3/package-lock.json
+++ b/packages/buidler-web3/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@nomiclabs/buidler-web3",
-	"version": "1.0.0-beta.7",
+	"version": "1.0.0-beta.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@nomiclabs/buidler": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.7.tgz",
-			"integrity": "sha512-u5jKcXnPOpqxFu5PXMaCQECjmn+1CIwDf6dTxaMVlVVHxbGkn0bIqj6XYfQQYJFt/PF8cOniIdrcopuY6QRkNA==",
+			"version": "1.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.0.0-beta.8.tgz",
+			"integrity": "sha512-qG348aP+kl4xJn1PG4pHgAeDlNOszvffRDS6H2yUJI7XiIgw8o1qkYEd4zFnLEJI+4PPrPtv2zhUg8tXpiaWWw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.2.4",
@@ -19,6 +19,7 @@
 				"find-up": "^2.1.0",
 				"fs-extra": "^7.0.1",
 				"glob": "^7.1.3",
+				"io-ts": "^1.8.6",
 				"lodash": "^4.17.11",
 				"mocha": "^5.2.0",
 				"semver": "^5.6.0",
@@ -1562,6 +1563,12 @@
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
+		"fp-ts": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.18.2.tgz",
+			"integrity": "sha512-kznerusCuG5dUt0bH6eiQHVp2fstPiSlyzGb//rYgMMxCuromWEoVS0riH++86vyJm9Nv1B+pbe6udDx1tqjfA==",
+			"dev": true
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1595,9 +1602,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -1943,6 +1950,15 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"io-ts": {
+			"version": "1.8.6",
+			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.8.6.tgz",
+			"integrity": "sha512-0V0gbEfW5FnlEL++hO+j1cbxSvhH3f/i5Puz5AjmN6Q071vJONWTuOHttMSe60gi4DBHBTd2eHbSnHv37ptTnQ==",
+			"dev": true,
+			"requires": {
+				"fp-ts": "^1.0.0"
+			}
 		},
 		"ipaddr.js": {
 			"version": "1.8.0",
@@ -3094,9 +3110,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.0.tgz",
-			"integrity": "sha512-YlUIghD6ilkMkzmFJpIdVjiamv2S8lNZ9YMwm1XII9JC0NcR5qQiv2DOp/G37sExBtaMStzba4VDJtvBXEbmMQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 			"dev": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -3105,14 +3121,14 @@
 				"create-hash": "^1.2.0",
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.4.1",
-				"nan": "^2.13.2",
+				"nan": "^2.14.0",
 				"safe-buffer": "^5.1.2"
 			},
 			"dependencies": {
 				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 					"dev": true
 				}
 			}
@@ -3293,9 +3309,9 @@
 			}
 		},
 		"solidity-parser-antlr": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
-			"integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.3.tgz",
+			"integrity": "sha512-+0Sm/NCrYxCouzT8lJPrM2T8vT3PPW0enlHtAnxDgv/lBUjymHeFfEPjaNdwCNueR9w/lUOv7ivDm8ypHUcZMQ==",
 			"dev": true
 		},
 		"sort-keys": {
@@ -4097,18 +4113,35 @@
 					"dev": true
 				},
 				"cacheable-request": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-					"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
 					"dev": true,
 					"requires": {
 						"clone-response": "^1.0.2",
-						"get-stream": "^4.0.0",
+						"get-stream": "^5.1.0",
 						"http-cache-semantics": "^4.0.0",
 						"keyv": "^3.0.0",
-						"lowercase-keys": "^1.0.1",
-						"normalize-url": "^3.1.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
 						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+							"dev": true
+						}
 					}
 				},
 				"fs-extra": {
@@ -4166,9 +4199,9 @@
 					}
 				},
 				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 					"dev": true
 				},
 				"p-cancelable": {
@@ -4255,18 +4288,18 @@
 					}
 				},
 				"tar": {
-					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"version": "4.4.10",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+					"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
+						"minipass": "^2.3.5",
+						"minizlib": "^1.2.1",
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"yallist": "^3.0.3"
 					}
 				},
 				"url-parse-lax": {

--- a/packages/buidler-web3/package.json
+++ b/packages/buidler-web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-web3",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "author": "Nomic Labs SRL",
   "license": "MIT",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-web3",
@@ -33,12 +33,12 @@
     "README.md"
   ],
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "chai": "^4.2.0",
     "web3": "1.0.0-beta.37"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.0-beta.7",
+    "@nomiclabs/buidler": "^1.0.0-beta.8",
     "web3": "1.0.0-beta.37"
   }
 }


### PR DESCRIPTION
This PR publishes Buidler Beta 8

The complete list of changes is:

* Buidler doesn't set a default evm version anymore (#277)
* Show stack traces on unknown errors (#287)
* Config validation (#285)
* Print a warning when ts-node fails to load (#289)
* Set the `gasMultiplier` to Truffle Contracts (#292)
* Fix multiple JSON-RPC errors (#292)
* Automatically Ganache gas estimations (#292)
* Change default `gasMultiplier` to 1 (#297)
* Make custom networks' `url` a required parameter (#298)
* Fix a bug that made `buidler run` and `buidler console` ignore some parameters (#300)
