### PR TITLE
Refactor plugin system

### DIFF
--- a/config/tslint/tslint.json
+++ b/config/tslint/tslint.json
@@ -53,7 +53,8 @@
       },
       { "type": "type", "format": "PascalCase" },
       { "type": "genericTypeParameter", "suffix": "T" },
-      { "type": "enumMember", "format": "PascalCase" }
+      { "type": "enum", "format": "PascalCase" },
+      { "type": "enumMember", "format": "UPPER_CASE" }
     ]
   }
 }

--- a/packages/buidler-core/README.md
+++ b/packages/buidler-core/README.md
@@ -22,6 +22,8 @@ The recommended way of using Buidler is through a local installation in your pro
 Be careful about inconsistent behavior across different projects that use different Buidler versions.
 
     npm -g install @nomiclabs/buidler
+    
+If you choose to install Buidler globally, you have to do the same for its plugins and their dependencies.
 
 ## Documentation
 

--- a/packages/buidler-core/package-lock.json
+++ b/packages/buidler-core/package-lock.json
@@ -1357,6 +1357,14 @@
 				"process": "~0.5.1"
 			}
 		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "^1.3.4"
+			}
+		},
 		"got": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
@@ -1608,6 +1616,15 @@
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
 			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
+		"is-installed-globally": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.2.0.tgz",
+			"integrity": "sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==",
+			"requires": {
+				"global-dirs": "^0.1.1",
+				"is-path-inside": "^2.1.0"
+			}
+		},
 		"is-natural-number": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -1617,6 +1634,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
 			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-path-inside": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+			"requires": {
+				"path-is-inside": "^1.0.2"
+			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -2186,6 +2211,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -71,6 +71,7 @@
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "io-ts": "^1.8.6",
+    "is-installed-globally": "^0.2.0",
     "lodash": "^4.17.11",
     "mocha": "^5.2.0",
     "semver": "^5.6.0",

