### PR TITLE
Don't kill Buidler in TASK_TEST nor TASK_RUN

### DIFF
--- a/packages/buidler-core/src/builtin-tasks/run.ts
+++ b/packages/buidler-core/src/builtin-tasks/run.ts
@@ -29,11 +29,10 @@ export default function() {
         }
 
         try {
-          const statusCode = await runScriptWithBuidler(
+          process.exitCode = await runScriptWithBuidler(
             buidlerArguments,
             script
           );
-          process.exit(statusCode);
         } catch (error) {
           throw new BuidlerError(
             ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,

--- a/packages/buidler-core/src/builtin-tasks/test.ts
+++ b/packages/buidler-core/src/builtin-tasks/test.ts
@@ -52,8 +52,7 @@ export default function() {
         mocha.run(resolve);
       });
 
-      const failures = await runPromise;
-      process.exit(failures);
+      process.exitCode = await runPromise;
     });
 
   task(TASK_TEST, "Runs mocha tests")

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -176,7 +176,7 @@ async function main() {
 }
 
 main()
-  .then(() => process.exit(0))
+  .then(() => process.exit(process.exitCode))
   .catch(error => {
     console.error(error);
     process.exit(1);

--- a/packages/buidler-core/test/builtin-tasks/run.ts
+++ b/packages/buidler-core/test/builtin-tasks/run.ts
@@ -10,23 +10,6 @@ describe("run task", function() {
   useFixtureProject("project-with-scripts");
   useEnvironment();
 
-  let exitCode: number | undefined;
-  let originalExit: (code?: number) => never;
-
-  before("Patch process.exit", function() {
-    originalExit = process.exit;
-
-    function patchedExit(code?: number) {
-      exitCode = code;
-    }
-
-    process.exit = patchedExit as any;
-  });
-
-  after("Unpatch process.exit", function() {
-    process.exit = originalExit;
-  });
-
   it("Should fail if a script doesn't exist", async function() {
     await expectBuidlerErrorAsync(
       () =>
@@ -41,8 +24,8 @@ describe("run task", function() {
       noCompile: true
     });
 
-    assert.equal(exitCode, 0);
-    exitCode = undefined;
+    assert.equal(process.exitCode, 0);
+    (process as any).exitCode = undefined;
   });
 
   it("Should compile before running", async function() {
@@ -57,8 +40,8 @@ describe("run task", function() {
     await this.env.run("run", {
       script: "./successful-script.js"
     });
-    assert.equal(exitCode, 0);
-    exitCode = undefined;
+    assert.equal(process.exitCode, 0);
+    (process as any).exitCode = undefined;
 
     const files = await fsExtra.readdir("artifacts");
     assert.deepEqual(files, ["A.json"]);
@@ -79,8 +62,8 @@ describe("run task", function() {
       script: "./successful-script.js",
       noCompile: true
     });
-    assert.equal(exitCode, 0);
-    exitCode = undefined;
+    assert.equal(process.exitCode, 0);
+    (process as any).exitCode = undefined;
 
     assert.isFalse(await fsExtra.pathExists("artifacts"));
   });
@@ -90,8 +73,8 @@ describe("run task", function() {
       script: "./successful-script.js",
       noCompile: true
     });
-    assert.equal(exitCode, 0);
-    exitCode = undefined;
+    assert.equal(process.exitCode, 0);
+    (process as any).exitCode = undefined;
   });
 
   it("Should return the script's status code on failure", async function() {
@@ -99,7 +82,7 @@ describe("run task", function() {
       script: "./failing-script.js",
       noCompile: true
     });
-    assert.notEqual(exitCode, 0);
-    exitCode = undefined;
+    assert.notEqual(process.exitCode, 0);
+    (process as any).exitCode = undefined;
   });
 });

--- a/packages/buidler-core/test/internal/core/typescript-support.ts
+++ b/packages/buidler-core/test/internal/core/typescript-support.ts
@@ -43,20 +43,9 @@ describe("Typescript support", function() {
     useEnvironment();
 
     it("Should run ts scripts", async function() {
-      let code: number | undefined;
-      const processExit = process.exit;
-
-      function patch(n: number | undefined) {
-        code = n;
-      }
-
-      process.exit = patch as any;
-
       await this.env.run("run", { script: "./script.ts", noCompile: true });
-
-      process.exit = processExit;
-
-      assert.equal(code, 123);
+      assert.equal(process.exitCode, 123);
+      (process as any).exitCode = undefined;
     });
   });
 


### PR DESCRIPTION
This PR changes the way `TASK_TEST` and `TASK_RUN` provide returns exit codes to the parent process. Previously, they called `process.exit`. They now set `process.exitCode`, and the CLI uses it.