### PR TITLE
Upgrade web3 to the stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 node_js:
   - "8"
   - "10"
-  - "11"
+  - "12"
 
 install:
   - scripts/install.sh

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -121,8 +121,7 @@ Now, you’ll likely want to run some tests. Out of the box Buidler provides an
 The sample project comes with a test written using the Ethereum provider directly, but let’s also install `buidler-truffle5` and test out the Truffle 5 integration:
 
 ```bash
-npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 
-npm install --save-exact web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3
 ```
 
 Add `usePlugin("@nomiclabs/buidler-truffle5")` to the top of your `buidler.config.js`, so that it looks like this:

--- a/docs/guides/create-task.md
+++ b/docs/guides/create-task.md
@@ -50,8 +50,7 @@ Tasks in Buidler are asynchronous JavaScript functions that get access to the [
 For our example we will use Web3.js to interact with our contracts, so we will install the [web3 plugin](https://github.com/nomiclabs/buidler/tree/master/packages/buidler-web3), which injects a Web3 instance into the Buidler environment:
 
 ```bash
-npm install @nomiclabs/buidler-web3 
-npm install --save-exact web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-web3 web3
 ```
 
 _Take a look at the [list of Buidler plugins](/plugins) to see other available libraries._

--- a/docs/guides/truffle-migration.md
+++ b/docs/guides/truffle-migration.md
@@ -23,8 +23,7 @@ npm install
 Install Buidler and the Truffle 5 plugin:
 
 ```bash
-npm install @nomiclabs/buidler @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3
-npm install --save-exact web3@1.0.0-beta.37
+npm install @nomiclabs/buidler @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3
 ```
 
 Then put the following into `buidler.config.js`:

--- a/packages/buidler-truffle5/README.md
+++ b/packages/buidler-truffle5/README.md
@@ -15,8 +15,7 @@ This plugin requires [buidler-web3](https://github.com/nomiclabs/buidler/tree/ma
 ## Installation
 
 ```bash
-npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 
-npm install --save-exact web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3
 ```
 
 And add the following statement to your `buidler.config.js`:

--- a/packages/buidler-truffle5/package.json
+++ b/packages/buidler-truffle5/package.json
@@ -41,11 +41,11 @@
     "@nomiclabs/buidler-web3": "^1.0.0-beta.8",
     "@types/chai": "^4.1.7",
     "@types/glob": "^7.1.1",
-    "web3": "1.0.0-beta.37"
+    "web3": "^1.2.0"
   },
   "peerDependencies": {
     "@nomiclabs/buidler": "^1.0.0-beta.8",
     "@nomiclabs/buidler-web3": "^1.0.0-beta.8",
-    "web3": "1.0.0-beta.37"
+    "web3": "^1.2.0"
   }
 }

--- a/packages/buidler-web3/README.md
+++ b/packages/buidler-web3/README.md
@@ -2,7 +2,7 @@
 
 # buidler-web3
 
-This plugin integrates [Web3.js](https://github.com/ethereum/web3.js) `1.x` into [Buidler](http://getbuidler.com). Tested against Web3@1.0.0-beta.37.
+This plugin integrates [Web3.js](https://github.com/ethereum/web3.js) `1.x` into [Buidler](http://getbuidler.com).
 
 ## What
 
@@ -11,8 +11,7 @@ This plugin brings to Buidler the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install @nomiclabs/buidler-web3
-npm install --save-exact web3@1.0.0-beta.37
+npm install @nomiclabs/buidler-web3 web3
 ```
 
 And add the following statement to your `buidler.config.js`:

--- a/packages/buidler-web3/package.json
+++ b/packages/buidler-web3/package.json
@@ -35,10 +35,10 @@
   "devDependencies": {
     "@nomiclabs/buidler": "^1.0.0-beta.8",
     "chai": "^4.2.0",
-    "web3": "1.0.0-beta.37"
+    "web3": "^1.2.0"
   },
   "peerDependencies": {
     "@nomiclabs/buidler": "^1.0.0-beta.8",
-    "web3": "1.0.0-beta.37"
+    "web3": "^1.2.0"
   }
 }


### PR DESCRIPTION
This PR upgrades web3 1.0.0-beta.37 to 1.2.0. It also updates the CI config, as it can now run on node 12.