### PR TITLE
Create scripts/install.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ node_js:
   - "11"
 
 install:
-  - npm install
-  - npx lerna bootstrap --no-ci
+  - scripts/install.sh
 
 script:
   - npm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,7 @@ is the main project (i.e. the one that published as [@nomiclabs/buidler](npmjs.c
 
 To install this project you have to run:
 
-1. `npm install`
-2. `npx lerna bootstrap`
+1. `scripts/install.sh`
 
 ## Building the projects
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+npm install --no-package-lock
+npx lerna bootstrap --no-package-lock --no-ci


### PR DESCRIPTION
This PR introduces a new installation script. The main reason for it is to avoid using `package-lock.json`s