### PR TITLE
Config extension/resolution mechanism for plugins

### DIFF
--- a/packages/buidler-core/src/internal/context.ts
+++ b/packages/buidler-core/src/internal/context.ts
@@ -1,4 +1,4 @@
-import { BuidlerRuntimeEnvironment } from "../types";
+import { BuidlerRuntimeEnvironment, ConfigExtender } from "../types";
 
 import { ExtenderManager } from "./core/config/extenders";
 import { BuidlerError, ERRORS } from "./core/errors";
@@ -39,6 +39,7 @@ export class BuidlerContext {
   public readonly extendersManager = new ExtenderManager();
   public environment?: BuidlerRuntimeEnvironment;
   public readonly loadedPlugins: string[] = [];
+  public readonly configExtenders: ConfigExtender[] = [];
 
   public setBuidlerRuntimeEnvironment(env: BuidlerRuntimeEnvironment) {
     if (this.environment !== undefined) {

--- a/packages/buidler-core/src/internal/core/config/config-env.ts
+++ b/packages/buidler-core/src/internal/core/config/config-env.ts
@@ -1,5 +1,6 @@
 import {
   ActionType,
+  ConfigExtender,
   ConfigurableTaskDefinition,
   EnvironmentExtender,
   TaskArguments
@@ -81,6 +82,11 @@ export function extendEnvironment(extender: EnvironmentExtender) {
   const ctx = BuidlerContext.getBuidlerContext();
   const extenderManager = ctx.extendersManager;
   extenderManager.add(extender);
+}
+
+export function extendConfig(extender: ConfigExtender) {
+  const ctx = BuidlerContext.getBuidlerContext();
+  ctx.configExtenders.push(extender);
 }
 
 /**

--- a/packages/buidler-core/src/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/src/internal/core/config/config-loading.ts
@@ -43,9 +43,6 @@ export function loadConfigAndTasks(configPath?: string): ResolvedBuidlerConfig {
   // To avoid bad practices we remove the previously exported stuff
   Object.keys(configEnv).forEach(key => (globalAsAny[key] = undefined));
 
-  // This object shouldn't be modified
-  Object.freeze(userConfig);
-
   return resolveConfig(
     configPath,
     defaultConfig,

--- a/packages/buidler-core/src/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/src/internal/core/config/config-loading.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 
 import { ResolvedBuidlerConfig } from "../../../types";
+import { BuidlerContext } from "../../context";
 import { loadPluginFile } from "../plugins";
 import { getUserConfigPath } from "../project-structure";
 
@@ -42,5 +43,13 @@ export function loadConfigAndTasks(configPath?: string): ResolvedBuidlerConfig {
   // To avoid bad practices we remove the previously exported stuff
   Object.keys(configEnv).forEach(key => (globalAsAny[key] = undefined));
 
-  return resolveConfig(configPath, defaultConfig, userConfig);
+  // This object shouldn't be modified
+  Object.freeze(userConfig);
+
+  return resolveConfig(
+    configPath,
+    defaultConfig,
+    userConfig,
+    BuidlerContext.getBuidlerContext().configExtenders
+  );
 }

--- a/packages/buidler-core/src/internal/core/config/config-resolution.ts
+++ b/packages/buidler-core/src/internal/core/config/config-resolution.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 import {
   BuidlerConfig,
+  ConfigExtender,
   ProjectPaths,
   ResolvedBuidlerConfig
 } from "../../../types";
@@ -25,19 +26,21 @@ function mergeUserAndDefaultConfigs(
  * @param userConfigPath the user config filepath
  * @param defaultConfig  the buidler's default config object
  * @param userConfig     the user config object
+ * @param configExtenders An array of ConfigExtenders
  *
  * @returns the resolved config
  */
 export function resolveConfig(
   userConfigPath: string,
   defaultConfig: BuidlerConfig,
-  userConfig: BuidlerConfig
+  userConfig: BuidlerConfig,
+  configExtenders: ConfigExtender[]
 ): ResolvedBuidlerConfig {
   const config = mergeUserAndDefaultConfigs(defaultConfig, userConfig);
 
   const paths = resolveProjectPaths(userConfigPath, userConfig.paths);
 
-  return {
+  const resolved = {
     ...config,
     paths,
     networks: config.networks!,
@@ -45,6 +48,12 @@ export function resolveConfig(
     defaultNetwork: config.defaultNetwork!,
     analytics: config.analytics!
   };
+
+  for (const extender of configExtenders) {
+    extender(resolved, userConfig);
+  }
+
+  return resolved;
 }
 
 function resolvePathFrom(

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -258,6 +258,11 @@ To learn more about Buidler's configuration, please go to https://buidler.dev/do
       number: 9,
       message: `Error while loading Buidler's configuration.
 You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
+    },
+    USER_CONFIG_MODIFIED: {
+      number: 10,
+      message: `Error while loading Buidler's configuration.
+You or one of your plugins is trying to modify the userConfig.%path% value from a config extender`
     }
   },
   NETWORK: {

--- a/packages/buidler-core/src/internal/reset.ts
+++ b/packages/buidler-core/src/internal/reset.ts
@@ -5,6 +5,7 @@
  * manually with `unloadModule`.
  */
 import { BuidlerContext } from "./context";
+import { getUserConfigPath } from "./core/project-structure";
 import { globSync } from "./util/glob";
 
 export function resetBuidlerContext() {
@@ -17,6 +18,19 @@ export function resetBuidlerContext() {
       }
       // unload config file too.
       unloadModule(ctx.environment.config.paths.configFile);
+    } else {
+      // We may get here if loading the config has thrown, so be unload it
+      let configPath: string | undefined;
+
+      try {
+        configPath = getUserConfigPath();
+      } catch (error) {
+        // We weren't in a buidler project
+      }
+
+      if (configPath !== undefined) {
+        unloadModule(configPath);
+      }
     }
     BuidlerContext.deleteBuidlerContext();
   }

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from "events";
-import { DeepPartial, Omit } from "ts-essentials";
+import { DeepPartial, DeepReadonly, Omit } from "ts-essentials";
 
-import { Analytics } from "./internal/cli/analytics";
 import * as types from "./internal/core/params/argumentTypes";
 
 // Begin config types
@@ -127,7 +126,7 @@ export type EnvironmentExtender = (env: BuidlerRuntimeEnvironment) => void;
 
 export type ConfigExtender = (
   config: ResolvedBuidlerConfig,
-  userConfig: BuidlerConfig
+  userConfig: DeepReadonly<BuidlerConfig>
 ) => void;
 
 export interface TasksMap {

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -125,6 +125,11 @@ export interface SolcInput {
  */
 export type EnvironmentExtender = (env: BuidlerRuntimeEnvironment) => void;
 
+export type ConfigExtender = (
+  config: ResolvedBuidlerConfig,
+  userConfig: BuidlerConfig
+) => void;
+
 export interface TasksMap {
   [name: string]: TaskDefinition;
 }

--- a/packages/buidler-core/test/fixture-projects/config-extensions/buidler.config.js
+++ b/packages/buidler-core/test/fixture-projects/config-extensions/buidler.config.js
@@ -1,0 +1,9 @@
+extendConfig((config, userConfig) => {
+  config.values = [1];
+});
+
+extendConfig((config, userConfig) => {
+  config.values.push(2);
+});
+
+module.exports = {};

--- a/packages/buidler-core/test/fixture-projects/invalid-config-extension/buidler.config.js
+++ b/packages/buidler-core/test/fixture-projects/invalid-config-extension/buidler.config.js
@@ -1,0 +1,5 @@
+extendConfig((config, userConfig) => {
+  userConfig.networks.asd = 123;
+});
+
+module.exports = { networks: {} };

--- a/packages/buidler-core/test/internal/core/config/config-extensions.ts
+++ b/packages/buidler-core/test/internal/core/config/config-extensions.ts
@@ -1,0 +1,54 @@
+// extendConfig must be available
+// extendConfig shouldn't let me modify th user config
+// config extenders must run in order
+// config extensions must be visible
+
+import { assert } from "chai";
+
+import { BuidlerContext } from "../../../../src/internal/context";
+import { loadConfigAndTasks } from "../../../../src/internal/core/config/config-loading";
+import { ERRORS } from "../../../../src/internal/core/errors";
+import { resetBuidlerContext } from "../../../../src/internal/reset";
+import { useEnvironment } from "../../../helpers/environment";
+import { expectBuidlerError } from "../../../helpers/errors";
+import { useFixtureProject } from "../../../helpers/project";
+
+describe("Config extensions", function() {
+  describe("Valid extenders", function() {
+    useFixtureProject("config-extensions");
+    useEnvironment();
+
+    it("Should expose the new values", function() {
+      const config: any = this.env.config;
+      assert.isDefined(config.values);
+    });
+
+    it("Should execute extenders in order", function() {
+      const config: any = this.env.config;
+      assert.deepEqual(config.values, [1, 2]);
+    });
+  });
+
+  describe("Invalid extensions", function() {
+    useFixtureProject("invalid-config-extension");
+
+    beforeEach(function() {
+      BuidlerContext.createBuidlerContext();
+    });
+
+    afterEach(function() {
+      resetBuidlerContext();
+    });
+
+    it("Should throw the right error when trying to modify the user config", function() {
+      expectBuidlerError(
+        () => loadConfigAndTasks(),
+        ERRORS.GENERAL.USER_CONFIG_MODIFIED
+      );
+    });
+
+    it("Should have the right property path", function() {
+      assert.throws(() => loadConfigAndTasks(), "userConfig.networks.asd");
+    });
+  });
+});


### PR DESCRIPTION
This is a WIP PR that introduces a new function to the config environment. It works very similarly to `extendEnvironment`, but it's used to extend/resolve the config.

The function is called `extendConfig` for now. I'm not sold on that name.