### PR TITLE
Implement --verbose Buidler argument

### DIFF
--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -63,6 +63,10 @@ async function main() {
       process.argv.slice(2)
     );
 
+    if (buidlerArguments.verbose) {
+      debug.enable("buidler*");
+    }
+
     if (buidlerArguments.emoji) {
       enableEmoji();
     }

--- a/packages/buidler-core/src/internal/core/params/buidler-params.ts
+++ b/packages/buidler-core/src/internal/core/params/buidler-params.ts
@@ -56,5 +56,14 @@ export const BUIDLER_PARAM_DEFINITIONS: BuidlerParamDefinitions = {
     isFlag: false,
     isOptional: true,
     isVariadic: false
+  },
+  verbose: {
+    name: "verbose",
+    defaultValue: false,
+    description: "Enables Buidler verbose logging",
+    type: types.boolean,
+    isFlag: true,
+    isOptional: true,
+    isVariadic: false
   }
 };

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -210,6 +210,7 @@ export interface BuidlerArguments {
   help: boolean;
   emoji: boolean;
   config?: string;
+  verbose: boolean;
 }
 
 export type BuidlerParamDefinitions = {

--- a/packages/buidler-core/test/internal/cli/ArgumentsParser.ts
+++ b/packages/buidler-core/test/internal/cli/ArgumentsParser.ts
@@ -28,7 +28,8 @@ describe("ArgumentsParser", () => {
       showStackTraces: false,
       version: false,
       help: false,
-      emoji: false
+      emoji: false,
+      verbose: false
     };
     taskDefinition = new SimpleTaskDefinition("compile", true)
       .addParam("param", "just a param", "a default value", string)

--- a/packages/buidler-core/test/internal/core/params/env-variables.ts
+++ b/packages/buidler-core/test/internal/core/params/env-variables.ts
@@ -82,6 +82,7 @@ describe("getEnvVariablesMap", () => {
         help: true,
         showStackTraces: true,
         version: false,
+        verbose: true,
         config: undefined // config is optional
       }),
       {
@@ -89,7 +90,8 @@ describe("getEnvVariablesMap", () => {
         BUIDLER_EMOJI: "false",
         BUIDLER_HELP: "true",
         BUIDLER_SHOW_STACK_TRACES: "true",
-        BUIDLER_VERSION: "false"
+        BUIDLER_VERSION: "false",
+        BUIDLER_VERBOSE: "true"
       }
     );
   });

--- a/packages/buidler-core/test/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/test/internal/core/runtime-environment.ts
@@ -49,7 +49,8 @@ describe("Environment", () => {
     showStackTraces: false,
     version: false,
     help: false,
-    emoji: false
+    emoji: false,
+    verbose: false
   };
 
   let tasks: TaskArguments;

--- a/packages/buidler-core/test/internal/core/tasks/task-definitions.ts
+++ b/packages/buidler-core/test/internal/core/tasks/task-definitions.ts
@@ -198,7 +198,8 @@ describe("SimpleTaskDefinition", () => {
           network: "",
           version: false,
           emoji: false,
-          help: false
+          help: false,
+          verbose: false
         };
 
         Object.keys(buidlerArgs).forEach(name => testClashWith(name));


### PR DESCRIPTION
This PR introduces a new Buidler argument that enables `debug`'s logs.