### PR TITLE
BuidlerError refactor

### DIFF
--- a/packages/buidler-core/src/builtin-tasks/run.ts
+++ b/packages/buidler-core/src/builtin-tasks/run.ts
@@ -35,10 +35,14 @@ export default function() {
           );
           process.exit(statusCode);
         } catch (error) {
-          throw new BuidlerError(ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR, error, {
-            script,
-            error: error.message
-          });
+          throw new BuidlerError(
+            ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
+            {
+              script,
+              error: error.message
+            },
+            error
+          );
         }
       }
     );

--- a/packages/buidler-core/src/builtin-tasks/run.ts
+++ b/packages/buidler-core/src/builtin-tasks/run.ts
@@ -19,10 +19,9 @@ export default function() {
         { run, buidlerArguments }
       ) => {
         if (!(await fsExtra.pathExists(script))) {
-          throw new BuidlerError(
-            ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND,
+          throw new BuidlerError(ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND, {
             script
-          );
+          });
         }
 
         if (!noCompile) {
@@ -36,12 +35,10 @@ export default function() {
           );
           process.exit(statusCode);
         } catch (error) {
-          throw new BuidlerError(
-            ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
-            error,
+          throw new BuidlerError(ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR, error, {
             script,
-            error.message
-          );
+            error: error.message
+          });
         }
       }
     );

