### PR TITLE
Fix error message on invalid number of constructor arguments

### DIFF
--- a/packages/buidler-etherscan/src/AbiEncoder.ts
+++ b/packages/buidler-etherscan/src/AbiEncoder.ts
@@ -6,21 +6,26 @@ export default class AbiEncoder {
     contractAbi: any[],
     constructorArguments: string[]
   ): string {
-    let constructorAbis: any[] = contractAbi.filter(
+    const constructorAbi: any | undefined = contractAbi.find(
       value => value.type === "constructor"
     );
-    if (constructorAbis.length === 0) {
+
+    if (constructorAbi === undefined) {
       return "";
     }
-    constructorAbis = constructorAbis.filter(
-      value => value.inputs.length === constructorArguments.length
-    );
-    if (constructorAbis.length === 0) {
-      throw new BuidlerPluginError("Invalid number of constructor arguments");
+
+    if (constructorAbi.inputs.length !== constructorArguments.length) {
+      throw new BuidlerPluginError(
+        `Invalid number of constructor arguments:
+          Expected: ${constructorAbi.inputs.length}
+          Received: ${constructorArguments.length}`
+      );
     }
-    const types = constructorAbis[0].inputs.map(
+
+    const types = constructorAbi.inputs.map(
       (value: { type: string }) => value.type
     );
+
     return abi.rawEncode(types, constructorArguments).toString("hex");
   }
 }

--- a/packages/buidler-etherscan/src/index.ts
+++ b/packages/buidler-etherscan/src/index.ts
@@ -24,7 +24,8 @@ task("verify-contract", "Verifies contract on etherscan")
   )
   .addOptionalVariadicPositionalParam(
     "constructorArguments",
-    "arguments for contract constructor"
+    "arguments for contract constructor",
+    []
   )
   .setAction(
     async (


### PR DESCRIPTION
# Description
Fixes #338.

Passing a wrong number of constructor arguments now shows a message like the following:
![image](https://user-images.githubusercontent.com/15112080/61328551-9f1dd480-a7f1-11e9-9810-a46ec66b5334.png)
