### PR TITLE
Disable old style import detection

### DIFF
--- a/packages/buidler-core/src/internal/core/plugins.ts
+++ b/packages/buidler-core/src/internal/core/plugins.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import * as semver from "semver";
 
 import { BuidlerContext } from "../context";
-import { getClosestCallerPackage } from "../util/caller-package";
 
 import { BuidlerError, ERRORS } from "./errors";
 import { ExecutionMode, getExecutionMode } from "./execution-mode";
@@ -142,35 +141,5 @@ export function readPackageJson(
 }
 
 export function ensurePluginLoadedWithUsePlugin() {
-  const previousPrepareStackTrace = Error.prepareStackTrace;
-
-  Error.prepareStackTrace = (e, s) => s;
-
-  const error = new Error();
-  const stack: NodeJS.CallSite[] = error.stack as any;
-
-  Error.prepareStackTrace = previousPrepareStackTrace;
-
-  for (const callSite of stack) {
-    const fileName = callSite.getFileName();
-    if (fileName === null) {
-      continue;
-    }
-
-    const functionName = callSite.getFunctionName();
-
-    if (
-      path.basename(fileName) === path.basename(__filename) &&
-      functionName === loadPluginFile.name
-    ) {
-      return;
-    }
-  }
-
-  const pluginName = getClosestCallerPackage();
-
-  throw new BuidlerError(ERRORS.PLUGINS.OLD_STYLE_IMPORT_DETECTED, {
-    pluginNameText: pluginName !== undefined ? pluginName : "a plugin",
-    pluginNameCode: pluginName !== undefined ? pluginName : "plugin-name"
-  });
+  // No-op. Only here for backwards compatibility
 }

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/index.js
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/index.js
@@ -1,8 +1,0 @@
-const {
-  ensurePluginLoadedWithUsePlugin
-} = require("../../../../../src/internal/core/plugins");
-ensurePluginLoadedWithUsePlugin();
-
-module.exports = function() {
-  global.loaded = true;
-};

--- a/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/package.json
+++ b/packages/buidler-core/test/fixture-projects/plugin-loading-project/node_modules/validates-import-style/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "validates-import-style",
-  "version": "2.1.0"
-}

--- a/packages/buidler-core/test/internal/core/plugins.ts
+++ b/packages/buidler-core/test/internal/core/plugins.ts
@@ -148,35 +148,4 @@ describe("plugin system", function() {
       );
     });
   });
-
-  describe("ensurePluginLoadedWithUsePlugin", function() {
-    const globalAsAny = global as any;
-
-    const pluginFile = require.resolve(
-      path.join(
-        FIXTURE_PROJECT_PATH,
-        "node_modules",
-        "validates-import-style",
-        "index.js"
-      )
-    );
-
-    afterEach(function() {
-      delete globalAsAny.loaded;
-      delete require.cache[pluginFile];
-    });
-
-    it("Should do nothing special if loadPluginFile is used", function() {
-      loadPluginFile(pluginFile);
-
-      assert.isTrue(globalAsAny.loaded);
-    });
-
-    it("Should throw if imported with a require", function() {
-      expectBuidlerError(
-        () => require(pluginFile),
-        ERRORS.PLUGINS.OLD_STYLE_IMPORT_DETECTED
-      );
-    });
-  });
 });

--- a/packages/buidler-ethers/src/index.ts
+++ b/packages/buidler-ethers/src/index.ts
@@ -1,15 +1,9 @@
 import { extendEnvironment } from "@nomiclabs/buidler/config";
-import {
-  ensurePluginLoadedWithUsePlugin,
-  lazyObject,
-  readArtifact
-} from "@nomiclabs/buidler/plugins";
+import { lazyObject, readArtifact } from "@nomiclabs/buidler/plugins";
 import { BuidlerRuntimeEnvironment } from "@nomiclabs/buidler/types";
 import { ContractFactory, Signer } from "ethers";
 
 import { EthersProviderWrapper } from "./ethers-provider-wrapper";