--- a/packages/buidler-core/src/internal/artifacts.ts
+++ b/packages/buidler-core/src/internal/artifacts.ts
@@ -65,7 +65,7 @@ export async function readArtifact(
   const artifactPath = getArtifactPath(artifactsPath, contractName);
 
   if (!fsExtra.pathExistsSync(artifactPath)) {
-    throw new BuidlerError(ERRORS.ARTIFACTS.NOT_FOUND, contractName);
+    throw new BuidlerError(ERRORS.ARTIFACTS.NOT_FOUND, { contractName });
   }
 
   return fsExtra.readJson(artifactPath);
@@ -84,7 +84,7 @@ export function readArtifactSync(
   const artifactPath = getArtifactPath(artifactsPath, contractName);
 
   if (!fsExtra.pathExistsSync(artifactPath)) {
-    throw new BuidlerError(ERRORS.ARTIFACTS.NOT_FOUND, contractName);
+    throw new BuidlerError(ERRORS.ARTIFACTS.NOT_FOUND, { contractName });
   }
 
   return fsExtra.readJsonSync(artifactPath);

--- a/packages/buidler-core/src/internal/cli/ArgumentsParser.ts
+++ b/packages/buidler-core/src/internal/cli/ArgumentsParser.ts
@@ -24,7 +24,9 @@ export class ArgumentsParser {
 
   public static cLAToParamName(cLA: string): string {
     if (cLA.toLowerCase() !== cLA) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.PARAM_NAME_INVALID_CASING, cLA);
+      throw new BuidlerError(ERRORS.ARGUMENTS.PARAM_NAME_INVALID_CASING, {
+        param: cLA
+      });
     }
 
     const parts = cLA.slice(ArgumentsParser.PARAM_PREFIX.length).split("-");
@@ -63,7 +65,7 @@ export class ArgumentsParser {
         if (!this._isCLAParamName(arg, buidlerParamDefinitions)) {
           throw new BuidlerError(
             ERRORS.ARGUMENTS.UNRECOGNIZED_COMMAND_LINE_ARG,
-            arg
+            { argument: arg }
           );
         }
 
@@ -134,7 +136,9 @@ export class ArgumentsParser {
       }
 
       if (!this._isCLAParamName(arg, taskDefinition.paramDefinitions)) {
-        throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_PARAM_NAME, arg);
+        throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_PARAM_NAME, {
+          param: arg
+        });
       }
 
       i = this._parseArgumentAt(
@@ -175,10 +179,9 @@ export class ArgumentsParser {
         if (definition.isOptional) {
           taskArguments[paramName] = definition.defaultValue;
         } else {
-          throw new BuidlerError(
-            ERRORS.ARGUMENTS.MISSING_TASK_ARGUMENT,
-            paramName
-          );
+          throw new BuidlerError(ERRORS.ARGUMENTS.MISSING_TASK_ARGUMENT, {
+            param: paramName
+          });
         }
       }
     }
@@ -208,7 +211,9 @@ export class ArgumentsParser {
     const definition = paramDefinitions[paramName];
 
     if (parsedArguments[paramName] !== undefined) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.REPEATED_PARAM, claArg);
+      throw new BuidlerError(ERRORS.ARGUMENTS.REPEATED_PARAM, {
+        param: claArg
+      });
     }
 
     if (definition.isFlag) {
@@ -218,10 +223,9 @@ export class ArgumentsParser {
       const value = rawCLAs[index];
 
       if (value === undefined) {
-        throw new BuidlerError(
-          ERRORS.ARGUMENTS.MISSING_TASK_ARGUMENT,
-          paramName
-        );
+        throw new BuidlerError(ERRORS.ARGUMENTS.MISSING_TASK_ARGUMENT, {
+          param: paramName
+        });
       }
 
       parsedArguments[paramName] = definition.type.parse(paramName, value);
@@ -243,10 +247,9 @@ export class ArgumentsParser {
 
       if (rawArg === undefined) {
         if (!definition.isOptional) {
-          throw new BuidlerError(
-            ERRORS.ARGUMENTS.MISSING_POSITIONAL_ARG,
-            definition.name
-          );
+          throw new BuidlerError(ERRORS.ARGUMENTS.MISSING_POSITIONAL_ARG, {
+            param: definition.name
+          });
         }
 
         args[definition.name] = definition.defaultValue;
@@ -269,10 +272,9 @@ export class ArgumentsParser {
       !hasVariadicParam &&
       rawPositionalParamArgs.length > positionalParamDefinitions.length
     ) {
-      throw new BuidlerError(
-        ERRORS.ARGUMENTS.UNRECOGNIZED_POSITIONAL_ARG,
-        rawPositionalParamArgs[positionalParamDefinitions.length]
-      );
+      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_POSITIONAL_ARG, {
+        argument: rawPositionalParamArgs[positionalParamDefinitions.length]
+      });
     }
 
     return args;

--- a/packages/buidler-core/src/internal/cli/HelpPrinter.ts
+++ b/packages/buidler-core/src/internal/cli/HelpPrinter.ts
@@ -60,7 +60,9 @@ export class HelpPrinter {
     const taskDefinition = this._tasks[taskName];
 
     if (taskDefinition === undefined) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, taskName);
+      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, {
+        task: taskName
+      });
     }
 
     const description =

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -27,7 +27,9 @@ async function printVersionMessage(packageJson: PackageJson) {
 function ensureValidNodeVersion(packageJson: PackageJson) {
   const requirement = packageJson.engines.node;
   if (!semver.satisfies(process.version, requirement)) {
-    throw new BuidlerError(ERRORS.GENERAL.INVALID_NODE_VERSION, requirement);
+    throw new BuidlerError(ERRORS.GENERAL.INVALID_NODE_VERSION, {
+      requirement
+    });
   }
 }
 
@@ -91,7 +93,9 @@ async function main() {
     const taskDefinition = taskDefinitions[taskName];
 
     if (taskDefinition === undefined) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, taskName);
+      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, {
+        task: taskName
+      });
     }
 
     const taskArguments = argumentsParser.parseTaskArguments(

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -163,7 +163,7 @@ export function validateConfig(config: any) {
 
   const errorList = "  * " + errors.join("\n  * ");
 
-  throw new BuidlerError(ERRORS.GENERAL.INVALID_CONFIG, errorList);
+  throw new BuidlerError(ERRORS.GENERAL.INVALID_CONFIG, { errors: errorList });
 }
 
 export function getValidationErrors(config: any): string[] {

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -318,7 +318,7 @@ You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
     RUNSUPER_NOT_AVAILABLE: {
       number: 206,
       message:
-        "Tried to call runSupper from a non-overridden definition of task %taskName%"
+        "Tried to call runSuper from a non-overridden definition of task %taskName%"
     },
     DEFAULT_VALUE_WRONG_TYPE: {
       number: 207,

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -268,7 +268,7 @@ You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
         "Buidler was set to use chain id %configChainId%, but connected to a chain with id %connectionChainId%."
     },
     /* DEPRECATED: This error only happened because of a misconception in Buidler */
-    INVALID_TX_CHAIN_ID: {
+    DEPRECATED_INVALID_TX_CHAIN_ID: {
       number: 102,
       message:
         "Trying to send a tx with chain id %txChainId%, but Buidler is connected to a chain with id %chainId%."

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -267,7 +267,8 @@ You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
       message:
         "Buidler was set to use chain id %configChainId%, but connected to a chain with id %connectionChainId%."
     },
-    /* DEPRECATED */ INVALID_TX_CHAIN_ID: {
+    /* DEPRECATED: This error only happened because of a misconception in Buidler */
+    INVALID_TX_CHAIN_ID: {
       number: 102,
       message:
         "Trying to send a tx with chain id %txChainId%, but Buidler is connected to a chain with id %chainId%."

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -299,7 +299,7 @@ You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
     INVALID_RPC_QUANTITY_VALUE: {
       number: 108,
       message:
-        "Received invalid value %value% from/to the node's JSON-RPC, but a Quantity was expected."
+        "Received invalid value `%value%` from/to the node's JSON-RPC, but a Quantity was expected."
     }
   },
   TASK_DEFINITIONS: {

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -59,21 +59,47 @@ export class BuidlerError extends Error {
 
 /**
  * This class is used to throw errors from buidler plugins.
- * Resolves automatically the plugin's name from which it's being thrown.
  */
 export class BuidlerPluginError extends Error {
+  public readonly parent?: Error;
   public readonly pluginName: string;
   public readonly isBuidlerPluginError: true;
 
   /**
    * Creates a BuidlerPluginError.
-   * @param message an error message.
-   * @param parent  an error.
+   *
+   * @param pluginName The name of the plugin.
+   * @param message An error message that will be shown to the user.
+   * @param parent The error that causes this error to be thrown.
    */
-  public constructor(message: string, public readonly parent?: Error) {
-    super(message);
+  public constructor(pluginName: string, message: string, parent?: Error);
 
-    this.pluginName = getClosestCallerPackage()!;
+  /**
+   * A DEPRECATED constructor that automatically obtains the caller package and
+   * use it as plugin name.
+   *
+   * @deprecated Use the above constructor.
+   *
+   * @param message An error message that will be shown to the user.
+   * @param parent The error that causes this error to be thrown.
+   */
+  public constructor(message: string, parent?: Error);
+
+  public constructor(
+    pluginNameOrMessage: string,
+    messageOrParent?: string | Error,
+    parent?: Error
+  ) {
+    if (typeof messageOrParent === "string") {
+      super(messageOrParent);
+      this.pluginName = pluginNameOrMessage;
+      this.parent = parent;
+    } else {
+      super(pluginNameOrMessage);
+      this.pluginName = getClosestCallerPackage()!;
+      this.parent = messageOrParent;
+    }
+
     this.isBuidlerPluginError = true;
   }
 }

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -17,32 +17,15 @@ export class BuidlerError extends Error {
 
   constructor(
     errorDescription: ErrorDescription,
-    parentError: Error,
-    messageArguments?: { [variableName: string]: any }
-  );
-  constructor(
-    errorDescription: ErrorDescription,
-    messageArguments?: { [variableName: string]: any }
-  );
-  constructor(
-    errorDescription: ErrorDescription,
-    parentError: Error | { [variableName: string]: any } = {},
-    messageArguments: { [variableName: string]: any } = {}
+    messageArguments: { [p: string]: any } = {},
+    parentError?: Error
   ) {
     const prefix = ERROR_PREFIX + errorDescription.number.toString() + ": ";
 
-    let formattedMessage: string;
-    if (parentError instanceof Error) {
-      formattedMessage = applyErrorMessageTemplate(
-        errorDescription.message,
-        messageArguments
-      );
-    } else {
-      formattedMessage = applyErrorMessageTemplate(
-        errorDescription.message,
-        parentError
-      );
-    }
+    const formattedMessage = applyErrorMessageTemplate(
+      errorDescription.message,
+      messageArguments
+    );
 
     super(prefix + formattedMessage);
     this.number = errorDescription.number;

--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -51,12 +51,11 @@ export const boolean: ArgumentType<boolean> = {
       return false;
     }
 
-    throw new BuidlerError(
-      ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-      strValue,
-      argName,
-      "boolean"
-    );
+    throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+      value: strValue,
+      name: argName,
+      type: "boolean"
+    });
   }
 };
 
@@ -75,12 +74,11 @@ export const int: ArgumentType<number> = {
       strValue.match(decimalPattern) === null &&
       strValue.match(hexPattern) === null
     ) {
-      throw new BuidlerError(
-        ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        strValue,
-        argName,
-        "int"
-      );
+      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        value: strValue,
+        name: argName,
+        type: "int"
+      });
     }
 
     return Number(strValue);
@@ -102,12 +100,11 @@ export const float: ArgumentType<number> = {
       strValue.match(decimalPattern) === null &&
       strValue.match(hexPattern) === null
     ) {
-      throw new BuidlerError(
-        ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        strValue,
-        argName,
-        "float"
-      );
+      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        value: strValue,
+        name: argName,
+        type: "float"
+      });
     }
 
     return Number(strValue);
@@ -132,12 +129,10 @@ export const inputFile: ArgumentType<string> = {
         throw new Error(strValue + " is a directory, not a file");
       }
     } catch (error) {
-      throw new BuidlerError(
-        ERRORS.ARGUMENTS.INVALID_INPUT_FILE,
-        error,
-        argName,
-        strValue
-      );
+      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_INPUT_FILE, error, {
+        name: argName,
+        value: strValue
+      });
     }
 
     return strValue;
