### PR TITLE
Enable tslint rule `prefer-template` 

### DIFF
--- a/config/tslint/tslint.json
+++ b/config/tslint/tslint.json
@@ -14,6 +14,7 @@
     "no-empty": false,
     "no-console": false,
     "only-arrow-functions": false,
+    "prefer-template": true,
     "variable-name": [
       true,
       "check-format",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch": "tsc --build --watch packages/*/src",
     "clean": "lerna exec -- npm run clean",
     "test": "scripts/run-tests.sh",
-    "lint": "lerna exec -- npm run lint",
+    "lint": "lerna exec --no-bail -- npm run lint",
     "lint:fix": "lerna exec -- npm run lint:fix"
   },
   "dependencies": {}

--- a/packages/buidler-core/src/internal/artifacts.ts
+++ b/packages/buidler-core/src/internal/artifacts.ts
@@ -44,7 +44,7 @@ function getArtifactPath(artifactsPath: string, contractName: string): string {
 export async function saveArtifact(artifactsPath: string, artifact: Artifact) {
   await fsExtra.ensureDir(artifactsPath);
   await fsExtra.writeJSON(
-    artifactsPath + "/" + artifact.contractName + ".json",
+    path.join(artifactsPath, `${artifact.contractName}.json`),
     artifact,
     {
       spaces: 2

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -164,11 +164,11 @@ async function main() {
 
     if (BuidlerError.isBuidlerError(error)) {
       isBuidlerError = true;
-      console.error(chalk.red("Error " + error.message));
+      console.error(chalk.red(`Error ${error.message}`));
     } else if (BuidlerPluginError.isBuidlerPluginError(error)) {
       isBuidlerError = true;
       console.error(
-        chalk.red("Error in plugin " + error.pluginName + ": " + error.message)
+        chalk.red(`Error in plugin ${error.pluginName}: ${error.message}`)
       );
     } else if (error instanceof Error) {
       console.error(chalk.red("An unexpected error occurred:"));

--- a/packages/buidler-core/src/internal/cli/project-creation.ts
+++ b/packages/buidler-core/src/internal/cli/project-creation.ts
@@ -69,7 +69,8 @@ async function addGitIgnore(projectRoot: string) {
 
   if (await fsExtra.pathExists(gitIgnorePath)) {
     const existingContent = await fsExtra.readFile(gitIgnorePath, "utf-8");
-    content = existingContent + "\n" + content;
+    content = `${existingContent}
+${content}`;
   }
 
   await fsExtra.writeFile(gitIgnorePath, content);
@@ -86,7 +87,8 @@ async function addGitAttributes(projectRoot: string) {
       return;
     }
 
-    content = existingContent + "\n" + content;
+    content = `${existingContent}
+${content}`;
   }
 
   await fsExtra.writeFile(gitAttributesPath, content);

--- a/packages/buidler-core/src/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/src/internal/core/config/config-loading.ts
@@ -1,8 +1,6 @@
 import * as path from "path";
 
 import { ResolvedBuidlerConfig } from "../../../types";
-import { BuidlerContext } from "../../context";
-import { BuidlerError, ERRORS } from "../errors";
 import { loadPluginFile } from "../plugins";
 import { getUserConfigPath } from "../project-structure";
 
@@ -34,7 +32,7 @@ export function loadConfigAndTasks(configPath?: string): ResolvedBuidlerConfig {
     ([key, value]) => (globalAsAny[key] = value)
   );
 
-  loadPluginFile(__dirname + "/../tasks/builtin-tasks");
+  loadPluginFile(path.join(__dirname, "..", "tasks", "builtin-tasks"));
 
   const defaultConfig = importCsjOrEsModule("./default-config");
   const userConfig = importCsjOrEsModule(configPath);

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -18,14 +18,12 @@ function stringify(v: any): string {
 }
 
 function getContextPath(context: Context): string {
-  return (
-    context[0].type.name +
-    "." +
-    context
-      .slice(1)
-      .map(c => c.key)
-      .join(".")
-  );
+  const keysPath = context
+    .slice(1)
+    .map(c => c.key)
+    .join(".");
+
+  return `${context[0].type.name}.${keysPath}`;
 }
 
 function getMessage(e: ValidationError): string {
@@ -166,7 +164,8 @@ export function validateConfig(config: any) {
     return;
   }
 
-  const errorList = "  * " + errors.join("\n  * ");
+  let errorList = errors.join("\n  * ");
+  errorList = `  * ${errorList}`;
 
   throw new BuidlerError(ERRORS.GENERAL.INVALID_CONFIG, { errors: errorList });
 }

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -28,7 +28,7 @@ export class BuidlerError extends Error {
     messageArguments: { [p: string]: any } = {},
     parentError?: Error
   ) {
-    const prefix = ERROR_PREFIX + errorDescription.number.toString() + ": ";
+    const prefix = `${ERROR_PREFIX}${errorDescription.number}: `;
 
     const formattedMessage = applyErrorMessageTemplate(
       errorDescription.message,
@@ -516,22 +516,19 @@ Please check your internet connection and networks config`
     },
     MISSING_DEPENDENCY: {
       number: 801,
-      message:
-        "Plugin %plugin% requires %dependency% to be installed.\n%extraMessage%" +
-        "Please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%"
+      message: `Plugin %plugin% requires %dependency% to be installed.
+%extraMessage%Please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%`
     },
     DEPENDENCY_VERSION_MISMATCH: {
       number: 802,
-      message:
-        "Plugin %plugin% requires %dependency% version %versionSpec% but got %installedVersion%.\n%extraMessage%" +
-        "If you haven't installed %dependency% manually, please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%\n" +
-        "If you have installed %dependency% yourself, please reinstall it with a valid version."
+      message: `Plugin %plugin% requires %dependency% version %versionSpec% but got %installedVersion%.
+%extraMessage%If you haven't installed %dependency% manually, please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%
+If you have installed %dependency% yourself, please reinstall it with a valid version.`
     },
     OLD_STYLE_IMPORT_DETECTED: {
       number: 803,
-      message:
-        "You are trying to load %pluginNameText% with a require or import statement.\n" +
-        'Please replace it with a call to usePlugin("%pluginNameCode%").'
+      message: `You are trying to load %pluginNameText% with a require or import statement.
+Please replace it with a call to usePlugin("%pluginNameCode%").`
     }
   },
   INTERNAL: {

--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -126,7 +126,7 @@ export const inputFile: ArgumentType<string> = {
       if (stats.isDirectory()) {
         // This is caught and encapsulated in a buidler error.
         // tslint:disable-next-line only-buidler-error
-        throw new Error(strValue + " is a directory, not a file");
+        throw new Error(`${strValue} is a directory, not a file`);
       }
     } catch (error) {
       throw new BuidlerError(

--- a/packages/buidler-core/src/internal/core/providers/provider-utils.ts
+++ b/packages/buidler-core/src/internal/core/providers/provider-utils.ts
@@ -21,7 +21,8 @@ export function rpcQuantityToNumber(quantity?: string) {
 }
 
 export function numberToRpcQuantity(n: number) {
-  return "0x" + n.toString(16);
+  const hex = n.toString(16);
+  return `0x${hex}`;
 }
 
 export function createChainIdGetter(provider: IEthereumProvider) {

--- a/packages/buidler-core/src/internal/core/tasks/builtin-tasks.ts
+++ b/packages/buidler-core/src/internal/core/tasks/builtin-tasks.ts
@@ -1,11 +1,33 @@
+import path from "path";
+
 import { loadPluginFile } from "../plugins";
 
 export default function() {
-  loadPluginFile(__dirname + "/../../../builtin-tasks/clean");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/compile");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/console");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/flatten");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/help");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/run");
-  loadPluginFile(__dirname + "/../../../builtin-tasks/test");
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "clean")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "compile")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "console")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "flatten")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "help")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "run")
+  );
+
+  loadPluginFile(
+    path.join(__dirname, "..", "..", "..", "builtin-tasks", "test")
+  );
 }

--- a/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/src/internal/solidity/compiler/downloader.ts
@@ -23,7 +23,7 @@ export interface CompilersList {
 const COMPILER_FILES_DIR_URL =
   "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/";
 
-const COMPILERS_LIST_URL = COMPILER_FILES_DIR_URL + "list.json";
+const COMPILERS_LIST_URL = `${COMPILER_FILES_DIR_URL}list.json`;
 
 async function downloadFile(
   url: string,
@@ -128,7 +128,7 @@ export class CompilerDownloader {
     compilerBuild: CompilerBuild,
     downloadedFilePath: string
   ) {
-    console.debug("Downloading compiler version " + compilerBuild.version);
+    console.debug(`Downloading compiler version ${compilerBuild.version}`);
 
     const compilerUrl = COMPILER_FILES_DIR_URL + compilerBuild.path;
 
@@ -155,8 +155,9 @@ export class CompilerDownloader {
     const expectedKeccak256 = compilerBuild.keccak256;
     const compiler = await fsExtra.readFile(downloadedFilePath);
 
-    const compilerKeccak256 =
-      "0x" + ethereumjsUtil.keccak(compiler).toString("hex");
+    const compilerKeccak256 = ethereumjsUtil.bufferToHex(
+      ethereumjsUtil.keccak(compiler)
+    );
 
     if (expectedKeccak256 !== compilerKeccak256) {
       await fsExtra.unlink(downloadedFilePath);

--- a/packages/buidler-core/src/internal/solidity/resolver.ts
+++ b/packages/buidler-core/src/internal/solidity/resolver.ts
@@ -154,7 +154,7 @@ export class Resolver {
         }
 
         const globalName = path.normalize(
-          path.dirname(from.globalName) + "/" + imported
+          path.join(path.dirname(from.globalName), imported)
         );
 
         const isIllegal = !globalName.startsWith(from.library.name + path.sep);

--- a/packages/buidler-core/src/internal/util/packageInfo.ts
+++ b/packages/buidler-core/src/internal/util/packageInfo.ts
@@ -26,5 +26,5 @@ function findClosestPackageJson(file: string): string | null {
 
 export async function getPackageJson(): Promise<PackageJson> {
   const root = await getPackageRoot();
-  return fsExtra.readJSON(root + "/package.json");
+  return fsExtra.readJSON(path.join(root, "package.json"));
 }

--- a/packages/buidler-core/src/internal/util/scripts-runner.ts
+++ b/packages/buidler-core/src/internal/util/scripts-runner.ts
@@ -1,4 +1,5 @@
 import debug from "debug";
+import path from "path";
 
 import { BuidlerArguments } from "../../types";
 import { ExecutionMode, getExecutionMode } from "../core/execution-mode";
@@ -43,12 +44,16 @@ export async function runScriptWithBuidler(
   extraNodeArgs: string[] = [],
   extraEnvVars: { [name: string]: string } = {}
 ): Promise<number> {
-  log("Creating Buidler subprocess to run " + scriptPath);
+  log(`Creating Buidler subprocess to run ${scriptPath}`);
 
   return runScript(
     scriptPath,
     scriptArgs,
-    [...extraNodeArgs, "--require", __dirname + "/../../register"],
+    [
+      ...extraNodeArgs,
+      "--require",
+      path.join(__dirname, "..", "..", "register")
+    ],
     {
       ...getEnvVariablesMap(buidlerArguments),
       ...extraEnvVars

--- a/packages/buidler-core/src/internal/util/strings.ts
+++ b/packages/buidler-core/src/internal/util/strings.ts
@@ -16,7 +16,7 @@ export function pluralize(n: number, singular: string, plural?: string) {
     return plural;
   }
 
-  return singular + "s";
+  return `${singular}s`;
 }
 
 /**

--- a/packages/buidler-core/test/helpers/fs.ts
+++ b/packages/buidler-core/test/helpers/fs.ts
@@ -1,5 +1,6 @@
 import fsExtra from "fs-extra";
 import * as os from "os";
+import path from "path";
 
 declare module "mocha" {
   interface Context {
@@ -9,7 +10,7 @@ declare module "mocha" {
 
 async function getEmptyTmpDir(nameHint: string) {
   const tmpDirContainer = os.tmpdir();
-  const tmpDir = tmpDirContainer + "/buidler-tests-" + nameHint;
+  const tmpDir = path.join(tmpDirContainer, `buidler-tests-${nameHint}`);
   await fsExtra.ensureDir(tmpDir);
   await fsExtra.emptyDir(tmpDir);
 

--- a/packages/buidler-core/test/helpers/project.ts
+++ b/packages/buidler-core/test/helpers/project.ts
@@ -1,4 +1,5 @@
 import * as fsExtra from "fs-extra";
+import path from "path";
 
 /**
  * This helper adds mocha hooks to run the tests inside one of the projects
@@ -27,7 +28,12 @@ export function useFixtureProject(projectName: string) {
 export async function getFixtureProjectPath(
   projectName: string
 ): Promise<string> {
-  const projectPath = __dirname + "/../fixture-projects/" + projectName;
+  const projectPath = path.join(
+    __dirname,
+    "..",
+    "fixture-projects",
+    projectName
+  );
   if (!(await fsExtra.pathExists(projectPath))) {
     throw new Error(`Fixture project ${projectName} doesn't exist`);
   }

--- a/packages/buidler-core/test/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/test/internal/core/config/config-loading.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import * as path from "path";
+import path from "path";
 
 import { TASK_CLEAN } from "../../../../src/builtin-tasks/task-names";
 import { BuidlerContext } from "../../../../src/internal/context";
@@ -69,7 +69,7 @@ describe("config loading", function() {
 
     it("should accept an absolute path", async function() {
       const fixtureDir = await getFixtureProjectPath("custom-config-file");
-      const config = loadConfigAndTasks(fixtureDir + "/config.js");
+      const config = loadConfigAndTasks(path.join(fixtureDir, "config.js"));
 
       assert.equal(
         config.paths.configFile,

--- a/packages/buidler-core/test/internal/core/config/config-resolution.ts
+++ b/packages/buidler-core/test/internal/core/config/config-resolution.ts
@@ -96,7 +96,7 @@ describe("Config resolution", () => {
         root: "blah"
       });
 
-      assert.equal(paths.root, __dirname + "/blah");
+      assert.equal(paths.root, path.join(__dirname, "blah"));
     });
 
     it("Should resolve the rest relative to the root", () => {
@@ -109,22 +109,22 @@ describe("Config resolution", () => {
         tests: "t"
       });
 
-      const root = __dirname + "/blah";
+      const root = path.join(__dirname, "blah");
       assert.equal(paths.root, root);
-      assert.equal((paths as any).asdf, root + "/asd");
-      assert.equal(paths.sources, root + "/c");
-      assert.equal(paths.artifacts, root + "/a");
-      assert.equal(paths.cache, root + "/ca");
-      assert.equal(paths.tests, root + "/t");
+      assert.equal((paths as any).asdf, path.join(root, "asd"));
+      assert.equal(paths.sources, path.join(root, "c"));
+      assert.equal(paths.artifacts, path.join(root, "a"));
+      assert.equal(paths.cache, path.join(root, "ca"));
+      assert.equal(paths.tests, path.join(root, "t"));
     });
 
     it("Should have the right default values", () => {
       const paths = resolveProjectPaths(__filename);
       assert.equal(paths.root, __dirname);
-      assert.equal(paths.sources, __dirname + "/contracts");
-      assert.equal(paths.artifacts, __dirname + "/artifacts");
-      assert.equal(paths.cache, __dirname + "/cache");
-      assert.equal(paths.tests, __dirname + "/test");
+      assert.equal(paths.sources, path.join(__dirname, "contracts"));
+      assert.equal(paths.artifacts, path.join(__dirname, "artifacts"));
+      assert.equal(paths.cache, path.join(__dirname, "cache"));
+      assert.equal(paths.tests, path.join(__dirname, "test"));
     });
   });
 });

--- a/packages/buidler-core/test/internal/core/errors.ts
+++ b/packages/buidler-core/test/internal/core/errors.ts
@@ -56,7 +56,7 @@ describe("BuilderError", () => {
 
     it("should have the right error message", () => {
       const error = new BuidlerError(mockErrorDescription);
-      assert.equal(error.message, "BDLR123: " + mockErrorDescription.message);
+      assert.equal(error.message, `BDLR123: ${mockErrorDescription.message}`);
     });
 
     it("should format the error message with the template params", () => {

--- a/packages/buidler-core/test/internal/core/plugins.ts
+++ b/packages/buidler-core/test/internal/core/plugins.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import path from "path";
 
 import { BuidlerContext } from "../../../src/internal/context";
 import { ERRORS } from "../../../src/internal/core/errors";
@@ -10,8 +11,13 @@ import {
 import { expectBuidlerError } from "../../helpers/errors";
 
 describe("plugin system", function() {
-  const FIXTURE_PROJECT_PATH =
-    __dirname + "/../../fixture-projects/plugin-loading-project";
+  const FIXTURE_PROJECT_PATH = path.join(
+    __dirname,
+    "..",
+    "..",
+    "fixture-projects",
+    "plugin-loading-project"
+  );
 
   describe("readPackageJson", function() {
     function assertPackageLoaded(packageName: string, version: string) {
@@ -46,7 +52,12 @@ describe("plugin system", function() {
 
     it("Should work when the plugin exports a function", function() {
       loadPluginFile(
-        FIXTURE_PROJECT_PATH + "/node_modules/pack1/plugin-with-function.js"
+        path.join(
+          FIXTURE_PROJECT_PATH,
+          "node_modules",
+          "pack1",
+          "plugin-with-function.js"
+        )
       );
 
       assert.isTrue(globalAsAny.loaded);
@@ -54,8 +65,12 @@ describe("plugin system", function() {
 
     it("Should work when the plugin exports a function with exports.default", function() {
       loadPluginFile(
-        FIXTURE_PROJECT_PATH +
-          "/node_modules/pack1/plugin-with-function-default-export.js"
+        path.join(
+          FIXTURE_PROJECT_PATH,
+          "node_modules",
+          "pack1",
+          "plugin-with-function-default-export.js"
+        )
       );
 
       assert.isTrue(globalAsAny.loaded);
@@ -63,7 +78,12 @@ describe("plugin system", function() {
 
     it("Should work when the plugin doesn't export a function", function() {
       loadPluginFile(
-        FIXTURE_PROJECT_PATH + "/node_modules/pack1/plugin-without-function.js"
+        path.join(
+          FIXTURE_PROJECT_PATH,
+          "node_modules",
+          "pack1",
+          "plugin-without-function.js"
+        )
       );
 
       assert.isTrue(globalAsAny.loaded);
@@ -72,8 +92,10 @@ describe("plugin system", function() {
 
   describe("loadPluginFile", function() {
     const globalAsAny = global as any;
-    const projectPath =
-      FIXTURE_PROJECT_PATH + "/doesnt-need-to-exist-config.js";
+    const projectPath = path.join(
+      FIXTURE_PROJECT_PATH,
+      "doesnt-need-to-exist-config.js"
+    );
     let ctx: BuidlerContext;
 
     beforeEach(function() {
@@ -131,7 +153,12 @@ describe("plugin system", function() {
     const globalAsAny = global as any;
 
     const pluginFile = require.resolve(
-      FIXTURE_PROJECT_PATH + "/node_modules/validates-import-style/index.js"
+      path.join(
+        FIXTURE_PROJECT_PATH,
+        "node_modules",
+        "validates-import-style",
+        "index.js"
+      )
     );
 
     afterEach(function() {

--- a/packages/buidler-core/test/internal/core/project-structure.ts
+++ b/packages/buidler-core/test/internal/core/project-structure.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import * as fsExtra from "fs-extra";
+import path from "path";
 
 import { ERRORS } from "../../../src/internal/core/errors";
 import {
@@ -40,24 +41,32 @@ describe("project structure", () => {
 
     describe("Inside a project", () => {
       useFixtureProject("default-config-project");
-      let path: string;
+      let configPath: string;
 
       before("get root path", async () => {
         // TODO: This is no longer needed once PR #71 gets merged
         const pathToFixtureRoot = await fsExtra.realpath(
-          __dirname + "/../../fixture-projects/default-config-project"
+          path.join(
+            __dirname,
+            "..",
+            "..",
+            "fixture-projects",
+            "default-config-project"
+          )
         );
 
-        path = await fsExtra.realpath(pathToFixtureRoot + "/buidler.config.js");
+        configPath = await fsExtra.realpath(
+          path.join(pathToFixtureRoot, "buidler.config.js")
+        );
       });
 
       it("should work from the project root", () => {
-        assert.equal(getUserConfigPath(), path);
+        assert.equal(getUserConfigPath(), configPath);
       });
 
       it("should work from deeper inside the project", () => {
         process.chdir("contracts");
-        assert.equal(getUserConfigPath(), path);
+        assert.equal(getUserConfigPath(), configPath);
       });
     });
   });
@@ -66,7 +75,7 @@ describe("project structure", () => {
 describe("getRecommendedGitIgnore", () => {
   it("Should return the one from this repo", async () => {
     const content = await fsExtra.readFile(
-      __dirname + "/../../../recommended-gitignore.txt",
+      path.join(__dirname, "..", "..", "..", "recommended-gitignore.txt"),
       "utf-8"
     );
 

--- a/packages/buidler-core/test/internal/core/providers/mocks.ts
+++ b/packages/buidler-core/test/internal/core/providers/mocks.ts
@@ -96,6 +96,6 @@ export class ChainIdMockProvider extends EventEmitter
       return numberToRpcQuantity(this._netVersion);
     }
 
-    throw new Error("Unsupported method " + method);
+    throw new Error(`Unsupported method ${method}`);
   }
 }

--- a/packages/buidler-core/test/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/test/internal/core/runtime-environment.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import path from "path";
 
 import { BuidlerContext } from "../../../src/internal/context";
 import { ERRORS } from "../../../src/internal/core/errors";
@@ -166,7 +167,7 @@ describe("Environment", () => {
     useFixtureProject("plugin-project");
 
     it("environment should contains plugin extensions", async () => {
-      require(process.cwd() + "/plugins/example");
+      require(path.join(process.cwd(), "plugins", "example"));
       const ctx = BuidlerContext.getBuidlerContext();
       env = new Environment(
         config,

--- a/packages/buidler-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/buidler-core/test/internal/solidity/compiler/downloader.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import fsExtra from "fs-extra";
+import path from "path";
 
 import { ERRORS } from "../../../../src/internal/core/errors";
 import {
@@ -67,7 +68,7 @@ describe("Compiler downloader", function() {
 
     it("Should throw if the download was unsuccessful, and delete it", async function() {
       const compilersDir = this.tmpDir;
-      const corruptCompilerBin = compilersDir + "/asd";
+      const corruptCompilerBin = path.join(compilersDir, "asd");
       await fsExtra.createFile(corruptCompilerBin);
 
       const downloader = new CompilerDownloader(
@@ -90,7 +91,7 @@ describe("Compiler downloader", function() {
   describe("Compiler download", function() {
     it("should call the download function with the right params", async function() {
       const compilersDir = this.tmpDir;
-      const downloadPath = compilersDir + "/downloadedCompiler";
+      const downloadPath = path.join(compilersDir, "downloadedCompiler");
       const expectedUrl = `https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/${localCompilerBuild.path}`;
 
       let urlUsed: string | undefined;
@@ -99,9 +100,9 @@ describe("Compiler downloader", function() {
       const downloader = new CompilerDownloader(
         compilersDir,
         getLocalCompilerVersion(),
-        async (url, path) => {
+        async (url, compilerPath) => {
           urlUsed = url;
-          pathUsed = path;
+          pathUsed = compilerPath;
         }
       );
 
@@ -113,12 +114,12 @@ describe("Compiler downloader", function() {
 
     it("Should throw the right error if the download fails", async function() {
       const compilersDir = this.tmpDir;
-      const downloadPath = compilersDir + "/downloadedCompiler";
+      const downloadPath = path.join(compilersDir, "downloadedCompiler");
 
       const downloader = new CompilerDownloader(
         compilersDir,
         getLocalCompilerVersion(),
-        async (url, path) => {
+        async (url, compilerPath) => {
           throw new Error("Expected");
         }
       );
@@ -141,23 +142,23 @@ describe("Compiler downloader", function() {
       const downloader = new CompilerDownloader(
         compilersDir,
         getLocalCompilerVersion(),
-        async (url, path) => {
+        async (url, compilerPath) => {
           urlUsed = url;
-          pathUsed = path;
+          pathUsed = compilerPath;
         }
       );
 
       await downloader.downloadCompilersList();
 
       assert.equal(urlUsed, expectedUrl);
-      assert.equal(pathUsed, compilersDir + "/list.json");
+      assert.equal(pathUsed, path.join(compilersDir, "list.json"));
     });
 
     it("Should throw the right error if the download fails", async function() {
       const downloader = new CompilerDownloader(
         this.tmpDir,
         getLocalCompilerVersion(),
-        async (url, path) => {
+        async (url, compilerPath) => {
           throw new Error("Expected");
         }
       );
@@ -172,7 +173,7 @@ describe("Compiler downloader", function() {
   describe("Compilers list exists", function() {
     it("Should return true if it does", async function() {
       const compilersDir = this.tmpDir;
-      await fsExtra.createFile(compilersDir + "/list.json");
+      await fsExtra.createFile(path.join(compilersDir, "list.json"));
 
       const downloader = new CompilerDownloader(
         compilersDir,
@@ -217,7 +218,10 @@ describe("Compiler downloader", function() {
     });
 
     async function saveMockCompilersList() {
-      await fsExtra.outputJSON(compilersDir + "/list.json", mockCompilerList);
+      await fsExtra.outputJSON(
+        path.join(compilersDir, "list.json"),
+        mockCompilerList
+      );
     }
 
     describe("When there's an already downloaded list", function() {
@@ -298,10 +302,13 @@ describe("Compiler downloader", function() {
     beforeEach(async function() {
       compilersDir = this.tmpDir;
 
-      downloadedPath = compilersDir + "/" + localCompilerBuild.path;
+      downloadedPath = path.join(compilersDir, localCompilerBuild.path);
 
       downloadCalled = false;
-      await fsExtra.outputJSON(compilersDir + "/list.json", mockCompilerList);
+      await fsExtra.outputJSON(
+        path.join(compilersDir, "list.json"),
+        mockCompilerList
+      );
 
       mockDownloader = new CompilerDownloader(
         compilersDir,
@@ -319,10 +326,10 @@ describe("Compiler downloader", function() {
         const compilerBin = require.resolve("solc/soljson.js");
         await fsExtra.copy(compilerBin, downloadedPath);
 
-        const path = await mockDownloader.getDownloadedCompilerPath(
+        const compilerPath = await mockDownloader.getDownloadedCompilerPath(
           localCompilerBuild.version
         );
-        assert.equal(path, downloadedPath);
+        assert.equal(compilerPath, downloadedPath);
       });
 
       it("Should throw and delete it if it doesn't", async function() {

--- a/packages/buidler-core/test/internal/solidity/dependencyGraph.ts
+++ b/packages/buidler-core/test/internal/solidity/dependencyGraph.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import * as fs from "fs";
+import path from "path";
 
 import { DependencyGraph } from "../../../src/internal/solidity/dependencyGraph";
 import {
@@ -51,56 +52,56 @@ describe("Dependency Graph", function() {
 
     fileWithoutDependencies = new ResolvedFile(
       "contracts/WD.sol",
-      projectRoot + "/contracts/WD.sol",
+      path.join(projectRoot, "contracts", "WD.sol"),
       "no dependecy",
       new Date()
     );
 
     fileWithoutDependencies2 = new ResolvedFile(
       "contracts/WD2.sol",
-      projectRoot + "/contracts/WD2.sol",
+      path.join(projectRoot, "contracts", "WD2.sol"),
       "no dependecy",
       new Date()
     );
 
     fileWithoutDependencies3 = new ResolvedFile(
       "contracts/WD3.sol",
-      projectRoot + "/contracts/WD3.sol",
+      path.join(projectRoot, "contracts", "WD3.sol"),
       "no dependecy",
       new Date()
     );
 
     dependsOnWDAndW2 = new ResolvedFile(
       "contracts/dependsOnWDAndW2.sol",
-      projectRoot + "/contracts/dependsOnWDAndW2.sol",
+      path.join(projectRoot, "contracts", "dependsOnWDAndW2.sol"),
       'import "./WD.sol"; import "./WD2.sol";',
       new Date()
     );
 
     dependsOnWD = new ResolvedFile(
       "contracts/dependsOnWD.sol",
-      projectRoot + "/contracts/dependsOnWD.sol",
+      path.join(projectRoot, "contracts", "dependsOnWD.sol"),
       'import "./WD.sol";',
       new Date()
     );
 
     loop1 = new ResolvedFile(
       "contracts/loop1.sol",
-      projectRoot + "/contracts/loop1.sol",
+      path.join(projectRoot, "contracts", "loop1.sol"),
       'import "./loop2.sol";',
       new Date()
     );
 
     loop2 = new ResolvedFile(
       "contracts/loop2.sol",
-      projectRoot + "/contracts/loop2.sol",
+      path.join(projectRoot, "contracts", "loop2.sol"),
       'import "./loop1.sol";',
       new Date()
     );
 
     dependsOnLoop2 = new ResolvedFile(
       "contracts/dependsOnLoop2.sol",
-      projectRoot + "/contracts/dependsOnLoop2.sol",
+      path.join(projectRoot, "contracts", "dependsOnLoop2.sol"),
       'import "./loop2.sol";',
       new Date()
     );
@@ -118,7 +119,7 @@ describe("Dependency Graph", function() {
           return loop2;
 
         default:
-          throw new Error(imported + " is not mocked");
+          throw new Error(`${imported} is not mocked`);
       }
     };
   });

--- a/packages/buidler-core/test/internal/solidity/resolver.ts
+++ b/packages/buidler-core/test/internal/solidity/resolver.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import * as fsExtra from "fs-extra";
+import path from "path";
 
 import { ERRORS } from "../../../src/internal/core/errors";
 import { getImports } from "../../../src/internal/solidity/imports";
@@ -83,7 +84,7 @@ describe("Resolved file", function() {
     it("Should add the version if the file is from a library", function() {
       assert.equal(
         resolvedFileWithLibrary.getVersionedName(),
-        globalName + "@v" + libraryVersion
+        `${globalName}@v${libraryVersion}`
       );
     });
   });
@@ -195,7 +196,15 @@ describe("Resolver", function() {
       await expectBuidlerErrorAsync(
         () =>
           resolver.resolveProjectSourceFile(
-            __dirname + "/../../../sample-project/contracts/Greeter.sol"
+            path.join(
+              __dirname,
+              "..",
+              "..",
+              "..",
+              "sample-project",
+              "contracts",
+              "Greeter.sol"
+            )
           ),
         ERRORS.RESOLVER.FILE_OUTSIDE_PROJECT
       );

--- a/packages/buidler-core/test/internal/util/packageInfo.ts
+++ b/packages/buidler-core/test/internal/util/packageInfo.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import fsExtra from "fs-extra";
+import path from "path";
 
 import {
   getPackageJson,
@@ -15,7 +16,7 @@ describe("packageInfo", () => {
   });
 
   it("should give the right package root", async () => {
-    const root = await fsExtra.realpath(__dirname + "/../../..");
+    const root = await fsExtra.realpath(path.join(__dirname, "..", "..", ".."));
     assert.equal(await getPackageRoot(), root);
   });
 });

--- a/packages/buidler-core/test/internal/util/scripts-runner.ts
+++ b/packages/buidler-core/test/internal/util/scripts-runner.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import path from "path";
 
 import {
   runScript,
@@ -31,7 +32,7 @@ describe("Scripts runner", function() {
     const statusCode1 = await runScript(
       "./async-script.js",
       [],
-      ["--require", __dirname + "/../../../src/register"]
+      ["--require", path.join(__dirname, "..", "..", "..", "src", "register")]
     );
     assert.equal(statusCode1, 0);
 
@@ -41,7 +42,7 @@ describe("Scripts runner", function() {
     const statusCode3 = await runScript(
       "./successful-script.js",
       [],
-      ["--require", __dirname + "/../../../src/register"]
+      ["--require", path.join(__dirname, "..", "..", "..", "src", "register")]
     );
     assert.equal(statusCode3, 0);
   });

--- a/packages/buidler-docker/src/buidler-docker.ts
+++ b/packages/buidler-docker/src/buidler-docker.ts
@@ -282,6 +282,6 @@ export class BuidlerDocker {
   private _imageToRepositoryPath(image: Image): string {
     return image.repository.includes("/")
       ? image.repository
-      : "library/" + image.repository;
+      : `library/{image.repository}`;
   }
 }

--- a/packages/buidler-ethers/test/index.ts
+++ b/packages/buidler-ethers/test/index.ts
@@ -1,9 +1,10 @@
 import { assert } from "chai";
+import path from "path";
 
 import { useEnvironment } from "./helpers";
 
 describe("Ethers plugin", function() {
-  useEnvironment(__dirname + "/buidler-project");
+  useEnvironment(path.join(__dirname, "buidler-project"));
 
   it("should extend buidler runtime environment", function() {
     assert.isDefined(this.env.ethers);

--- a/packages/buidler-etherscan/src/solc/SolcVersions.ts
+++ b/packages/buidler-etherscan/src/solc/SolcVersions.ts
@@ -2,10 +2,8 @@ import { CompilersList } from "@nomiclabs/buidler/internal/solidity/compiler/dow
 import { BuidlerPluginError } from "@nomiclabs/buidler/plugins";
 import request from "request-promise";
 
-const COMPILER_FILES_DIR_URL =
-  "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/";
-
-const COMPILERS_LIST_URL = COMPILER_FILES_DIR_URL + "list.json";
+const COMPILERS_LIST_URL =
+  "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json";
 
 export async function getVersions(): Promise<CompilersList> {
   try {

--- a/packages/buidler-etherscan/test/integration/BuidlerRuntimeEnvironmentExtensionTests.ts
+++ b/packages/buidler-etherscan/test/integration/BuidlerRuntimeEnvironmentExtensionTests.ts
@@ -1,14 +1,11 @@
-import {
-  BuidlerConfig,
-  BuidlerRuntimeEnvironment
-} from "@nomiclabs/buidler/types";
 import { assert } from "chai";
+import path from "path";
 
 import { getDefaultEtherscanConfig } from "../../src/config";
 import { useEnvironment } from "../helpers";
 
 describe("BuidlerConfig extension", function() {
-  useEnvironment(__dirname + "/../buidler-project");
+  useEnvironment(path.join(__dirname, "..", "buidler-project"));
 
   it("It should add the etherscan field", function() {
     assert.isDefined(this.env.config.etherscan);

--- a/packages/buidler-etherscan/test/integration/PluginTests.ts
+++ b/packages/buidler-etherscan/test/integration/PluginTests.ts
@@ -1,9 +1,6 @@
-import {
-  TASK_COMPILE,
-  TASK_FLATTEN_GET_FLATTENED_SOURCE
-} from "@nomiclabs/buidler/builtin-tasks/task-names";
+import { TASK_COMPILE } from "@nomiclabs/buidler/builtin-tasks/task-names";
 import { BuidlerPluginError, readArtifact } from "@nomiclabs/buidler/plugins";
-import { assert, expect } from "chai";
+import { assert } from "chai";
 // tslint:disable: no-implicit-dependencies
 import { ethers } from "ethers";
 import { readFileSync, writeFileSync } from "fs";
@@ -16,7 +13,7 @@ describe.skip("Plugin integration tests", function() {
   this.timeout(120000);
 
   describe("Using a correct Buidler project", () => {
-    useEnvironment(__dirname + "/../buidler-project");
+    useEnvironment(path.join(__dirname, "..", "buidler-project"));
 
     let placeholder: string;
     this.beforeEach(() => {
@@ -59,7 +56,7 @@ describe.skip("Plugin integration tests", function() {
   });
 
   describe("Using a Buidler project with circular dependencies", () => {
-    useEnvironment(__dirname + "/../buidler-project-circular-dep");
+    useEnvironment(path.join(__dirname, "..", "buidler-project-circular-dep"));
     it("Fails with an error message indicating to use Etherscan's GUI", async function() {
       this.env
         .run("verify-contract", {

--- a/packages/buidler-solhint/src/index.ts
+++ b/packages/buidler-solhint/src/index.ts
@@ -81,7 +81,7 @@ export default function() {
   internalTask("buidler-solhint:run-solhint", async (_, { config }) => {
     const { processPath } = await import("solhint/lib/index");
     return processPath(
-      config.paths.sources + "/**/*.sol",
+      join(config.paths.sources, "**", "*.sol"),
       await getSolhintConfig(config.paths.root)
     );
   });