-
-ensurePluginLoadedWithUsePlugin();
 
 export default function() {
   extendEnvironment((env: BuidlerRuntimeEnvironment) => {

--- a/packages/buidler-solhint/src/index.ts
+++ b/packages/buidler-solhint/src/index.ts
@@ -1,10 +1,7 @@
 import { internalTask, task } from "@nomiclabs/buidler/config";
 import { BuidlerPluginError } from "@nomiclabs/buidler/internal/core/errors";
-import { ensurePluginLoadedWithUsePlugin } from "@nomiclabs/buidler/plugins";
 import * as fs from "fs";
 import { join } from "path";
-
-ensurePluginLoadedWithUsePlugin();
 
 function getDefaultConfig() {
   return {

--- a/packages/buidler-solpp/src/index.ts
+++ b/packages/buidler-solpp/src/index.ts
@@ -1,13 +1,10 @@
 import { TASK_COMPILE_GET_SOURCE_PATHS } from "@nomiclabs/buidler/builtin-tasks/task-names";
 import { internalTask } from "@nomiclabs/buidler/config";
-import { ensurePluginLoadedWithUsePlugin } from "@nomiclabs/buidler/plugins";
 import { ResolvedBuidlerConfig } from "@nomiclabs/buidler/types";
 import fsExtra from "fs-extra";
 import path from "path";
 
 import { SolppConfig } from "./types";
-
-ensurePluginLoadedWithUsePlugin();
 
 export const PROCESSED_CACHE_DIRNAME = "solpp-generated-contracts";
 

--- a/packages/buidler-truffle4/src/index.ts
+++ b/packages/buidler-truffle4/src/index.ts
@@ -8,16 +8,11 @@ import {
   usePlugin
 } from "@nomiclabs/buidler/config";
 import { glob } from "@nomiclabs/buidler/internal/util/glob";
-import {
-  ensurePluginLoadedWithUsePlugin,
-  lazyObject
-} from "@nomiclabs/buidler/plugins";
+import { lazyObject } from "@nomiclabs/buidler/plugins";
 import { join } from "path";
 
 import { TruffleEnvironmentArtifacts } from "./artifacts";
 import { LazyTruffleContractProvisioner } from "./provisioner";
-
-ensurePluginLoadedWithUsePlugin();
 
 export default function() {
   usePlugin("@nomiclabs/buidler-web3-legacy");

--- a/packages/buidler-truffle5/src/index.ts
+++ b/packages/buidler-truffle5/src/index.ts
@@ -8,17 +8,11 @@ import {
   usePlugin
 } from "@nomiclabs/buidler/config";
 import { glob } from "@nomiclabs/buidler/internal/util/glob";
-import {
-  BuidlerPluginError,
-  ensurePluginLoadedWithUsePlugin,
-  lazyObject
-} from "@nomiclabs/buidler/plugins";
+import { BuidlerPluginError, lazyObject } from "@nomiclabs/buidler/plugins";
 import { join } from "path";
 
 import { TruffleEnvironmentArtifacts } from "./artifacts";
 import { LazyTruffleContractProvisioner } from "./provisioner";
-
-ensurePluginLoadedWithUsePlugin();
 
 export default function() {
   usePlugin("@nomiclabs/buidler-web3");

--- a/packages/buidler-web3-legacy/src/index.ts
+++ b/packages/buidler-web3-legacy/src/index.ts
@@ -1,14 +1,8 @@
 import { extendEnvironment } from "@nomiclabs/buidler/config";
-import {
-  ensurePluginLoadedWithUsePlugin,
-  lazyFunction,
-  lazyObject
-} from "@nomiclabs/buidler/plugins";
+import { lazyFunction, lazyObject } from "@nomiclabs/buidler/plugins";
 
 import { promisifyWeb3 } from "./pweb3";
 import { Web3HTTPProviderAdapter } from "./web3-provider-adapter";
-
-ensurePluginLoadedWithUsePlugin();
 
 export default function() {
   extendEnvironment(env => {

--- a/packages/buidler-web3/src/index.ts
+++ b/packages/buidler-web3/src/index.ts
@@ -1,13 +1,7 @@
 import { extendEnvironment } from "@nomiclabs/buidler/config";
-import {
-  ensurePluginLoadedWithUsePlugin,
-  lazyFunction,
-  lazyObject
-} from "@nomiclabs/buidler/plugins";
+import { lazyFunction, lazyObject } from "@nomiclabs/buidler/plugins";
 
 import { Web3HTTPProviderAdapter } from "./web3-provider-adapter";
-
-ensurePluginLoadedWithUsePlugin();
 
 export default function() {
   extendEnvironment(env => {


### PR DESCRIPTION
This PR disables the old-style plugins' import detection, effectively turning it into a no-op.

This was done because some corner cases were found, and it doesn't seem to be needed anymore. All of our doc and marketing material uses the new style, and it has been released for some time.