@@ -150,12 +145,10 @@ export const json: ArgumentType<any> = {
     try {
       return JSON.parse(strValue);
     } catch (error) {
-      throw new BuidlerError(
-        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT,
-        error,
-        argName,
-        error.message
-      );
+      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT, error, {
+        param: argName,
+        error: error.message
+      });
     }
   }
 };

--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -129,10 +129,14 @@ export const inputFile: ArgumentType<string> = {
         throw new Error(strValue + " is a directory, not a file");
       }
     } catch (error) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_INPUT_FILE, error, {
-        name: argName,
-        value: strValue
-      });
+      throw new BuidlerError(
+        ERRORS.ARGUMENTS.INVALID_INPUT_FILE,
+        {
+          name: argName,
+          value: strValue
+        },
+        error
+      );
     }
 
     return strValue;
@@ -145,10 +149,14 @@ export const json: ArgumentType<any> = {
     try {
       return JSON.parse(strValue);
     } catch (error) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT, error, {
-        param: argName,
-        error: error.message
-      });
+      throw new BuidlerError(
+        ERRORS.ARGUMENTS.INVALID_JSON_ARGUMENT,
+        {
+          param: argName,
+          error: error.message
+        },
+        error
+      );
     }
   }
 };

--- a/packages/buidler-core/src/internal/core/params/env-variables.ts
+++ b/packages/buidler-core/src/internal/core/params/env-variables.ts
@@ -47,10 +47,14 @@ export function getEnvBuidlerArguments(
       try {
         envArgs[paramName] = definition.type.parse(paramName, rawValue);
       } catch (error) {
-        throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_ENV_VAR_VALUE, error, {
-          varName: envVarName,
-          value: rawValue
-        });
+        throw new BuidlerError(
+          ERRORS.ARGUMENTS.INVALID_ENV_VAR_VALUE,
+          {
+            varName: envVarName,
+            value: rawValue
+          },
+          error
+        );
       }
     } else {
       envArgs[paramName] = definition.defaultValue;

--- a/packages/buidler-core/src/internal/core/params/env-variables.ts
+++ b/packages/buidler-core/src/internal/core/params/env-variables.ts
@@ -47,12 +47,10 @@ export function getEnvBuidlerArguments(
       try {
         envArgs[paramName] = definition.type.parse(paramName, rawValue);
       } catch (error) {
-        throw new BuidlerError(
-          ERRORS.ARGUMENTS.INVALID_ENV_VAR_VALUE,
-          error,
-          envVarName,
-          rawValue
-        );
+        throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_ENV_VAR_VALUE, error, {
+          varName: envVarName,
+          value: rawValue
+        });
       }
     } else {
       envArgs[paramName] = definition.defaultValue;

--- a/packages/buidler-core/src/internal/core/plugins.ts
+++ b/packages/buidler-core/src/internal/core/plugins.ts
@@ -51,7 +51,9 @@ export function usePlugin(
   const pluginPackageJson = readPackageJson(pluginName, from);
 
   if (pluginPackageJson === undefined) {
-    throw new BuidlerError(ERRORS.PLUGINS.NOT_INSTALLED, pluginName);
+    throw new BuidlerError(ERRORS.PLUGINS.NOT_INSTALLED, {
+      plugin: pluginName
+    });
   }
 
   // We use the package.json's version of the name, as it is normalized.
@@ -82,33 +84,26 @@ export function usePlugin(
       }
 
       if (dependencyPackageJson === undefined) {
-        throw new BuidlerError(
-          ERRORS.PLUGINS.MISSING_DEPENDENCY,
-          pluginName,
-          dependencyName,
-          globalWarning,
-          installExtraFlags,
-          dependencyName,
+        throw new BuidlerError(ERRORS.PLUGINS.MISSING_DEPENDENCY, {
+          plugin: pluginName,
+          dependency: dependencyName,
+          extraMessage: globalWarning,
+          extraFlags: installExtraFlags,
           versionSpec
-        );
+        });
       }
 
       const installedVersion = dependencyPackageJson.version;
 
       if (!semver.satisfies(installedVersion, versionSpec)) {
-        throw new BuidlerError(
-          ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
-          pluginName,
-          dependencyName,
+        throw new BuidlerError(ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH, {
+          plugin: pluginName,
+          dependency: dependencyName,
+          extraMessage: globalWarning,
+          extraFlags: installExtraFlags,
           versionSpec,
-          installedVersion,
-          globalWarning,
-          dependencyName,
-          installExtraFlags,
-          dependencyName,
-          versionSpec,
-          dependencyName
-        );
+          installedVersion
+        });
       }
     }
   }