--- a/packages/buidler-solhint/test/tests.ts
+++ b/packages/buidler-solhint/test/tests.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 // tslint:disable-next-line no-implicit-dependencies
 import { unlink, writeFile, writeJson } from "fs-extra";
+import path from "path";
 
 import { useEnvironment } from "./helpers";
 
@@ -19,7 +20,7 @@ describe("Solhint plugin", function() {
   const SOLHINT_CONFIG_FILENAME = ".solhint.json";
 
   describe("Project with solhint config", function() {
-    useEnvironment(__dirname + "/buidler-project");
+    useEnvironment(path.join(__dirname, "buidler-project"));
 
     it("should define solhint task", function() {
       assert.isDefined(this.env.tasks["buidler-solhint:run-solhint"]);
@@ -34,7 +35,7 @@ describe("Solhint plugin", function() {
   });
 
   describe("Project with no solhint config", function() {
-    useEnvironment(__dirname + "/no-config-project");
+    useEnvironment(path.join(__dirname, "no-config-project"));
 
     it("return a report", async function() {
       const reports = await this.env.run("buidler-solhint:run-solhint");
@@ -44,7 +45,7 @@ describe("Solhint plugin", function() {
   });
 
   describe("Project with invalid solhint configs", function() {
-    useEnvironment(__dirname + "/invalid-config-project");
+    useEnvironment(path.join(__dirname, "invalid-config-project"));
 
     it("should throw when using invalid extensions", async function() {
       const invalidExtensionConfig = {

--- a/packages/buidler-solpp/test/tests.ts
+++ b/packages/buidler-solpp/test/tests.ts
@@ -22,7 +22,7 @@ export async function expectErrorAsync(
 
 describe("Solpp plugin", async function() {
   describe("js-config-project", async function() {
-    useEnvironment(__dirname + "/js-config-project");
+    useEnvironment(join(__dirname, "js-config-project"));
 
     it("should evaluate symbols as javascript functions", async function() {
       const paths = await this.env.run(TASK_COMPILE_GET_SOURCE_PATHS);
@@ -37,7 +37,7 @@ describe("Solpp plugin", async function() {
   });
 
   describe("json-config-project", async function() {
-    useEnvironment(__dirname + "/json-config-project");
+    useEnvironment(join(__dirname, "json-config-project"));
 
     it("should load definitions from json", async function() {
       const paths = await this.env.run(TASK_COMPILE_GET_SOURCE_PATHS);
@@ -55,7 +55,7 @@ describe("Solpp plugin", async function() {
   });
 
   describe("buidler-project", async function() {
-    useEnvironment(__dirname + "/buidler-project");
+    useEnvironment(join(__dirname, "buidler-project"));
 
     it("should create processed contracts in the cache directory", async function() {
       const paths = await this.env.run(TASK_COMPILE_GET_SOURCE_PATHS);
@@ -103,7 +103,7 @@ describe("Solpp plugin", async function() {
 
     // This test skipped because solpp won't fail if a contract has an non-defined symbol.
     describe.skip("fail-project", async function() {
-      useEnvironment(__dirname + "/fail-project");
+      useEnvironment(join(__dirname, "fail-project"));
 
       it("should fail when symbol does not exist", async function() {
         const contractPath = join(this.env.config.paths.sources, "A.sol");

--- a/packages/buidler-truffle4/test/tests.ts
+++ b/packages/buidler-truffle4/test/tests.ts
@@ -1,6 +1,7 @@
 import { TASK_COMPILE_GET_SOURCE_PATHS } from "@nomiclabs/buidler/builtin-tasks/task-names";
 import { assert } from "chai";
 import * as fs from "fs";
+import path from "path";
 
 import { TruffleEnvironmentArtifacts } from "../src/artifacts";
 import { TruffleContract, TruffleContractInstance } from "../src/types";
@@ -138,7 +139,7 @@ function testArtifactsFunctionality() {
 }
 
 describe("BuidlerRuntimeEnvironment extension", function() {
-  useEnvironment(__dirname + "/buidler-project-solc-0.5");
+  useEnvironment(path.join(__dirname, "buidler-project-solc-0.5"));
 
   it("It should add the artifacts object", function() {
     assert.instanceOf(this.env.artifacts, TruffleEnvironmentArtifacts);
@@ -147,12 +148,12 @@ describe("BuidlerRuntimeEnvironment extension", function() {
 
 describe("TruffleContracts loading and provisioning", function() {
   describe("When compiling with solc 0.5.x", function() {
-    useEnvironment(__dirname + "/buidler-project-solc-0.5");
+    useEnvironment(path.join(__dirname, "buidler-project-solc-0.5"));
     testArtifactsFunctionality();
   });
 
   describe("When compiling with solc 0.4.x", function() {
-    useEnvironment(__dirname + "/buidler-project-solc-0.4");
+    useEnvironment(path.join(__dirname, "buidler-project-solc-0.4"));
     testArtifactsFunctionality();
   });
 
@@ -174,7 +175,7 @@ describe("TruffleContracts loading and provisioning", function() {
 
     describe("With solc 0.4.x", function() {
       useEnvironment(
-        __dirname + "/buidler-project-solc-0.4",
+        path.join(__dirname, "buidler-project-solc-0.4"),
         "withoutAccounts"
       );
       shouldWorkWithoutAccounts();
@@ -182,7 +183,7 @@ describe("TruffleContracts loading and provisioning", function() {
 
     describe("With solc 0.4.x", function() {
       useEnvironment(
-        __dirname + "/buidler-project-solc-0.5",
+        path.join(__dirname, "buidler-project-solc-0.5"),
         "withoutAccounts"
       );
       shouldWorkWithoutAccounts();
@@ -191,7 +192,7 @@ describe("TruffleContracts loading and provisioning", function() {
 });
 
 describe("Test contracts compilation", function() {
-  useEnvironment(__dirname + "/project-with-test-contracts");
+  useEnvironment(path.join(__dirname, "project-with-test-contracts"));
 
   it("Should include sources from sources", async function() {
     const sources = await this.env.run(TASK_COMPILE_GET_SOURCE_PATHS);
@@ -199,7 +200,12 @@ describe("Test contracts compilation", function() {
     assert.include(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/contracts/fromContracts.sol"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "contracts",
+          "fromContracts.sol"
+        )
       )
     );
   });
@@ -210,7 +216,12 @@ describe("Test contracts compilation", function() {
     assert.include(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/test/fromTest.sol"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "test",
+          "fromTest.sol"
+        )
       )
     );
   });
@@ -221,7 +232,12 @@ describe("Test contracts compilation", function() {
     assert.notInclude(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/test/shouldBeIgnored.txt"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "test",
+          "shouldBeIgnored.txt"
+        )
       )
     );
   });

--- a/packages/buidler-truffle5/test/tests.ts
+++ b/packages/buidler-truffle5/test/tests.ts
@@ -2,6 +2,7 @@ import { TASK_COMPILE_GET_SOURCE_PATHS } from "@nomiclabs/buidler/builtin-tasks/
 import { BuidlerRuntimeEnvironment } from "@nomiclabs/buidler/types";
 import { assert } from "chai";
 import * as fs from "fs";
+import path from "path";
 
 import { TruffleEnvironmentArtifacts } from "../src/artifacts";
 import { DEFAULT_GAS_MULTIPLIER } from "../src/constants";
@@ -131,7 +132,7 @@ function testArtifactsFunctionality() {
 }
 
 describe("BuidlerRuntimeEnvironment extension", function() {
-  useEnvironment(__dirname + "/buidler-project-solc-0.5");
+  useEnvironment(path.join(__dirname, "buidler-project-solc-0.5"));
 
   it("It should add the artifacts object", function() {
     assert.instanceOf(this.env.artifacts, TruffleEnvironmentArtifacts);
@@ -140,12 +141,12 @@ describe("BuidlerRuntimeEnvironment extension", function() {
 
 describe("TruffleContracts loading and provisioning", function() {
   describe("When compiling with solc 0.5.x", function() {
-    useEnvironment(__dirname + "/buidler-project-solc-0.5");
+    useEnvironment(path.join(__dirname, "buidler-project-solc-0.5"));
     testArtifactsFunctionality();
   });
 
   describe("When compiling with solc 0.4.x", function() {
-    useEnvironment(__dirname + "/buidler-project-solc-0.4");
+    useEnvironment(path.join(__dirname, "buidler-project-solc-0.4"));
     testArtifactsFunctionality();
   });
 
@@ -167,7 +168,7 @@ describe("TruffleContracts loading and provisioning", function() {
 
     describe("With solc 0.4.x", function() {
       useEnvironment(
-        __dirname + "/buidler-project-solc-0.4",
+        path.join(__dirname, "buidler-project-solc-0.4"),
         "withoutAccounts"
       );
       shouldWorkWithoutAccounts();
@@ -175,7 +176,7 @@ describe("TruffleContracts loading and provisioning", function() {
 
     describe("With solc 0.4.x", function() {
       useEnvironment(
-        __dirname + "/buidler-project-solc-0.5",
+        path.join(__dirname, "buidler-project-solc-0.5"),
         "withoutAccounts"
       );
       shouldWorkWithoutAccounts();
@@ -184,7 +185,7 @@ describe("TruffleContracts loading and provisioning", function() {
 });
 
 describe("Test contracts compilation", function() {
-  useEnvironment(__dirname + "/project-with-test-contracts");
+  useEnvironment(path.join(__dirname, "project-with-test-contracts"));
 
   it("Should include sources from sources", async function() {
     const sources = await this.env.run(TASK_COMPILE_GET_SOURCE_PATHS);
@@ -192,7 +193,12 @@ describe("Test contracts compilation", function() {
     assert.include(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/contracts/fromContracts.sol"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "contracts",
+          "fromContracts.sol"
+        )
       )
     );
   });
@@ -203,7 +209,12 @@ describe("Test contracts compilation", function() {
     assert.include(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/test/fromTest.sol"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "test",
+          "fromTest.sol"
+        )
       )
     );
   });
@@ -214,7 +225,12 @@ describe("Test contracts compilation", function() {
     assert.notInclude(
       sources,
       fs.realpathSync(
-        __dirname + "/project-with-test-contracts/test/shouldBeIgnored.txt"
+        path.join(
+          __dirname,
+          "project-with-test-contracts",
+          "test",
+          "shouldBeIgnored.txt"
+        )
       )
     );
   });
@@ -285,7 +301,7 @@ describe("Gas multiplier", function() {
 
   describe("When it's set in the network", function() {
     useEnvironment(
-      __dirname + "/buidler-project-solc-0.4",
+      path.join(__dirname, "buidler-project-solc-0.4"),
       "withGasMultiplier"
     );
 
@@ -301,7 +317,7 @@ describe("Gas multiplier", function() {
   });
 
   describe("When it's not set in the network", function() {
-    useEnvironment(__dirname + "/buidler-project-solc-0.4");
+    useEnvironment(path.join(__dirname, "buidler-project-solc-0.4"));
 
     it("Should use the set one for deployments", async function() {
       await assertItWorksForDeployments(this.env, DEFAULT_GAS_MULTIPLIER);

--- a/packages/buidler-vyper/test/tests.ts
+++ b/packages/buidler-vyper/test/tests.ts
@@ -4,12 +4,13 @@ import {
   readArtifactSync
 } from "@nomiclabs/buidler/plugins";
 import { assert } from "chai";
+import path from "path";
 
 import { useEnvironment } from "./helpers";
 
 describe("Vyper plugin", async function() {
   describe("Successful compilation", async function() {
-    useEnvironment(__dirname + "/projects/successful-compilation");
+    useEnvironment(path.join(__dirname, "projects", "successful-compilation"));
 
     it("Should successfully compile the contract", async function() {
       await this.env.run(TASK_COMPILE);
@@ -21,7 +22,7 @@ describe("Vyper plugin", async function() {
   });
 
   describe("Partial compilation", async function() {
-    useEnvironment(__dirname + "/projects/partial-compilation");
+    useEnvironment(path.join(__dirname, "projects", "partial-compilation"));
 
     it("Should successfully compile the contract", async function() {
       try {


### PR DESCRIPTION
This PR enables a tslint rule that forbids strings concatenation in favor of using template strings. 

I was initially skeptical about this rule, as it forces you into patterns I don't like, mostly when there's a single concatenation. For example

```ts
`${thing}s`
`Hello, ${planet}`
```

Nevertheless, I applied the rule to understand how common these things were. 

I replaced many concatenations with `path.join`, but I'm not sure if that's necessary.

What do you think @jjant?