### PR TITLE
Remove web3x

### DIFF
--- a/config/typescript/@types/ethereumjs-tx/index.d.ts
+++ b/config/typescript/@types/ethereumjs-tx/index.d.ts
@@ -1,1 +1,0 @@
-declare module "ethereumjs-tx";

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -63,12 +63,16 @@
     "time-require": "^0.1.2"
   },
   "dependencies": {
+    "@types/bn.js": "^4.11.5",
+    "bip32": "^2.0.3",
+    "bip39": "^3.0.2",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
     "deepmerge": "^2.1.0",
     "download": "^7.1.0",
     "enquirer": "^2.3.0",
-    "ethereumjs-tx": "^1.3.7",
+    "ethereumjs-common": "^1.3.0",
+    "ethereumjs-tx": "^2.0.0",
     "ethereumjs-util": "^6.1.0",
     "find-up": "^2.1.0",
     "fp-ts": "1.19.3",
@@ -84,8 +88,7 @@
     "solidity-parser-antlr": "^0.4.2",
     "source-map-support": "^0.5.12",
     "ts-essentials": "^2.0.7",
-    "tsort": "0.0.1",
-    "web3x": "^2.0.0"
+    "tsort": "0.0.1"
   },
   "nyc": {
     "extension": [

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -57,6 +57,7 @@
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.123",
+    "@types/node-fetch": "^2.3.7",
     "@types/semver": "^5.5.0",
     "chai": "^4.2.0",
     "time-require": "^0.1.2"
@@ -77,6 +78,7 @@
     "is-installed-globally": "^0.2.0",
     "lodash": "^4.17.11",
     "mocha": "^5.2.0",
+    "node-fetch": "^2.6.0",
     "semver": "^5.6.0",
     "solc": "0.5.8",
     "solidity-parser-antlr": "^0.4.2",

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -297,6 +297,11 @@ Please check your internet connection and networks config`
     INVALID_JSON_RESPONSE: {
       number: 111,
       message: "Invalid JSON-RPC response received: %response%"
+    },
+    CANT_DERIVE_KEY: {
+      number: 112,
+      message:
+        "Cannot derive key %path% from mnemonic '%mnemonic%.\nTry using another mnemonic or deriving less keys."
     }
   },
   TASK_DEFINITIONS: {

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -283,6 +283,20 @@ You probably imported @nomiclabs/buidler instead of @nomiclabs/buidler/config`
       number: 108,
       message:
         "Received invalid value `%value%` from/to the node's JSON-RPC, but a Quantity was expected."
+    },
+    NODE_IS_NOT_RUNNING: {
+      number: 109,
+      message: `Cannot connect to the network %network%.
+Please make sure your node is running, and check your internet connection and networks config`
+    },
+    NETWORK_TIMEOUT: {
+      number: 110,
+      message: `Network connection timed-out.
+Please check your internet connection and networks config`
+    },
+    INVALID_JSON_RESPONSE: {
+      number: 111,
+      message: "Invalid JSON-RPC response received: %response%"
     }
   },
   TASK_DEFINITIONS: {

--- a/packages/buidler-core/src/internal/core/providers/accounts.ts
+++ b/packages/buidler-core/src/internal/core/providers/accounts.ts
@@ -1,28 +1,54 @@
-import { Account } from "web3x/account";
-import { Tx } from "web3x/eth";
+import { Transaction as TransactionT } from "ethereumjs-tx";
 
 import { IEthereumProvider } from "../../../types";
+import { deriveKeyFromMnemonicAndPath } from "../../util/keys-derivation";
 import { BuidlerError, ERRORS } from "../errors";
 
 import { createChainIdGetter } from "./provider-utils";
 import { wrapSend } from "./wrapper";
 
+export interface JsonRpcTransactionData {
+  from?: string;
+  to?: string;
+  gas?: string | number;
+  gasPrice?: string | number;
+  value?: string | number;
+  data?: string;
+  nonce?: string | number;
+}
+
 const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
 
 export function createLocalAccountsProvider(
   provider: IEthereumProvider,
-  privateKeys: string[]
+  hexPrivateKeys: string[]
 ) {
-  const { bufferToHex, toBuffer } = require("ethereumjs-util");
-  const accounts: Account[] = privateKeys.map(pkString =>
-    Account.fromPrivate(toBuffer(pkString))
-  );
+  const {
+    bufferToHex,
+    toBuffer,
+    privateToAddress
+  } = require("ethereumjs-util");
+
+  const privateKeys = hexPrivateKeys.map(h => toBuffer(h));
+  const addresses = privateKeys.map(pk => bufferToHex(privateToAddress(pk)));
 
   const getChainId = createChainIdGetter(provider);
 
+  function getPrivateKey(address: string): Buffer | undefined {
+    for (let i = 0; i < address.length; i++) {
+      if (addresses[i] === address.toLowerCase()) {
+        return privateKeys[i];
+      }
+    }
+  }
+
   return wrapSend(provider, async (method: string, params: any[]) => {
+    const { ecsign, hashPersonalMessage, toRpcSig } = await import(
+      "ethereumjs-util"
+    );
+
     if (method === "eth_accounts" || method === "eth_requestAccounts") {
-      return accounts.map(acc => acc.address.toLowerCase());
+      return [...addresses];
     }
 
     if (method === "eth_sign") {
@@ -33,22 +59,23 @@ export function createLocalAccountsProvider(
           throw new BuidlerError(ERRORS.NETWORK.ETHSIGN_MISSING_DATA_PARAM);
         }
 
-        const account = accounts.find(
-          acc => acc.address.toLowerCase() === address.toLowerCase()
-        );
+        const privateKey = getPrivateKey(address);
 
-        if (account === undefined) {
+        if (privateKey === undefined) {
           throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, {
             account: address
           });
         }
 
-        return account.sign(data).signature;
+        const messageHash = hashPersonalMessage(toBuffer(data));
+
+        const signature = ecsign(messageHash, privateKey);
+        return toRpcSig(signature.v, signature.r, signature.s);
       }
     }
 
     if (method === "eth_sendTransaction" && params.length > 0) {
-      const tx: Tx = params[0];
+      const tx: JsonRpcTransactionData = params[0];
 
       if (tx.gas === undefined) {
         throw new BuidlerError(
@@ -71,11 +98,9 @@ export function createLocalAccountsProvider(
         ]);
       }
 
-      const account = accounts.find(
-        acc => acc.address.toLowerCase() === tx.from!.toLowerCase()
-      );
+      const privateKey = getPrivateKey(tx.from!);
 
-      if (account === undefined) {
+      if (privateKey === undefined) {
         throw new BuidlerError(ERRORS.NETWORK.NOT_LOCAL_ACCOUNT, {
           account: tx.from
         });
@@ -83,14 +108,14 @@ export function createLocalAccountsProvider(
 
       const chainId = await getChainId();
 
-      const { default: Transaction } = await import("ethereumjs-tx");
-
-      // TODO: EIP155 works differently in ethereumjs-tx 2.0
-      const transaction = new Transaction({ ...tx, chainId });
-      transaction.sign(account.privateKey);
+      const rawTransaction = await getSignedTransaction(
+        tx,
+        chainId,
+        privateKey
+      );
 
       return provider.send("eth_sendRawTransaction", [
-        bufferToHex(transaction.serialize())
+        bufferToHex(rawTransaction)
       ]);
     }
 
@@ -113,18 +138,29 @@ export function createHDWalletProvider(
     hdpath += "/";
   }
 
-  const accounts: Account[] = [];
+  const privateKeys: Buffer[] = [];
+
   for (let i = initialIndex; i < initialIndex + count; i++) {
-    accounts.push(
-      Account.createFromMnemonicAndPath(mnemonic, hdpath + i.toString())
+    const privateKey = deriveKeyFromMnemonicAndPath(
+      mnemonic,
+      hdpath + i.toString()
     );
+
+    if (privateKey === undefined) {
+      throw new BuidlerError(ERRORS.NETWORK.CANT_DERIVE_KEY, {
+        mnemonic,
+        path: hdpath
+      });
+    }
+
+    privateKeys.push(privateKey);
   }
 
   const { bufferToHex } = require("ethereumjs-util");
 
   return createLocalAccountsProvider(
     provider,
-    accounts.map(account => bufferToHex(account.privateKey))
+    privateKeys.map(pk => bufferToHex(pk))
   );
 }
 
@@ -136,7 +172,7 @@ export function createSenderProvider(
 
   return wrapSend(provider, async (method: string, params: any[]) => {
     if (method === "eth_sendTransaction" || method === "eth_call") {
-      const tx: Tx = params[0];
+      const tx: JsonRpcTransactionData = params[0];
 
       if (tx !== undefined && tx.from === undefined) {
         const [senderAccount] = await getAccounts();
@@ -160,4 +196,36 @@ export function createSenderProvider(
     addresses = (await provider.send("eth_accounts")) as string[];
     return addresses;
   }
+}
+
+async function getSignedTransaction(
+  tx: JsonRpcTransactionData,
+  chainId: number,
+  privateKey: Buffer
+): Promise<Buffer> {
+  const chains = require("ethereumjs-common/dist/chains");
+
+  const { Transaction } = await import("ethereumjs-tx");
+  let transaction: TransactionT;
+
+  if (chains.chains.names[chainId] !== undefined) {
+    transaction = new Transaction(tx, { chain: chainId });
+  } else {
+    const { default: Common } = await import("ethereumjs-common");
+
+    const common = Common.forCustomChain(
+      "mainnet",
+      {
+        chainId,
+        networkId: chainId
+      },
+      "petersburg"
+    );
+
+    transaction = new Transaction(tx, { common });
+  }
+
+  transaction.sign(privateKey);
+
+  return transaction.serialize();
 }

--- a/packages/buidler-core/src/internal/core/providers/construction.ts
+++ b/packages/buidler-core/src/internal/core/providers/construction.ts
@@ -18,9 +18,6 @@ export function createProvider(
   networkName: string,
   networkConfig: NetworkConfig
 ): IEthereumProvider {
-  // These dependencies are lazy-loaded because they are really big.
-  // We use require() instead of import() here, because we need it to be sync.
-
   const netConfig = networkConfig as HttpNetworkConfig;
 
   const provider: IEthereumProvider = new HttpProvider(

--- a/packages/buidler-core/src/internal/core/providers/construction.ts
+++ b/packages/buidler-core/src/internal/core/providers/construction.ts
@@ -3,10 +3,10 @@ import {
   HttpNetworkConfig,
   IEthereumProvider,
   NetworkConfig,
-  NetworkConfigAccounts,
-  Networks
+  NetworkConfigAccounts
 } from "../../../types";
-import { BuidlerError, ERRORS } from "../errors";
+
+import { HttpProvider } from "./http";
 
 export function isHDAccountsConfig(
   accounts?: NetworkConfigAccounts
@@ -15,6 +15,7 @@ export function isHDAccountsConfig(
 }
 
 export function createProvider(
+  networkName: string,
   networkConfig: NetworkConfig
 ): IEthereumProvider {
   // These dependencies are lazy-loaded because they are really big.
@@ -22,8 +23,10 @@ export function createProvider(
 
   const netConfig = networkConfig as HttpNetworkConfig;
 
-  const { HttpProvider } = require("web3x/providers");
-  const provider: IEthereumProvider = new HttpProvider(netConfig.url!);
+  const provider: IEthereumProvider = new HttpProvider(
+    netConfig.url!,
+    networkName
+  );
 
   return wrapEthereumProvider(provider, netConfig);
 }

--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -1,0 +1,144 @@
+import { EventEmitter } from "events";
+
+import { BuidlerError, ERRORS } from "../errors";
+
+export interface JsonRpcRequest {
+  jsonrpc: string;
+  method: string;
+  params: any[];
+  id: number;
+}
+
+interface SuccessfulJsonRpcResponse {
+  jsonrpc: string;
+  id: number;
+  result: any;
+}
+
+interface FailedJsonRpcResponse {
+  jsonrpc: string;
+  id: number;
+  error: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+}
+
+export type JsonRpcResponse = SuccessfulJsonRpcResponse | FailedJsonRpcResponse;
+
+function isErrorResponse(response: any): response is FailedJsonRpcResponse {
+  return typeof response.error !== "undefined";
+}
+
+export class HttpProvider extends EventEmitter {
+  private _nextRequestId = 1;
+
+  constructor(
+    private readonly _url: string,
+    private readonly _networkName: string,
+    private readonly _extraHeaders: { [name: string]: string } = {},
+    private readonly _timeout = 3000
+  ) {
+    super();
+  }
+
+  public async send(method: string, params?: any[]): Promise<any> {
+    // We defined the error here to capture this stack traces at this point,
+    // the async call that follows would probably loose of the stack trace
+    const error = new Error();
+
+    const jsonRpcRequest = this._getJsonRpcRequest(method, params);
+    const jsonRpcResponse = await this._fetchJsonRpcResponse(jsonRpcRequest);
+
+    if (isErrorResponse(jsonRpcResponse)) {
+      error.message = jsonRpcResponse.error.message;
+      // tslint:disable-next-line only-buidler-error
+      throw error;
+    }
+
+    return jsonRpcResponse.result;
+  }
+
+  private async _fetchJsonRpcResponse(
+    request: JsonRpcRequest
+  ): Promise<JsonRpcResponse> {
+    const { default: fetch } = await import("node-fetch");
+
+    try {
+      const response = await fetch(this._url, {
+        method: "POST",
+        body: JSON.stringify(request),
+        redirect: "follow",
+        timeout: this._timeout,
+        headers: {
+          "Content-Type": "application/json",
+          ...this._extraHeaders
+        }
+      });
+
+      const json = await response.json();
+
+      if (!this._isValidJsonResponse(json)) {
+        throw new BuidlerError(ERRORS.NETWORK.INVALID_JSON_RESPONSE, {
+          response: await response.text()
+        });
+      }
+
+      return json;
+    } catch (error) {
+      if (error.code === "ECONNREFUSED") {
+        throw new BuidlerError(
+          ERRORS.NETWORK.NODE_IS_NOT_RUNNING,
+          { network: this._networkName },
+          error
+        );
+      }
+
+      if (error.type === "request-timeout") {
+        throw new BuidlerError(ERRORS.NETWORK.NETWORK_TIMEOUT, {}, error);
+      }
+
+      // tslint:disable-next-line only-buidler-error
+      throw error;
+    }
+  }
+
+  private _getJsonRpcRequest(
+    method: string,
+    params: any[] = []
+  ): JsonRpcRequest {
+    return {
+      jsonrpc: "2.0",
+      method,
+      params,
+      id: this._nextRequestId++
+    };
+  }
+
+  private _isValidJsonResponse(payload: any) {
+    if (payload.jsonrpc !== "2.0") {
+      return false;
+    }
+
+    if (typeof payload.id !== "number") {
+      return false;
+    }
+
+    if (payload.result === undefined && payload.error === undefined) {
+      return false;
+    }
+
+    if (payload.error !== undefined) {
+      if (typeof payload.error.code !== "number") {
+        return false;
+      }
+
+      if (typeof payload.error.message !== "string") {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -79,7 +79,7 @@ export class HttpProvider extends EventEmitter {
 
       const json = await response.json();
 
-      if (!this._isValidJsonResponse(json)) {
+      if (!isValidJsonResponse(json)) {
         throw new BuidlerError(ERRORS.NETWORK.INVALID_JSON_RESPONSE, {
           response: await response.text()
         });
@@ -115,30 +115,30 @@ export class HttpProvider extends EventEmitter {
       id: this._nextRequestId++
     };
   }
+}
 
-  private _isValidJsonResponse(payload: any) {
-    if (payload.jsonrpc !== "2.0") {
-      return false;
-    }
-
-    if (typeof payload.id !== "number") {
-      return false;
-    }
-
-    if (payload.result === undefined && payload.error === undefined) {
-      return false;
-    }
-
-    if (payload.error !== undefined) {
-      if (typeof payload.error.code !== "number") {
-        return false;
-      }
-
-      if (typeof payload.error.message !== "string") {
-        return false;
-      }
-    }
-
-    return true;
+export function isValidJsonResponse(payload: any) {
+  if (payload.jsonrpc !== "2.0") {
+    return false;
   }
+
+  if (typeof payload.id !== "number" && typeof payload.id !== "string") {
+    return false;
+  }
+
+  if (payload.result === undefined && payload.error === undefined) {
+    return false;
+  }
+
+  if (payload.error !== undefined) {
+    if (typeof payload.error.code !== "number") {
+      return false;
+    }
+
+    if (typeof payload.error.message !== "string") {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/buidler-core/src/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/src/internal/core/runtime-environment.ts
@@ -69,7 +69,9 @@ export class Environment implements BuidlerRuntimeEnvironment {
       });
     }
 
-    const provider = lazyObject(() => createProvider(networkConfig));
+    const provider = lazyObject(() =>
+      createProvider(networkName, networkConfig)
+    );
 
     this.network = {
       name: networkName,

--- a/packages/buidler-core/src/internal/util/keys-derivation.ts
+++ b/packages/buidler-core/src/internal/util/keys-derivation.ts
@@ -1,0 +1,13 @@
+import { fromSeed } from "bip32";
+import { mnemonicToSeedSync } from "bip39";
+
+export function deriveKeyFromMnemonicAndPath(
+  mnemonic: string,
+  hdPath: string
+): Buffer | undefined {
+  const seed = mnemonicToSeedSync(mnemonic);
+  const masterKey = fromSeed(seed);
+  const derived = masterKey.derivePath(hdPath);
+
+  return derived.privateKey;
+}

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -1,5 +1,5 @@
+import { EventEmitter } from "events";
 import { DeepPartial, Omit } from "ts-essentials";
-import { EthereumProvider } from "web3x/providers";
 
 import * as types from "./internal/core/params/argumentTypes";
 
@@ -251,14 +251,17 @@ export type ActionType<ArgsT extends TaskArguments> = (
   runSuper: RunSuperFunction<ArgsT>
 ) => Promise<any>;
 
-// TODO: This may not be the correct interface, see
-// https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640/31?u=alcuadrado
+export interface EthereumProvider extends EventEmitter {
+  send(method: string, params?: any[]): Promise<any>;
+}
+
+// This alias is here for backwards compatibility
 export type IEthereumProvider = EthereumProvider;
 
 export interface Network {
   name: string;
   config: NetworkConfig;
-  provider: IEthereumProvider;
+  provider: EthereumProvider;
 }
 
 export interface BuidlerRuntimeEnvironment {
@@ -267,7 +270,7 @@ export interface BuidlerRuntimeEnvironment {
   readonly tasks: TasksMap;
   readonly run: RunTaskFunction;
   readonly network: Network;
-  readonly ethereum: IEthereumProvider; // DEPRECATED: Use network.provider
+  readonly ethereum: EthereumProvider; // DEPRECATED: Use network.provider
 }
 
 /**

--- a/packages/buidler-core/test/internal/core/providers/accounts.ts
+++ b/packages/buidler-core/test/internal/core/providers/accounts.ts
@@ -1,12 +1,12 @@
 import { assert } from "chai";
 import { bufferToHex, privateToAddress, toBuffer } from "ethereumjs-util";
-import { Tx } from "web3x/eth";
 
 import { ERRORS } from "../../../../src/internal/core/errors";
 import {
   createHDWalletProvider,
   createLocalAccountsProvider,
-  createSenderProvider
+  createSenderProvider,
+  JsonRpcTransactionData
 } from "../../../../src/internal/core/providers/accounts";
 import { wrapSend } from "../../../../src/internal/core/providers/wrapper";
 import { IEthereumProvider } from "../../../../src/types";
@@ -321,7 +321,7 @@ describe("Account provider", () => {
   let mock: IEthereumProvider;
   let provider: IEthereumProvider;
   let wrapper: IEthereumProvider;
-  let tx: Tx;
+  let tx: JsonRpcTransactionData;
   beforeEach(() => {
     tx = {
       to: "0xb5bc06d4548a3ac17d72b372ae1e416bf65b8ead",

--- a/packages/buidler-core/test/internal/core/providers/construction.ts
+++ b/packages/buidler-core/test/internal/core/providers/construction.ts
@@ -1,6 +1,5 @@
 import { assert } from "chai";
 import Tx from "ethereumjs-tx";
-import { HttpProvider } from "web3x/providers";
 import { bufferToHex } from "web3x/utils";
 
 import { DEFAULT_GAS_MULTIPLIER } from "../../../../../buidler-truffle5/src/constants";
@@ -16,12 +15,10 @@ import {
   createFixedGasProvider,
   GANACHE_GAS_MULTIPLIER
 } from "../../../../src/internal/core/providers/gas-providers";
+import { HttpProvider } from "../../../../src/internal/core/providers/http";
 import { rpcQuantityToNumber } from "../../../../src/internal/core/providers/provider-utils";
 import { IEthereumProvider } from "../../../../src/types";
-import {
-  expectBuidlerError,
-  expectBuidlerErrorAsync
-} from "../../../helpers/errors";
+import { expectBuidlerErrorAsync } from "../../../helpers/errors";
 
 import { BasicGanacheMockProvider, BasicMockProvider } from "./mocks";
 
@@ -35,7 +32,7 @@ describe("Network config typeguards", async () => {
 
 describe("Base provider creation", () => {
   it("Should create a valid HTTP provider and wrap it", () => {
-    const provider = createProvider({ url: "http://localhost:8545" });
+    const provider = createProvider("net", { url: "http://localhost:8545" });
 
     assert.instanceOf(provider, HttpProvider);
   });

--- a/packages/buidler-core/test/internal/core/providers/construction.ts
+++ b/packages/buidler-core/test/internal/core/providers/construction.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import Tx from "ethereumjs-tx";
-import { bufferToHex } from "web3x/utils";
+import { bufferToHex } from "ethereumjs-util";
 
 import { DEFAULT_GAS_MULTIPLIER } from "../../../../../buidler-truffle5/src/constants";
 import { ERRORS } from "../../../../src/internal/core/errors";

--- a/packages/buidler-core/test/internal/core/providers/http.ts
+++ b/packages/buidler-core/test/internal/core/providers/http.ts
@@ -1,0 +1,168 @@
+import { assert } from "chai";
+
+import { isValidJsonResponse } from "../../../../src/internal/core/providers/http";
+
+describe("HttpProvider", function() {
+  describe("JSON-RPC response validation", function() {
+    describe("Invalid responses", function() {
+      it("Should validate the jsonrpc field", function() {
+        assert.isFalse(
+          isValidJsonResponse({
+            jsonrpc: "2.0.0",
+            id: 123,
+            result: "asd"
+          })
+        );
+
+        assert.isFalse(
+          isValidJsonResponse({
+            jsonrpc: 123,
+            id: 123,
+            result: "asd"
+          })
+        );
+
+        assert.isFalse(
+          isValidJsonResponse({
+            id: 123,
+            result: "asd"
+          })
+        );
+      });
+
+      it("Should validate the id field", function() {
+        assert.isFalse(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            result: "asd"
+          })
+        );
+
+        assert.isFalse(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: [],
+            result: "asd"
+          })
+        );
+
+        assert.isFalse(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: {},
+            result: "asd"
+          })
+        );
+      });
+
+      it("Should validate that only response or error are present", function() {
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: "123",
+            result: "asd",
+            error: {
+              code: 123,
+              message: "asd"
+            }
+          })
+        );
+      });
+    });
+
+    describe("Valid responses", function() {
+      it("Should be true for valid successful responses", function() {
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            result: "asd"
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: "123",
+            result: "asd"
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            result: { asd: 123 }
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            result: 123
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            result: [123]
+          })
+        );
+      });
+
+      it("Should be true for valid failure responses with data", function() {
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            error: {
+              code: 2,
+              message: "err"
+            }
+          })
+        );
+      });
+
+      it("Should be true for valid failure responses without data", function() {
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            error: {
+              code: 2,
+              message: "err",
+              data: 123
+            }
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            error: {
+              code: 2,
+              message: "err",
+              data: ["asd"]
+            }
+          })
+        );
+
+        assert.isTrue(
+          isValidJsonResponse({
+            jsonrpc: "2.0",
+            id: 123,
+            error: {
+              code: 2,
+              message: "err",
+              data: { a: 1 }
+            }
+          })
+        );
+      });
+    });
+  });
+});

--- a/packages/buidler-core/test/internal/util/keys-derivation.ts
+++ b/packages/buidler-core/test/internal/util/keys-derivation.ts
@@ -1,0 +1,26 @@
+import { assert } from "chai";
+import {
+  bufferToHex,
+  privateToAddress,
+  toChecksumAddress
+} from "ethereumjs-util";
+
+import { deriveKeyFromMnemonicAndPath } from "../../../src/internal/util/keys-derivation";
+
+describe("Keys derivation", function() {
+  describe("deriveKeyFromMnemonicAndPath", function() {
+    it("Should derive the right keys", function() {
+      const mnemonic =
+        "atom exist unusual amazing find assault penalty wall curve lunar promote cattle";
+      const path = "m/123/123'";
+
+      const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path);
+      const address = bufferToHex(privateToAddress(derivedPk!));
+
+      assert.equal(
+        toChecksumAddress(address),
+        "0x9CFE3206BD8beDC01c1f04E644eCd3e96a16F095"
+      );
+    });
+  });
+});

--- a/packages/buidler-ethers/test/ethers-provider-wrapper.ts
+++ b/packages/buidler-ethers/test/ethers-provider-wrapper.ts
@@ -39,7 +39,6 @@ describe("Ethers provider wrapper", function() {
         await wrapper.send("error_please", []);
         assert.fail("Wrapped provider should have failed");
       } catch (err2) {
-        console.log(err2);
         assert.deepEqual(err2.message, err.message);
       }
     }

--- a/packages/buidler-ethers/test/ethers-provider-wrapper.ts
+++ b/packages/buidler-ethers/test/ethers-provider-wrapper.ts
@@ -39,6 +39,7 @@ describe("Ethers provider wrapper", function() {
         await wrapper.send("error_please", []);
         assert.fail("Wrapped provider should have failed");
       } catch (err2) {
+        console.log(err2);
         assert.deepEqual(err2.message, err.message);
       }
     }


### PR DESCRIPTION
This PR removes web3x. The reasons to do that are:

1. We used very few parts of it, and it's not a small library.
2. We used a very old version.
3. It had some problems handling networking errors.

We replaced it with:

1. Our own HttpProvider based on `node-fetch`, which handles offline and unresponsive nodes correctly.
2. We use `ethereumjs-util`, `bip32` and `bip39` to derive keys and sign.

Fixes #276 

~~PS: This PR is based on #323~~