@@ -174,9 +169,8 @@ export function ensurePluginLoadedWithUsePlugin() {
 
   const pluginName = getClosestCallerPackage();
 
-  throw new BuidlerError(
-    ERRORS.PLUGINS.OLD_STYLE_IMPORT_DETECTED,
-    pluginName !== undefined ? pluginName : "a plugin",
-    pluginName !== undefined ? pluginName : "plugin-name"
-  );
+  throw new BuidlerError(ERRORS.PLUGINS.OLD_STYLE_IMPORT_DETECTED, {
+    pluginNameText: pluginName !== undefined ? pluginName : "a plugin",
+    pluginNameCode: pluginName !== undefined ? pluginName : "plugin-name"
+  });
 }

--- a/packages/buidler-core/src/internal/core/providers/accounts.ts
+++ b/packages/buidler-core/src/internal/core/providers/accounts.ts
@@ -38,7 +38,9 @@ export function createLocalAccountsProvider(
         );
 
         if (account === undefined) {
-          throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, address);
+          throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, {
+            account: address
+          });
         }
 
         return account.sign(data).signature;
@@ -51,14 +53,14 @@ export function createLocalAccountsProvider(
       if (tx.gas === undefined) {
         throw new BuidlerError(
           ERRORS.NETWORK.MISSING_TX_PARAM_TO_SIGN_LOCALLY,
-          "gas"
+          { param: "gas" }
         );
       }
 
       if (tx.gasPrice === undefined) {
         throw new BuidlerError(
           ERRORS.NETWORK.MISSING_TX_PARAM_TO_SIGN_LOCALLY,
-          "gasPrice"
+          { param: "gasPrice" }
         );
       }
 
@@ -74,7 +76,9 @@ export function createLocalAccountsProvider(
       );
 
       if (account === undefined) {
-        throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, tx.from);
+        throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, {
+          account: tx.from
+        });
       }
 
       const chainId = await getChainId();
