### PR TITLE
Don't fail if gas estimation reverts

### DIFF
--- a/packages/buidler-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/buidler-core/src/internal/core/providers/gas-providers.ts
@@ -166,6 +166,7 @@ function createMultipliedGasEstimationGetter() {
         return numberToRpcQuantity(blockGasLimit);
       }
 
+      // tslint:disable-next-line only-buidler-error
       throw error;
     }
   };


### PR DESCRIPTION
This PR adds some logic to catch reverts on gas estimation. If that happens, we return the block gas limit.