### PR TITLE
Fix build by not using ganache-core typings

### DIFF
--- a/config/typescript/@types/ganache-core/index.d.ts
+++ b/config/typescript/@types/ganache-core/index.d.ts
@@ -1,1 +1,0 @@
-declare module "ganache-core";

--- a/packages/buidler-ganache/src/ganache-service.ts
+++ b/packages/buidler-ganache/src/ganache-service.ts
@@ -60,7 +60,7 @@ export class GanacheService {
 
   public static async create(options: any): Promise<GanacheService> {
     // Get Ganache lib
-    const Ganache = await import("ganache-core");
+    const Ganache = require("ganache-core");
 
     // Get and initialize option validator
     const { default: optionsSchema } = await import("./ganache-options-ti");


### PR DESCRIPTION
The latest release of `web3` includes TS typings, and that broke `ganache-core`'s typings, as it used `@types/web3`. That broke our build.

We workaround this error in this PR by not using `ganache-core`'s types.