@@ -102,7 +106,7 @@ export function createHDWalletProvider(
   count: number = 10
 ) {
   if (hdpath.match(HD_PATH_REGEX) === null) {
-    throw new BuidlerError(ERRORS.NETWORK.INVALID_HD_PATH, hdpath);
+    throw new BuidlerError(ERRORS.NETWORK.INVALID_HD_PATH, { path: hdpath });
   }
 
   if (!hdpath.endsWith("/")) {

--- a/packages/buidler-core/src/internal/core/providers/chainId.ts
+++ b/packages/buidler-core/src/internal/core/providers/chainId.ts
@@ -14,11 +14,10 @@ export function createChainIdValidationProvider(
     const realChainId = await getChainId();
 
     if (chainId !== undefined && realChainId !== chainId) {
-      throw new BuidlerError(
-        ERRORS.NETWORK.INVALID_GLOBAL_CHAIN_ID,
-        chainId,
-        realChainId
-      );
+      throw new BuidlerError(ERRORS.NETWORK.INVALID_GLOBAL_CHAIN_ID, {
+        configChainId: chainId,
+        connectionChainId: realChainId
+      });
     }
 
     return provider.send(method, params);

--- a/packages/buidler-core/src/internal/core/providers/provider-utils.ts
+++ b/packages/buidler-core/src/internal/core/providers/provider-utils.ts
@@ -3,17 +3,18 @@ import { BuidlerError, ERRORS } from "../errors";
 
 export function rpcQuantityToNumber(quantity?: string) {
   if (quantity === undefined) {
-    throw new BuidlerError(
-      ERRORS.NETWORK.INVALID_RPC_QUANTITY_VALUE,
-      "undefined"
-    );
+    throw new BuidlerError(ERRORS.NETWORK.INVALID_RPC_QUANTITY_VALUE, {
+      value: quantity
+    });
   }
 
   if (
     typeof quantity !== "string" ||
     quantity.match(/^0x(?:0|(?:[1-9a-fA-F][0-9a-fA-F]*))$/) === null
   ) {
-    throw new BuidlerError(ERRORS.NETWORK.INVALID_RPC_QUANTITY_VALUE, quantity);
+    throw new BuidlerError(ERRORS.NETWORK.INVALID_RPC_QUANTITY_VALUE, {
+      value: quantity
+    });
   }
 
   return parseInt(quantity.substring(2), 16);

--- a/packages/buidler-core/src/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/src/internal/core/runtime-environment.ts
@@ -64,7 +64,9 @@ export class Environment implements BuidlerRuntimeEnvironment {
     const networkConfig = config.networks[networkName];
 
     if (networkConfig === undefined) {
-      throw new BuidlerError(ERRORS.NETWORK.CONFIG_NOT_FOUND, networkName);
+      throw new BuidlerError(ERRORS.NETWORK.CONFIG_NOT_FOUND, {
+        network: networkName
+      });
     }
 
     const provider = lazyObject(() => createProvider(networkConfig));
@@ -96,7 +98,9 @@ export class Environment implements BuidlerRuntimeEnvironment {
     log("Running task %s", name);
 
     if (taskDefinition === undefined) {
-      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, name);
+      throw new BuidlerError(ERRORS.ARGUMENTS.UNRECOGNIZED_TASK, {
+        task: name
+      });
     }
 
     return this._runTaskDefinition(taskDefinition, taskArguments);
@@ -153,10 +157,9 @@ export class Environment implements BuidlerRuntimeEnvironment {
       };
     } else {
       runSuper = async () => {
-        throw new BuidlerError(
-          ERRORS.TASK_DEFINITIONS.RUNSUPER_NOT_AVAILABLE,
-          taskDefinition.name
-        );
+        throw new BuidlerError(ERRORS.TASK_DEFINITIONS.RUNSUPER_NOT_AVAILABLE, {
+          taskName: taskDefinition.name
+        });
       };
     }
 

--- a/packages/buidler-core/src/internal/core/tasks/task-definitions.ts
+++ b/packages/buidler-core/src/internal/core/tasks/task-definitions.ts
@@ -46,7 +46,9 @@ export class SimpleTaskDefinition implements TaskDefinition {
     this._hasVariadicParam = false;
     this._hasOptionalPositionalParam = false;
     this.action = () => {
-      throw new BuidlerError(ERRORS.TASK_DEFINITIONS.ACTION_NOT_SET, name);
+      throw new BuidlerError(ERRORS.TASK_DEFINITIONS.ACTION_NOT_SET, {
+        taskName: name
+      });
     };
   }
 
@@ -92,8 +94,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
       if (defaultValue !== undefined && typeof defaultValue !== "string") {
         throw new BuidlerError(
           ERRORS.TASK_DEFINITIONS.DEFAULT_VALUE_WRONG_TYPE,
-          name,
-          this.name
+          {
+            paramName: name,
+            taskName: this.name
+          }
         );
       }
 
@@ -199,8 +203,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
       if (defaultValue !== undefined && typeof defaultValue !== "string") {
         throw new BuidlerError(
           ERRORS.TASK_DEFINITIONS.DEFAULT_VALUE_WRONG_TYPE,
-          name,
-          this.name
+          {
+            paramName: name,
+            taskName: this.name
+          }
         );
       }
 
@@ -282,8 +288,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
       if (defaultValue !== undefined && !this._isStringArray(defaultValue)) {
         throw new BuidlerError(
           ERRORS.TASK_DEFINITIONS.DEFAULT_VALUE_WRONG_TYPE,
-          name,
-          this.name
+          {
+            paramName: name,
+            taskName: this.name
+          }
         );
       }
 
@@ -372,11 +380,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
    */
   public _validateNotAfterVariadicParam(name: string) {
     if (this._hasVariadicParam) {
-      throw new BuidlerError(
-        ERRORS.TASK_DEFINITIONS.PARAM_AFTER_VARIADIC,
-        name,
-        this.name
-      );
+      throw new BuidlerError(ERRORS.TASK_DEFINITIONS.PARAM_AFTER_VARIADIC, {
+        paramName: name,
+        taskName: this.name
+      });
     }
   }
 
@@ -389,18 +396,19 @@ export class SimpleTaskDefinition implements TaskDefinition {
    */
   public _validateNameNotUsed(name: string) {
     if (this._hasParamDefined(name)) {
-      throw new BuidlerError(
-        ERRORS.TASK_DEFINITIONS.PARAM_ALREADY_DEFINED,
-        name,
-        this.name
-      );
+      throw new BuidlerError(ERRORS.TASK_DEFINITIONS.PARAM_ALREADY_DEFINED, {
+        paramName: name,
+        taskName: this.name
+      });
     }
 
     if (Object.keys(BUIDLER_PARAM_DEFINITIONS).includes(name)) {
       throw new BuidlerError(
         ERRORS.TASK_DEFINITIONS.PARAM_CLASHES_WITH_BUIDLER_PARAM,
-        name,
-        this.name
+        {
+          paramName: name,
+          taskName: this.name
+        }
       );
     }
   }
@@ -431,8 +439,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
     if (!isOptional && this._hasOptionalPositionalParam) {
       throw new BuidlerError(
         ERRORS.TASK_DEFINITIONS.MANDATORY_PARAM_AFTER_OPTIONAL,
-        name,
-        this.name
+        {
+          paramName: name,
+          taskName: this.name
+        }
       );
     }
   }
@@ -443,8 +453,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
     if (match === null) {
       throw new BuidlerError(
         ERRORS.TASK_DEFINITIONS.INVALID_PARAM_NAME_CASING,
-        this.name,
-        name
+        {
+          paramName: name,
+          taskName: this.name
+        }
       );
     }
   }
@@ -457,8 +469,10 @@ export class SimpleTaskDefinition implements TaskDefinition {
     if (defaultValue !== undefined && !isOptional) {
       throw new BuidlerError(
         ERRORS.TASK_DEFINITIONS.DEFAULT_IN_MANDATORY_PARAM,
-        name,
-        this.name
+        {
+          paramName: name,
+          taskName: this.name
+        }
       );
     }
   }
@@ -632,9 +646,8 @@ export class OverriddenTaskDefinition implements TaskDefinition {
   }
 
   public _throwNoParamsOverrideError(): never {
-    throw new BuidlerError(
-      ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS,
-      this.name
-    );
+    throw new BuidlerError(ERRORS.TASK_DEFINITIONS.OVERRIDE_NO_PARAMS, {
+      taskName: this.name
+    });
   }
 }

--- a/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
@@ -88,7 +88,7 @@ export class CompilerDownloader {
     const compilerBuild = list.builds.find(b => b.path === compilerBuildPath);
 
     if (compilerBuild === undefined) {
-      throw new BuidlerError(ERRORS.SOLC.INVALID_VERSION, version);
+      throw new BuidlerError(ERRORS.SOLC.INVALID_VERSION, { version });
     }
 
     return compilerBuild;
@@ -114,11 +114,9 @@ export class CompilerDownloader {
     try {
       await this._download(COMPILERS_LIST_URL, this.getCompilersListPath());
     } catch (error) {
-      throw new BuidlerError(
-        ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
-        error,
-        this._localSolcVersion
-      );
+      throw new BuidlerError(ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED, error, {
+        localVersion: this._localSolcVersion
+      });
     }
   }
 
@@ -133,12 +131,10 @@ export class CompilerDownloader {
     try {
       await this._download(compilerUrl, downloadedFilePath);
     } catch (error) {
-      throw new BuidlerError(
-        ERRORS.SOLC.DOWNLOAD_FAILED,
-        error,
-        compilerBuild.version,
-        this._localSolcVersion
-      );
+      throw new BuidlerError(ERRORS.SOLC.DOWNLOAD_FAILED, error, {
+        remoteVersion: compilerBuild.version,
+        localVersion: this._localSolcVersion
+      });
     }
   }
 
@@ -157,11 +153,10 @@ export class CompilerDownloader {
     if (expectedKeccak256 !== compilerKeccak256) {
       await fsExtra.unlink(downloadedFilePath);
 
-      throw new BuidlerError(
-        ERRORS.SOLC.INVALID_DOWNLOAD,
-        compilerBuild.version,
-        this._localSolcVersion
-      );
+      throw new BuidlerError(ERRORS.SOLC.INVALID_DOWNLOAD, {
+        remoteVersion: compilerBuild.version,
+        localVersion: this._localSolcVersion
+      });
     }
   }
 

--- a/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
@@ -114,9 +114,13 @@ export class CompilerDownloader {
     try {
       await this._download(COMPILERS_LIST_URL, this.getCompilersListPath());
     } catch (error) {
-      throw new BuidlerError(ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED, error, {
-        localVersion: this._localSolcVersion
-      });
+      throw new BuidlerError(
+        ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
+        {
+          localVersion: this._localSolcVersion
+        },
+        error
+      );
     }
   }
 
@@ -131,10 +135,14 @@ export class CompilerDownloader {
     try {
       await this._download(compilerUrl, downloadedFilePath);
     } catch (error) {
-      throw new BuidlerError(ERRORS.SOLC.DOWNLOAD_FAILED, error, {
-        remoteVersion: compilerBuild.version,
-        localVersion: this._localSolcVersion
-      });
+      throw new BuidlerError(
+        ERRORS.SOLC.DOWNLOAD_FAILED,
+        {
+          remoteVersion: compilerBuild.version,
+          localVersion: this._localSolcVersion
+        },
+        error
+      );
     }
   }
 

--- a/packages/buidler-core/src/internal/solidity/resolver.ts
+++ b/packages/buidler-core/src/internal/solidity/resolver.ts
@@ -90,18 +90,26 @@ export class Resolver {
         path.join(libraryName, "package.json")
       );
     } catch (error) {
-      throw new BuidlerError(ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED, error, {
-        library: libraryName
-      });
+      throw new BuidlerError(
+        ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
+        {
+          library: libraryName
+        },
+        error
+      );
     }
 
     let absolutePath;
     try {
       absolutePath = this._resolveFromProjectRoot(globalName);
     } catch (error) {
-      throw new BuidlerError(ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND, error, {
-        file: globalName
-      });
+      throw new BuidlerError(
+        ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND,
+        {
+          file: globalName
+        },
+        error
+      );
     }
 
     const libraryPath = path.dirname(packagePath);
@@ -167,10 +175,14 @@ export class Resolver {
         error.number === ERRORS.RESOLVER.FILE_NOT_FOUND.number ||
         error.number === ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND.number
       ) {
-        throw new BuidlerError(ERRORS.RESOLVER.IMPORTED_FILE_NOT_FOUND, error, {
-          imported,
-          from: from.globalName
-        });
+        throw new BuidlerError(
+          ERRORS.RESOLVER.IMPORTED_FILE_NOT_FOUND,
+          {
+            imported,
+            from: from.globalName
+          },
+          error
+        );
       }
 
       // tslint:disable-next-line only-buidler-error

--- a/packages/buidler-core/src/internal/util/lazy.ts
+++ b/packages/buidler-core/src/internal/util/lazy.ts
@@ -33,17 +33,15 @@ export function lazyObject<T extends object>(objectCreator: () => T): T {
     () => ({}),
     object => {
       if (object instanceof Function) {
-        throw new BuidlerError(
-          ERRORS.GENERAL.UNSUPPORTED_OPERATION,
-          "Creating lazy functions or classes with lazyObject"
-        );
+        throw new BuidlerError(ERRORS.GENERAL.UNSUPPORTED_OPERATION, {
+          operation: "Creating lazy functions or classes with lazyObject"
+        });
       }
 
       if (typeof object !== "object" || object === null) {
-        throw new BuidlerError(
-          ERRORS.GENERAL.UNSUPPORTED_OPERATION,
-          "Using lazyObject with anything other than objects"
-        );
+        throw new BuidlerError(ERRORS.GENERAL.UNSUPPORTED_OPERATION, {
+          operation: "Using lazyObject with anything other than objects"
+        });
       }
     }
   );
@@ -56,10 +54,9 @@ export function lazyFunction<T extends Function>(functionCreator: () => T): T {
     () => function() {},
     object => {
       if (!(object instanceof Function)) {
-        throw new BuidlerError(
-          ERRORS.GENERAL.UNSUPPORTED_OPERATION,
-          "lazyFunction should be used for functions"
-        );
+        throw new BuidlerError(ERRORS.GENERAL.UNSUPPORTED_OPERATION, {
+          operation: "lazyFunction should be used for functions"
+        });
       }
     }
   );

--- a/packages/buidler-core/src/internal/util/strings.ts
+++ b/packages/buidler-core/src/internal/util/strings.ts
@@ -18,3 +18,14 @@ export function pluralize(n: number, singular: string, plural?: string) {
 
   return singular + "s";
 }
+
+/**
+ * Replaces all the instances of [[toReplace]] by [[replacement]] in [[str]].
+ */
+export function replaceAll(
+  str: string,
+  toReplace: string,
+  replacement: string
+) {
+  return str.split(toReplace).join(replacement);
+}

--- a/packages/buidler-core/test/helpers/errors.ts
+++ b/packages/buidler-core/test/helpers/errors.ts
@@ -50,7 +50,16 @@ export function expectBuidlerError(
   } catch (error) {
     assert.instanceOf(error, BuidlerError);
     assert.equal(error.number, errorDescription.number);
-    assert.notInclude(error.message, "%s", "BuidlerError wrongly formatted");
+    assert.notInclude(
+      error.message,
+      "%s",
+      "BuidlerError has old-style format tag"
+    );
+    assert.notMatch(
+      error.message,
+      /%[a-zA-Z][a-zA-Z0-9]*%/,
+      "BuidlerError has an non-replaced variable tag"
+    );
 
     if (typeof errorMessage === "string") {
       assert.include(error.message, errorMessage);
@@ -91,7 +100,16 @@ export async function expectBuidlerErrorAsync(
   } catch (error) {
     assert.instanceOf(error, BuidlerError);
     assert.equal(error.number, errorDescription.number);
-    assert.notInclude(error.message, "%s", "BuidlerError wrongly formatted");
+    assert.notInclude(
+      error.message,
+      "%s",
+      "BuidlerError has old-style format tag"
+    );
+    assert.notMatch(
+      error.message,
+      /%[a-zA-Z][a-zA-Z0-9]*%/,
+      "BuidlerError has an non-replaced variable tag"
+    );
 
     if (errorMessage !== undefined) {
       if (typeof errorMessage === "string") {

--- a/packages/buidler-core/test/internal/core/errors.ts
+++ b/packages/buidler-core/test/internal/core/errors.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 
 import {
   BuidlerError,
+  BuidlerPluginError,
   ERROR_RANGES,
   ErrorDescription,
   ERRORS
@@ -148,5 +149,65 @@ describe("Error descriptions", () => {
         }
       }
     }
+  });
+});
+
+describe("BuidlerPluginError", () => {
+  describe("constructors", () => {
+    describe("automatic plugin name", () => {
+      it("Should accept a parent error", () => {
+        const message = "m";
+        const parent = new Error();
+
+        const error = new BuidlerPluginError(message, parent);
+
+        assert.equal(error.message, message);
+        assert.equal(error.parent, parent);
+      });
+
+      it("Should work without a parent error", () => {
+        const message = "m2";
+
+        const error = new BuidlerPluginError(message);
+
+        assert.equal(error.message, message);
+        assert.isUndefined(error.parent);
+      });
+
+      it("Should autodetect the plugin name", () => {
+        const message = "m";
+        const parent = new Error();
+
+        const error = new BuidlerPluginError(message, parent);
+
+        // This is being called from mocha, so that would be used as plugin name
+        assert.equal(error.pluginName, "mocha");
+      });
+    });
+
+    describe("explicit plugin name", () => {
+      it("Should accept a parent error", () => {
+        const plugin = "p";
+        const message = "m";
+        const parent = new Error();
+
+        const error = new BuidlerPluginError(plugin, message, parent);
+
+        assert.equal(error.pluginName, plugin);
+        assert.equal(error.message, message);
+        assert.equal(error.parent, parent);
+      });
+
+      it("Should work without a parent error", () => {
+        const plugin = "p";
+        const message = "m";
+
+        const error = new BuidlerPluginError(plugin, message);
+
+        assert.equal(error.pluginName, plugin);
+        assert.equal(error.message, message);
+        assert.isUndefined(error.parent);
+      });
+    });
   });
 });

--- a/packages/buidler-core/test/internal/core/errors.ts
+++ b/packages/buidler-core/test/internal/core/errors.ts
@@ -60,22 +60,22 @@ describe("BuilderError", () => {
   describe("With parent error", () => {
     it("should have the right parent error", () => {
       const parent = new Error();
-      const error = new BuidlerError(mockErrorDescription, parent);
+      const error = new BuidlerError(mockErrorDescription, {}, parent);
       assert.equal(error.parent, parent);
     });
 
     it("should format the error message with the template params", () => {
       const error = new BuidlerError(
         { number: 12, message: "%a% %b% %c%" },
-        new Error(),
-        { a: "a", b: "b", c: 123 }
+        { a: "a", b: "b", c: 123 },
+        new Error()
       );
       assert.equal(error.message, "BDLR12: a b 123");
     });
 
     it("Should work with instanceof", () => {
       const parent = new Error();
-      const error = new BuidlerError(mockErrorDescription, parent);
+      const error = new BuidlerError(mockErrorDescription, {}, parent);
       assert.instanceOf(error, BuidlerError);
     });
   });

--- a/packages/buidler-core/test/internal/core/errors.ts
+++ b/packages/buidler-core/test/internal/core/errors.ts
@@ -53,7 +53,7 @@ describe("BuilderError", () => {
 
     it("Should work with instanceof", () => {
       const error = new BuidlerError(mockErrorDescription);
-      assert.isTrue(error instanceof BuidlerError);
+      assert.instanceOf(error, BuidlerError);
     });
   });
 
@@ -76,7 +76,7 @@ describe("BuilderError", () => {
     it("Should work with instanceof", () => {
       const parent = new Error();
       const error = new BuidlerError(mockErrorDescription, parent);
-      assert.isTrue(error instanceof BuidlerError);
+      assert.instanceOf(error, BuidlerError);
     });
   });
 });
@@ -199,7 +199,7 @@ describe("BuidlerPluginError", () => {
 
         const error = new BuidlerPluginError(message, parent);
 
-        assert.isTrue(error instanceof BuidlerPluginError);
+        assert.instanceOf(error, BuidlerPluginError);
       });
     });
 
@@ -234,7 +234,7 @@ describe("BuidlerPluginError", () => {
 
         const error = new BuidlerPluginError(plugin, message, parent);
 
-        assert.isTrue(error instanceof BuidlerPluginError);
+        assert.instanceOf(error, BuidlerPluginError);
       });
     });
   });

