### PR TITLE
[core] Don't duplicate errors in the CLI

### DIFF
--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -149,10 +149,7 @@ async function main() {
         chalk.red("Error in plugin " + error.pluginName + ": " + error.message)
       );
     } else if (error instanceof Error) {
-      console.error(
-        chalk.red("An unexpected error occurred: " + error.message)
-      );
-
+      console.error(chalk.red("An unexpected error occurred:"));
       showStackTraces = true;
     } else {
       console.error(chalk.red("An unexpected error occurred."));

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -140,10 +140,10 @@ async function main() {
   } catch (error) {
     let isBuidlerError = false;
 
-    if (error instanceof BuidlerError) {
+    if (BuidlerError.isBuidlerError(error)) {
       isBuidlerError = true;
       console.error(chalk.red("Error " + error.message));
-    } else if (error instanceof BuidlerPluginError) {
+    } else if (BuidlerPluginError.isBuidlerPluginError(error)) {
       isBuidlerError = true;
       console.error(
         chalk.red("Error in plugin " + error.pluginName + ": " + error.message)

--- a/packages/buidler-core/src/internal/core/errors.ts
+++ b/packages/buidler-core/src/internal/core/errors.ts
@@ -12,8 +12,16 @@ export interface ErrorDescription {
 // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
 
 export class BuidlerError extends Error {
+  public static isBuidlerError(other: any): other is BuidlerError {
+    return (
+      other !== undefined && other !== null && other._isBuidlerError === true
+    );
+  }
+
   public readonly number: number;
   public readonly parent?: Error;
+
+  private readonly _isBuidlerError: boolean;
 
   constructor(
     errorDescription: ErrorDescription,
@@ -34,6 +42,7 @@ export class BuidlerError extends Error {
       this.parent = parentError;
     }
 
+    this._isBuidlerError = true;
     Object.setPrototypeOf(this, BuidlerError.prototype);
   }
 }
@@ -42,8 +51,18 @@ export class BuidlerError extends Error {
  * This class is used to throw errors from buidler plugins.
  */
 export class BuidlerPluginError extends Error {
+  public static isBuidlerPluginError(other: any): other is BuidlerPluginError {
+    return (
+      other !== undefined &&
+      other !== null &&
+      other._isBuidlerPluginError === true
+    );
+  }
+
   public readonly parent?: Error;
   public readonly pluginName: string;
+
+  private readonly _isBuidlerPluginError: boolean;
 
   /**
    * Creates a BuidlerPluginError.
@@ -80,6 +99,7 @@ export class BuidlerPluginError extends Error {
       this.parent = messageOrParent;
     }
 
+    this._isBuidlerPluginError = true;
     Object.setPrototypeOf(this, BuidlerPluginError.prototype);
   }
 }

--- a/packages/buidler-core/test/internal/core/errors.ts
+++ b/packages/buidler-core/test/internal/core/errors.ts
@@ -17,6 +17,26 @@ const mockErrorDescription: ErrorDescription = {
 };
 
 describe("BuilderError", () => {
+  describe("Type guard", () => {
+    it("Should return true for BuidlerErrors", () => {
+      assert.isTrue(
+        BuidlerError.isBuidlerError(new BuidlerError(mockErrorDescription))
+      );
+    });
+
+    it("Should return false for everything else", () => {
+      assert.isFalse(BuidlerError.isBuidlerError(new Error()));
+      assert.isFalse(
+        BuidlerError.isBuidlerError(new BuidlerPluginError("asd", "asd"))
+      );
+      assert.isFalse(BuidlerError.isBuidlerError(undefined));
+      assert.isFalse(BuidlerError.isBuidlerError(null));
+      assert.isFalse(BuidlerError.isBuidlerError(123));
+      assert.isFalse(BuidlerError.isBuidlerError("123"));
+      assert.isFalse(BuidlerError.isBuidlerError({ asd: 123 }));
+    });
+  });
+
   describe("Without parent error", () => {
     it("should have the right error number", () => {
       const error = new BuidlerError(mockErrorDescription);
@@ -162,6 +182,30 @@ describe("Error descriptions", () => {
 });
 
 describe("BuidlerPluginError", () => {
+  describe("Type guard", () => {
+    it("Should return true for BuidlerPluginError", () => {
+      assert.isTrue(
+        BuidlerPluginError.isBuidlerPluginError(
+          new BuidlerPluginError("asd", "asd")
+        )
+      );
+    });
+
+    it("Should return false for everything else", () => {
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError(new Error()));
+      assert.isFalse(
+        BuidlerPluginError.isBuidlerPluginError(
+          new BuidlerError(ERRORS.GENERAL.NOT_INSIDE_PROJECT)
+        )
+      );
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError(undefined));
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError(null));
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError(123));
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError("123"));
+      assert.isFalse(BuidlerPluginError.isBuidlerPluginError({ asd: 123 }));
+    });
+  });
+
   describe("constructors", () => {
     describe("automatic plugin name", () => {
       it("Should accept a parent error", () => {


### PR DESCRIPTION
This PR prevents the CLI from duplicating error messages.

This is done in two ways:

1. Remove an unnecessary argument in a `console.error`
2. Add user-defined type guards for `BuidlerError` and `BuidlerPluginError`. This is necessary for development time. When running Buidler and plugins locally, it's not uncommon to have multiple instances of these classes due to linking.