### PR TITLE
corrected the run command.

### DIFF
--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -30,7 +30,7 @@ main()
 You can run it with
 
 ```sh
-npx buidler --network your-network scripts/deploy.js
+npx buidler run --network your-network scripts/deploy.js
 ```
 
 ### Truffle migrations support


### PR DESCRIPTION
The example: 

```sh
npx buidler run --network your-network scripts/deploy.js
```

is missing the command "run"