--- a/packages/buidler-core/test/internal/util/strings.ts
+++ b/packages/buidler-core/test/internal/util/strings.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { pluralize } from "../../../src/internal/util/strings";
+import { pluralize, replaceAll } from "../../../src/internal/util/strings";
 
 describe("String utils", function() {
   describe("pluralize", function() {
@@ -20,5 +20,27 @@ describe("String utils", function() {
       assert.equal(pluralize(0, "sing"), "sings");
       assert.equal(pluralize(123, "sing"), "sings");
     });
+  });
+});
+
+describe("replaceAll", function() {
+  it("Should work with empty strings", function() {
+    assert.equal(replaceAll("", "asd", "123"), "");
+  });
+
+  it("Should work with no occurrence", function() {
+    assert.equal(replaceAll("a", "b", "c"), "a");
+  });
+
+  it("Should work with a single occurrence", function() {
+    assert.equal(replaceAll("ayguhi", "a", "c"), "cyguhi");
+  });
+
+  it("Should work with a multiple occurrences", function() {
+    assert.equal(replaceAll("alakjahjkasd", "a", "c"), "clckjchjkcsd");
+  });
+
+  it("Should not replace occurrences present in the replacement string", function() {
+    assert.equal(replaceAll("a b c d a", "a", "_a_"), "_a_ b c d _a_");
   });
 });


### PR DESCRIPTION
This plugin makes two medium-sized refactors:

1) Introduces a new constructor to `BuidlerPluginError` that lets you specify the plugin name.
2) Introduces a small template language for `BuidlerError` messages, and updates all the messages and uses of `BuidlerError`.