### PR TITLE
Fix web3 installation instructions

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -84,7 +84,8 @@ These are:
 The sample project comes with a test written using the Ethereum provider, but let’s also install `buidler-truffle5` and test out the Truffle 5 integration:
 
 ```bash
-npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 
+npm install --save-exact web3@1.0.0-beta.37
 ```
 
 Add `usePlugin("@nomiclabs/buidler-truffle5")` to the top of your `buidler.config.js`, and let’s change `test/sample-test.js` to:

--- a/docs/guides/create-task.md
+++ b/docs/guides/create-task.md
@@ -22,7 +22,8 @@ Tasks in Buidler are asynchronous JavaScript functions that get access to the [
 For our example we will use Web3.js to interact with our contracts, so we will install the [web3 plugin](https://github.com/nomiclabs/buidler/tree/master/packages/buidler-web3), which injects a Web3 instance into the Buidler environment:
 
 ```bash
-npm install @nomiclabs/buidler-web3 web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-web3 
+npm install --save-exact web3@1.0.0-beta.37
 ```
 
 _Take a look at the [list of Buidler plugins](/plugins) to see other available libraries._

--- a/docs/guides/truffle-migration.md
+++ b/docs/guides/truffle-migration.md
@@ -23,7 +23,8 @@ npm install
 Install Buidler and the Truffle 5 plugin:
 
 ```bash
-npm install @nomiclabs/buidler @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3@1.0.0-beta.37
+npm install @nomiclabs/buidler @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3
+npm install --save-exact web3@1.0.0-beta.37
 ```
 
 Then put the following into `buidler.config.js`:

--- a/packages/buidler-truffle5/README.md
+++ b/packages/buidler-truffle5/README.md
@@ -15,7 +15,8 @@ This plugin requires [buidler-web3](https://github.com/nomiclabs/buidler/tree/ma
 ## Installation
 
 ```bash
-npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 
+npm install --save-exact web3@1.0.0-beta.37
 ```
 
 And add the following statement to your `buidler.config.js`:

--- a/packages/buidler-web3/README.md
+++ b/packages/buidler-web3/README.md
@@ -11,7 +11,8 @@ This plugin brings to Buidler the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install @nomiclabs/buidler-web3 web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-web3
+npm install --save-exact web3@1.0.0-beta.37
 ```
 
 And add the following statement to your `buidler.config.js`:


### PR DESCRIPTION
This PR updaters the docs wherever they indicated to install `web3@1.0.0-beta.37`. They now instruct the user to use the `--save-exact` npm flag.