--- a/packages/buidler-core/src/internal/context.ts
+++ b/packages/buidler-core/src/internal/context.ts
@@ -38,7 +38,7 @@ export class BuidlerContext {
   public readonly tasksDSL = new TasksDSL();
   public readonly extendersManager = new ExtenderManager();
   public environment?: BuidlerRuntimeEnvironment;
-  public configPath?: string;
+  public readonly loadedPlugins: string[] = [];
 
   public setBuidlerRuntimeEnvironment(env: BuidlerRuntimeEnvironment) {
     if (this.environment !== undefined) {
@@ -52,5 +52,9 @@ export class BuidlerContext {
       throw new BuidlerError(ERRORS.GENERAL.CONTEXT_BRE_NOT_DEFINED);
     }
     return this.environment;
+  }
+
+  public setPluginAsLoaded(pluginName: string) {
+    this.loadedPlugins.push(pluginName);
   }
 }

--- a/packages/buidler-core/src/internal/core/config/config-env.ts
+++ b/packages/buidler-core/src/internal/core/config/config-env.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../types";
 import { BuidlerContext } from "../../context";
 import * as argumentTypes from "../params/argumentTypes";
+import { usePlugin as usePluginImplementation } from "../plugins";
 
 export function task<ArgsT extends TaskArguments>(
   name: string,
@@ -82,4 +83,6 @@ export function extendEnvironment(extender: EnvironmentExtender) {
   extenderManager.add(extender);
 }
 
-export { usePlugin } from "../plugins";
+export function usePlugin(pluginName: string) {
+  usePluginImplementation(pluginName);
+}

--- a/packages/buidler-core/src/internal/core/config/config-env.ts
+++ b/packages/buidler-core/src/internal/core/config/config-env.ts
@@ -83,6 +83,11 @@ export function extendEnvironment(extender: EnvironmentExtender) {
   extenderManager.add(extender);
 }
 
+/**
+ * Loads a Buidler plugin
+ * @param pluginName The plugin name.
+ */
 export function usePlugin(pluginName: string) {
-  usePluginImplementation(pluginName);
+  const ctx = BuidlerContext.getBuidlerContext();
+  usePluginImplementation(ctx, pluginName);
 }

--- a/packages/buidler-core/src/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/src/internal/core/config/config-loading.ts
@@ -34,21 +34,6 @@ export function loadConfigAndTasks(configPath?: string): ResolvedBuidlerConfig {
     ([key, value]) => (globalAsAny[key] = value)
   );
 
-  // This is a horrible hack that deserves an explanation.
-  //   - config files can execute the usePlugin function, which is imported
-  //     from config.ts.
-  //   - There's no way to pass it arguments.
-  //   - Internally, usePlugin calls require, which should use the same
-  //     node_module's paths than the Buidler project.
-  //   - Except that it doesn't when we are linking Buidler for local tests.
-  //   - node resolves symlinks before loading modules, so imports from
-  //     Buidler files are run in this context, not inside the Buidler project.
-  //   - We solve this by using require.resolve and specifying the paths,
-  //     but we need the config path in order to do so.
-  //   - We set the config path into the BuidlerContext and cry a little 😢
-  const ctx = BuidlerContext.getBuidlerContext();
-  ctx.configPath = configPath;
-
   loadPluginFile(__dirname + "/../tasks/builtin-tasks");
 
   const defaultConfig = importCsjOrEsModule("./default-config");

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -373,14 +373,14 @@ To learn more about Buidler's configuration, please go to https://buidler.dev/do
     MISSING_DEPENDENCY: {
       number: 801,
       message:
-        "Plugin %s requires %s to be installed.\n" +
-        "Please run: npm install --save-dev %s@%s"
+        "Plugin %s requires %s to be installed.\n%s" +
+        "Please run: npm install --save-dev%s %s@%s"
     },
     DEPENDENCY_VERSION_MISMATCH: {
       number: 802,
       message:
-        "Plugin %s requires %s version %s but got %s.\n" +
-        "If you haven't installed %s manually, please run: npm install --save-dev %s@%s\n" +
+        "Plugin %s requires %s version %s but got %s.\n%s" +
+        "If you haven't installed %s manually, please run: npm install --save-dev%s %s@%s\n" +
         "If you have installed %s yourself, please reinstall it with a valid version."
     },
     OLD_STYLE_IMPORT_DETECTED: {

--- a/packages/buidler-core/src/internal/core/execution-mode.ts
+++ b/packages/buidler-core/src/internal/core/execution-mode.ts
@@ -1,0 +1,34 @@
+/**
+ * This module defines different Buidler execution modes and autodetects them.
+ *
+ * IMPORTANT: This will have to be revisited once Yarn PnP and npm's tink get
+ * widely adopted.
+ */
+export enum ExecutionMode {
+  EXECUTION_MODE_TS_NODE_TESTS,
+  EXECUTION_MODE_LINKED,
+  EXECUTION_MODE_GLOBAL_INSTALLATION,
+  EXECUTION_MODE_LOCAL_INSTALLATION
+}
+
+const workingDirectoryOnLoad = process.cwd();
+
+export function getExecutionMode(): ExecutionMode {
+  const isInstalled = __filename.includes("node_modules");
+
+  if (!isInstalled) {
+    // When running the tests with ts-node we set the CWD to the root of
+    // buidler-core. We could check if the __filename ends with .ts
+    if (__dirname.startsWith(workingDirectoryOnLoad)) {
+      return ExecutionMode.EXECUTION_MODE_TS_NODE_TESTS;
+    }
+
+    return ExecutionMode.EXECUTION_MODE_LINKED;
+  }
+
+  if (require("is-installed-globally")) {
+    return ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION;
+  }
+
+  return ExecutionMode.EXECUTION_MODE_LOCAL_INSTALLATION;
+}

--- a/packages/buidler-core/src/internal/core/plugins.ts
+++ b/packages/buidler-core/src/internal/core/plugins.ts
@@ -54,17 +54,33 @@ export function usePlugin(
     return;
   }
 
+  let globalFlag = "";
+  let globalWarning = "";
+  if (getExecutionMode() === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION) {
+    globalFlag = " --global";
+    globalWarning =
+      "You are using a global installation of Buidler. Plugins and their dependencies must also be global.\n";
+  }
+
   if (pluginPackageJson.peerDependencies !== undefined) {
     for (const [dependencyName, versionSpec] of Object.entries(
       pluginPackageJson.peerDependencies
     )) {
       const dependencyPackageJson = readPackageJson(dependencyName, from);
 
+      let installExtraFlags = globalFlag;
+
+      if (versionSpec.match(/^[0-9]/) !== null) {
+        installExtraFlags += " --save-exact";
+      }
+
       if (dependencyPackageJson === undefined) {
         throw new BuidlerError(
           ERRORS.PLUGINS.MISSING_DEPENDENCY,
           pluginName,
           dependencyName,
+          globalWarning,
+          installExtraFlags,
           dependencyName,
           versionSpec
         );
@@ -79,7 +95,9 @@ export function usePlugin(
           dependencyName,
           versionSpec,
           installedVersion,
+          globalWarning,
           dependencyName,
+          installExtraFlags,
           dependencyName,
           versionSpec,
           dependencyName

--- a/packages/buidler-core/src/internal/core/plugins.ts
+++ b/packages/buidler-core/src/internal/core/plugins.ts
@@ -102,8 +102,16 @@ export function ensurePluginLoadedWithUsePlugin() {
 
   for (const callSite of stack) {
     const fileName = callSite.getFileName();
+    if (fileName === null) {
+      continue;
+    }
+
     const functionName = callSite.getFunctionName();
-    if (fileName === __filename && functionName === loadPluginFile.name) {
+
+    if (
+      path.basename(fileName) === path.basename(__filename) &&
+      functionName === loadPluginFile.name
+    ) {
       return;
     }
   }

--- a/packages/buidler-core/src/internal/core/typescript-support.ts
+++ b/packages/buidler-core/src/internal/core/typescript-support.ts
@@ -2,15 +2,9 @@ import colors from "ansi-colors";
 import * as fs from "fs";
 import * as path from "path";
 
-const NODE_MODULES_DIR = "node_modules";
+import { ExecutionMode, getExecutionMode } from "./execution-mode";
 
-/**
- * This function returns true only if Buidler was installed as a dependency. It
- * returns false otherwise, including when it's being linked.
- */
-function isBuidlerInstalledAsADependency() {
-  return __dirname.lastIndexOf(NODE_MODULES_DIR) !== -1;
-}
+const NODE_MODULES_DIR = "node_modules";
 
 function getBuidlerNodeModules() {
   return __dirname.substring(
@@ -23,7 +17,11 @@ let cachedIsTypescriptSupported: boolean | undefined;
 
 export function isTypescriptSupported() {
   if (cachedIsTypescriptSupported === undefined) {
-    if (isBuidlerInstalledAsADependency()) {
+    const executionMode = getExecutionMode();
+    if (
+      executionMode === ExecutionMode.EXECUTION_MODE_LOCAL_INSTALLATION ||
+      executionMode === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION
+    ) {
       const nodeModules = getBuidlerNodeModules();
       cachedIsTypescriptSupported =
         fs.existsSync(path.join(nodeModules, "typescript")) &&

--- a/packages/buidler-core/src/internal/util/scripts-runner.ts
+++ b/packages/buidler-core/src/internal/util/scripts-runner.ts
@@ -1,4 +1,5 @@
 import { BuidlerArguments } from "../../types";
+import { ExecutionMode, getExecutionMode } from "../core/execution-mode";
 import { getEnvVariablesMap } from "../core/params/env-variables";
 
 export async function runScript(
@@ -46,8 +47,7 @@ export async function runScriptWithBuidler(
 }
 
 function getTsNodeArgsIfNeeded() {
-  // This means we are running the tests
-  if (!__filename.endsWith(".ts")) {
+  if (getExecutionMode() !== ExecutionMode.EXECUTION_MODE_TS_NODE_TESTS) {
     return [];
   }
 

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/pack1/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/pack1/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "pack1",
   "version": "2.1.0"
 }

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-missing-pack/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-missing-pack/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "requires-missing-pack",
   "version": "1.0.0",
   "peerDependencies": {
     "non-existent": "^0.0.1"

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-other-version-pack1/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-other-version-pack1/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "requires-other-version-pack1",
   "version": "1.0.0",
   "peerDependencies": {
     "pack1": "^0.0.1"

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-pack1/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/requires-pack1/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "requires-pack1",
   "version": "1.2.3",
   "peerDependencies": {
     "pack1": "^2.0.1"

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "validates-import-style",
   "version": "2.1.0"
 }

--- a/packages/buidler-core/test/internal/core/plugins.ts
+++ b/packages/buidler-core/test/internal/core/plugins.ts
@@ -31,6 +31,10 @@ describe("plugin system", function() {
       assert.isUndefined(readPackageJson("NOPE", FIXTURE_PROJECT_PATH));
       assert.isUndefined(readPackageJson("NOPE2", __dirname));
     });
+
+    it("Should work without from param", function() {
+      assert.isDefined(readPackageJson("mocha"));
+    });
   });
 
   describe("loadPluginFile", function() {
@@ -68,11 +72,11 @@ describe("plugin system", function() {
 
   describe("loadPluginFile", function() {
     const globalAsAny = global as any;
+    const projectPath =
+      FIXTURE_PROJECT_PATH + "/doesnt-need-to-exist-config.js";
 
     beforeEach(function() {
       BuidlerContext.createBuidlerContext();
-      const ctx = BuidlerContext.getBuidlerContext();
-      ctx.configPath = FIXTURE_PROJECT_PATH + "/doesnt-need-to-exist-config.js";
     });
 
     afterEach(function() {
@@ -81,32 +85,32 @@ describe("plugin system", function() {
     });
 
     it("Should load a plugin if it has no peer dependency", function() {
-      usePlugin("pack1");
+      usePlugin("pack1", projectPath);
       assert.isTrue(globalAsAny.loaded);
     });
 
     it("Should load a plugin if it has all of its dependencies", function() {
-      usePlugin("requires-pack1");
+      usePlugin("requires-pack1", projectPath);
       assert.isTrue(globalAsAny.loaded);
     });
 
     it("Should fail if a peer dependency is missing", function() {
       expectBuidlerError(
-        () => usePlugin("requires-missing-pack"),
+        () => usePlugin("requires-missing-pack", projectPath),
         ERRORS.PLUGINS.MISSING_DEPENDENCY
       );
     });
 
     it("Should fail if a peer dependency has an incompatible version", function() {
       expectBuidlerError(
-        () => usePlugin("requires-other-version-pack1"),
+        () => usePlugin("requires-other-version-pack1", projectPath),
         ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH
       );
     });
 
     it("Should fail if the plugin isn't installed", function() {
       expectBuidlerError(
-        () => usePlugin("not-installed"),
+        () => usePlugin("not-installed", projectPath),
         ERRORS.PLUGINS.NOT_INSTALLED
       );
     });

--- a/packages/buidler-core/test/internal/core/plugins.ts
+++ b/packages/buidler-core/test/internal/core/plugins.ts
@@ -74,9 +74,10 @@ describe("plugin system", function() {
     const globalAsAny = global as any;
     const projectPath =
       FIXTURE_PROJECT_PATH + "/doesnt-need-to-exist-config.js";
+    let ctx: BuidlerContext;
 
     beforeEach(function() {
-      BuidlerContext.createBuidlerContext();
+      ctx = BuidlerContext.createBuidlerContext();
     });
 
     afterEach(function() {
@@ -85,32 +86,42 @@ describe("plugin system", function() {
     });
 
     it("Should load a plugin if it has no peer dependency", function() {
-      usePlugin("pack1", projectPath);
+      usePlugin(ctx, "pack1", projectPath);
       assert.isTrue(globalAsAny.loaded);
     });
 
+    it("Shouldn't load a plugin twice", function() {
+      usePlugin(ctx, "pack1", projectPath);
+      assert.isTrue(globalAsAny.loaded);
+
+      globalAsAny.loaded = false;
+
+      usePlugin(ctx, "pack1", projectPath);
+      assert.isFalse(globalAsAny.loaded);
+    });
+
     it("Should load a plugin if it has all of its dependencies", function() {
-      usePlugin("requires-pack1", projectPath);
+      usePlugin(ctx, "requires-pack1", projectPath);
       assert.isTrue(globalAsAny.loaded);
     });
 
     it("Should fail if a peer dependency is missing", function() {
       expectBuidlerError(
-        () => usePlugin("requires-missing-pack", projectPath),
+        () => usePlugin(ctx, "requires-missing-pack", projectPath),
         ERRORS.PLUGINS.MISSING_DEPENDENCY
       );
     });
 
     it("Should fail if a peer dependency has an incompatible version", function() {
       expectBuidlerError(
-        () => usePlugin("requires-other-version-pack1", projectPath),
+        () => usePlugin(ctx, "requires-other-version-pack1", projectPath),
         ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH
       );
     });
 
     it("Should fail if the plugin isn't installed", function() {
       expectBuidlerError(
-        () => usePlugin("not-installed", projectPath),
+        () => usePlugin(ctx, "not-installed", projectPath),
         ERRORS.PLUGINS.NOT_INSTALLED
       );
     });


### PR DESCRIPTION
This refactor changes how we load plugins. Instead of always loading them from the Buidler project's `node_modules`, we use the normal module resolution.

It also improves plugin error messages when Buidler is installed globally, instructing the user to fix their dependencies problems globally.