### PR TITLE
Cache gas limit

### DIFF
--- a/packages/buidler-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/buidler-core/src/internal/core/providers/gas-providers.ts
@@ -116,14 +116,14 @@ export function createGanacheGasMultiplierProvider(
 }
 
 let cachedGasLimit: number | undefined;
-async function getGasLimit(provider: IEthereumProvider): Promise<number> {
+async function getBlockGasLimit(provider: IEthereumProvider): Promise<number> {
   if (cachedGasLimit === undefined) {
-    const pendingBlock = await provider.send("eth_getBlockByNumber", [
+    const latestBlock = await provider.send("eth_getBlockByNumber", [
       "latest",
       false
     ]);
 
-    const fetchedGasLimit = rpcQuantityToNumber(pendingBlock.gasLimit);
+    const fetchedGasLimit = rpcQuantityToNumber(latestBlock.gasLimit);
 
     // For future uses, we store a lower value in case the gas limit varies slightly
     cachedGasLimit = fetchedGasLimit * 0.95;
@@ -146,7 +146,7 @@ async function getMultipliedGasEstimation(
   }
 
   const normalGas = rpcQuantityToNumber(realEstimation);
-  const gasLimit = await getGasLimit(provider);
+  const gasLimit = await getBlockGasLimit(provider);
 
   const multiplied = Math.floor(normalGas * gasMultiplier);
   const gas = multiplied > gasLimit ? gasLimit - 1 : multiplied;

--- a/packages/buidler-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/buidler-core/src/internal/core/providers/gas-providers.ts
@@ -115,6 +115,25 @@ export function createGanacheGasMultiplierProvider(
   });
 }
 
+let cachedGasLimit: number | undefined;
+async function getGasLimit(provider: IEthereumProvider): Promise<number> {
+  if (cachedGasLimit === undefined) {
+    const pendingBlock = await provider.send("eth_getBlockByNumber", [
+      "latest",
+      false
+    ]);
+
+    const fetchedGasLimit = rpcQuantityToNumber(pendingBlock.gasLimit);
+
+    // For future uses, we store a lower value in case the gas limit varies slightly
+    cachedGasLimit = fetchedGasLimit * 0.95;
+
+    return fetchedGasLimit;
+  }
+
+  return cachedGasLimit;
+}
+
 async function getMultipliedGasEstimation(
   provider: IEthereumProvider,
   params: any[],
@@ -126,13 +145,8 @@ async function getMultipliedGasEstimation(
     return realEstimation;
   }
 
-  const pendingBlock = await provider.send("eth_getBlockByNumber", [
-    "latest",
-    false
-  ]);
-
   const normalGas = rpcQuantityToNumber(realEstimation);
-  const gasLimit = rpcQuantityToNumber(pendingBlock.gasLimit);
+  const gasLimit = await getGasLimit(provider);
 
   const multiplied = Math.floor(normalGas * gasMultiplier);
   const gas = multiplied > gasLimit ? gasLimit - 1 : multiplied;


### PR DESCRIPTION
Cache gas limit (per process), so that `eth_getBlockByNumber` is only called once for obtaining it per execution. This should greatly reduce data usage.
