### PR TITLE
Finish up #309

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -195,8 +195,8 @@ For example, adding an instance of Web3.js to the BRE can be done in this way:
 extendEnvironment(env => {
   env.Web3 = require("web3");
 
-  // env.ethereum is the EIP1193-compatible provider.
-  env.web3 = new env.Web3(new Web3HTTPProviderAdapter(env.ethereum));
+  // env.network.provider is the EIP1193-compatible provider.
+  env.web3 = new env.Web3(new Web3HTTPProviderAdapter(env.network.provider));
 });
 ```
 
@@ -252,7 +252,7 @@ The `networks` config field is an optional object where network names map to obj
 - `gasMultiplier`: A number used to multiply the results of gas estimation to give it some slack due to the uncertainty of the estimation process. Default: `1`.
 - `accounts`: This field controls which accounts Buidler uses. It can use the node's accounts (by setting it to `"remote"`), a list of local accounts (by setting it to an array of hex-encoded private keys), or use an HD Wallet (see below). Default value: `"remote"`.
 
-You can customize which network is used by default when running Buidler by setting the config's `defaultNetwork` field. If you omit this config, its default value will be `"develop"`. 
+You can customize which network is used by default when running Buidler by setting the config's `defaultNetwork` field. If you omit this config, its default value will be `"develop"`.
 
 ##### HD Wallet config
 

--- a/docs/guides/create-plugin.md
+++ b/docs/guides/create-plugin.md
@@ -49,7 +49,7 @@ This is literally all it takes to put together a plugin for Buidler. Injecting a
 
 ```js
 extendEnvironment(env => {
-  const wrapper = new EthersProviderWrapper(env.ethereum);
+  const wrapper = new EthersProviderWrapper(env.network.provider);
 
   env.ethers = {
     provider: wrapper,
@@ -63,7 +63,7 @@ extendEnvironment(env => {
     },
 
     signers: async function() {
-      const accounts = await env.ethereum.send("eth_accounts");
+      const accounts = await env.network.provider.send("eth_accounts");
 
       return accounts.map(account => wrapper.getSigner(account));
     }

--- a/packages/buidler-core/sample-project/scripts/sample-script.js
+++ b/packages/buidler-core/sample-project/scripts/sample-script.js
@@ -4,7 +4,7 @@ const env = require("@nomiclabs/buidler");
 async function main() {
   await env.run("compile");
 
-  const accounts = await env.ethereum.send("eth_accounts");
+  const accounts = await env.network.provider.send("eth_accounts");
 
   console.log("Accounts:", accounts);
 }

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -99,6 +99,12 @@ async function main() {
       unparsedCLAs
     );
 
+    // TODO: This is here for backwards compatibility
+    // There are very few projects using this.
+    if (buidlerArguments.network === undefined) {
+      buidlerArguments.network = config.defaultNetwork;
+    }
+
     const env = new Environment(
       config,
       buidlerArguments,

--- a/packages/buidler-core/src/internal/lib/buidler-lib.ts
+++ b/packages/buidler-core/src/internal/lib/buidler-lib.ts
@@ -26,7 +26,14 @@ if (BuidlerContext.isCreated()) {
     BUIDLER_PARAM_DEFINITIONS,
     process.env
   );
+
   const config = loadConfigAndTasks(buidlerArguments.config);
+
+  // TODO: This is here for backwards compatibility.
+  // There are very few projects using this.
+  if (buidlerArguments.network === undefined) {
+    buidlerArguments.network = config.defaultNetwork;
+  }
 
   env = new Environment(
     config,

--- a/packages/buidler-core/src/register.ts
+++ b/packages/buidler-core/src/register.ts
@@ -28,6 +28,12 @@ if (!BuidlerContext.isCreated()) {
 
   const config = loadConfigAndTasks(buidlerArguments.config);
 
+  // TODO: This is here for backwards compatibility.
+  // There are very few projects using this.
+  if (buidlerArguments.network === undefined) {
+    buidlerArguments.network = config.defaultNetwork;
+  }
+
   const env = new Environment(
     config,
     buidlerArguments,

--- a/packages/buidler-ethers/src/index.ts
+++ b/packages/buidler-ethers/src/index.ts
@@ -15,7 +15,7 @@ export default function() {
   extendEnvironment((env: BuidlerRuntimeEnvironment) => {
     env.ethers = {
       provider: lazyObject(() => {
-        return new EthersProviderWrapper(env.ethereum);
+        return new EthersProviderWrapper(env.network.provider);
       }),
       getContract: async (name: string): Promise<ContractFactory> => {
         const { ethers } = await import("ethers");

--- a/packages/buidler-ethers/test/ethers-provider-wrapper.ts
+++ b/packages/buidler-ethers/test/ethers-provider-wrapper.ts
@@ -13,7 +13,7 @@ describe("Ethers provider wrapper", function() {
 
   beforeEach(function() {
     realProvider = new JsonRpcProvider();
-    wrapper = new EthersProviderWrapper(this.env.ethereum);
+    wrapper = new EthersProviderWrapper(this.env.network.provider);
   });
 
   it("Should return the same as the real provider", async function() {
@@ -26,7 +26,7 @@ describe("Ethers provider wrapper", function() {
   it("Should return the same error", async function() {
     // We disable this test for RskJ
     // See: https://github.com/rsksmart/rskj/issues/876
-    const version = await this.env.ethereum.send("web3_clientVersion");
+    const version = await this.env.network.provider.send("web3_clientVersion");
     if (version.includes("RskJ")) {
       this.skip();
     }

--- a/packages/buidler-truffle4/test/tests.ts
+++ b/packages/buidler-truffle4/test/tests.ts
@@ -31,7 +31,7 @@ function assertIsContractInstance(
 
 function testArtifactsFunctionality() {
   beforeEach(async function() {
-    const version = await this.env.ethereum.send("web3_clientVersion");
+    const version = await this.env.network.provider.send("web3_clientVersion");
     // We only run these test on Ganache, see this:
     // https://github.com/ethereum/web3.js/issues/935
     if (!version.toLowerCase().includes("testrpc")) {

--- a/packages/buidler-web3-legacy/src/index.ts
+++ b/packages/buidler-web3-legacy/src/index.ts
@@ -14,7 +14,7 @@ export default function() {
   extendEnvironment(env => {
     env.Web3 = lazyFunction(() => require("web3"));
     env.web3 = lazyObject(
-      () => new env.Web3(new Web3HTTPProviderAdapter(env.ethereum))
+      () => new env.Web3(new Web3HTTPProviderAdapter(env.network.provider))
     );
     env.pweb3 = lazyObject(() => promisifyWeb3(env.web3));
   });

--- a/packages/buidler-web3-legacy/test/web3-provider-adapter.ts
+++ b/packages/buidler-web3-legacy/test/web3-provider-adapter.ts
@@ -31,7 +31,7 @@ describe("Web3 provider adapter", function() {
 
   beforeEach(function() {
     realWeb3Provider = new Web3.providers.HttpProvider("http://localhost:8545");
-    adaptedProvider = new Web3HTTPProviderAdapter(this.env.ethereum);
+    adaptedProvider = new Web3HTTPProviderAdapter(this.env.network.provider);
 
     assert.isDefined(this.env.web3);
   });
@@ -88,7 +88,7 @@ describe("Web3 provider adapter", function() {
   it("Should return the same on error", function(done) {
     // We disable this test for RskJ
     // See: https://github.com/rsksmart/rskj/issues/876
-    this.env.ethereum
+    this.env.network.provider
       .send("web3_clientVersion")
       .then(version => {
         if (version.includes("RskJ")) {
@@ -133,7 +133,7 @@ describe("Web3 provider adapter", function() {
 
           // We disable this test for RskJ
           // See: https://github.com/rsksmart/rskj/issues/876
-          this.env.ethereum
+          this.env.network.provider
             .send("web3_clientVersion")
             .then(version => {
               if (version.includes("RskJ")) {

--- a/packages/buidler-web3/src/index.ts
+++ b/packages/buidler-web3/src/index.ts
@@ -34,7 +34,7 @@ export default function() {
 
     env.Web3 = lazyFunction(() => require("web3"));
     env.web3 = lazyObject(
-      () => new env.Web3(new Web3HTTPProviderAdapter(env.ethereum))
+      () => new env.Web3(new Web3HTTPProviderAdapter(env.network.provider))
     );
   });
 }

--- a/packages/buidler-web3/test/web3-provider-adapter.ts
+++ b/packages/buidler-web3/test/web3-provider-adapter.ts
@@ -31,7 +31,7 @@ describe("Web3 provider adapter", function() {
 
   beforeEach(function() {
     realWeb3Provider = new Web3.providers.HttpProvider("http://localhost:8545");
-    adaptedProvider = new Web3HTTPProviderAdapter(this.env.ethereum);
+    adaptedProvider = new Web3HTTPProviderAdapter(this.env.network.provider);
   });
 
   it("Should always return true when isConnected is called", function() {
@@ -74,7 +74,7 @@ describe("Web3 provider adapter", function() {
   it("Should return the same on error", function(done) {
     // We disable this test for RskJ
     // See: https://github.com/rsksmart/rskj/issues/876
-    this.env.ethereum
+    this.env.network.provider
       .send("web3_clientVersion")
       .then(version => {
         if (version.includes("RskJ")) {
@@ -123,7 +123,7 @@ describe("Web3 provider adapter", function() {
 
           // We disable this test for RskJ
           // See: https://github.com/rsksmart/rskj/issues/876
-          this.env.ethereum
+          this.env.network.provider
             .send("web3_clientVersion")
             .then(version => {
               if (version.includes("RskJ")) {


### PR DESCRIPTION
This PR finishes up the work started in #309 by doing two things.

1) It assigns the default network to `buidlerArguments.network` if no value is present. This is not completely backward-compatible though, as it's type is now different.
2) Replaces all the uses `env.ethereum` for `env.network.provider`.