### PR TITLE
Don't parse a task's arguments just to print its help

### DIFF
--- a/packages/buidler-core/src/internal/core/params/buidler-params.ts
+++ b/packages/buidler-core/src/internal/core/params/buidler-params.ts
@@ -33,7 +33,7 @@ export const BUIDLER_PARAM_DEFINITIONS: BuidlerParamDefinitions = {
   help: {
     name: "help",
     defaultValue: false,
-    description: "Shows this message.",
+    description: "Shows this message, or a task's help if its name is provided",
     type: types.boolean,
     isFlag: true,
     isOptional: true,


### PR DESCRIPTION
This PR fixes the case where `npx buidler --help task` would fail because of missing or invalid arguments.