### PR TITLE
Add snapshots functionality to Buidler EVM

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/provider/blockchain.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/blockchain.ts
@@ -94,4 +94,21 @@ export class Blockchain {
   public getDetails(_: string, cb: any): void {
     cb(null);
   }
+
+  public deleteAllFollowingBlocks(block: Block): void {
+    const blockNumber = bufferToInt(block.header.number);
+    const actualBlock = this._blocks[blockNumber];
+
+    if (actualBlock === undefined || !block.hash().equals(actualBlock.hash())) {
+      // tslint:disable-next-line only-buidler-error
+      throw new Error("Invalid block");
+    }
+
+    for (let i = blockNumber + 1; i < this._blocks.length; i++) {
+      const blockToDelete = this._blocks[i];
+      this._blockNumberByHash.delete(bufferToHex(blockToDelete.hash()));
+    }
+
+    this._blocks.splice(blockNumber + 1);
+  }
 }

--- a/packages/buidler-core/src/internal/buidler-evm/provider/input.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/input.ts
@@ -200,6 +200,8 @@ export function validateParams(
   data: typeof rpcUnknown
 ): [Buffer, any];
 
+export function validateParams(params: any[], number: typeof rpcQuantity): [BN];
+
 // tslint:disable only-buidler-error
 
 export function validateParams(params: any[], ...types: Array<t.Type<any>>) {

--- a/packages/buidler-core/src/internal/buidler-evm/provider/modules/evm.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/modules/evm.ts
@@ -2,7 +2,7 @@ import { BN } from "ethereumjs-util";
 import * as t from "io-ts";
 
 import { MethodNotFoundError, MethodNotSupportedError } from "../errors";
-import { validateParams } from "../input";
+import { rpcQuantity, validateParams } from "../input";
 import { BuidlerNode } from "../node";
 import { numberToRpcQuantity } from "../output";
 
@@ -23,10 +23,10 @@ export class EvmModule {
         return this._mineAction(...this._mineParams(params));
 
       case "evm_revert":
-        throw new MethodNotSupportedError(`Method ${method} is not supported`);
+        return this._revertAction(...this._revertParams(params));
 
       case "evm_snapshot":
-        throw new MethodNotSupportedError(`Method ${method} is not supported`);
+        return this._snapshotAction(...this._snapshotParams(params));
     }
 
     throw new MethodNotFoundError(`Method ${method} not found`);
@@ -58,5 +58,22 @@ export class EvmModule {
 
   // evm_revert
 
+  private _revertParams(params: any[]): [BN] {
+    return validateParams(params, rpcQuantity);
+  }
+
+  private async _revertAction(snapshotId: BN): Promise<boolean> {
+    return this._node.revertToSnapshot(snapshotId.toNumber());
+  }
+
   // evm_snapshot
+
+  private _snapshotParams(params: any[]): [] {
+    return [];
+  }
+
+  private async _snapshotAction(): Promise<string> {
+    const snapshotId = await this._node.takeSnapshot();
+    return numberToRpcQuantity(snapshotId);
+  }
 }

--- a/packages/buidler-core/src/internal/buidler-evm/provider/provider.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/provider.ts
@@ -55,7 +55,7 @@ export class BuidlerEVMProvider extends EventEmitter
     const release = await this._mutex.acquire();
 
     try {
-      return await this._send(method, params);
+      return await this._sendDebug(method, params);
     } finally {
       release();
     }

--- a/packages/buidler-core/test/internal/buidler-evm/helpers/assertions.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/helpers/assertions.ts
@@ -18,6 +18,7 @@ import {
   RpcTransactionReceiptOutput
 } from "../../../../src/internal/buidler-evm/provider/output";
 import { BuidlerEVMProvider } from "../../../../src/internal/buidler-evm/provider/provider";
+import { EthereumProvider } from "../../../../src/types";
 
 export async function assertBuidlerEVMProviderError(
   provider: BuidlerEVMProvider,
@@ -199,4 +200,14 @@ export function assertTransaction(
   assert.isTrue(rpcQuantity.decode(tx.r).isRight());
   assert.isTrue(rpcQuantity.decode(tx.s).isRight());
   assert.isTrue(rpcQuantity.decode(tx.v).isRight());
+}
+
+export async function assertLatestBlockNumber(
+  provider: EthereumProvider,
+  latestBlockNumber: number
+) {
+  const block = await provider.send("eth_getBlockByNumber", ["latest", false]);
+
+  assert.isNotNull(block);
+  assert.equal(block.number, numberToRpcQuantity(latestBlockNumber));
 }

--- a/packages/buidler-core/test/internal/buidler-evm/provider/modules/evm.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/provider/modules/evm.ts
@@ -1,13 +1,15 @@
 import { assert } from "chai";
-import { zeroAddress } from "ethereumjs-util";
+import { BN, zeroAddress } from "ethereumjs-util";
 
 import {
+  bufferToRpcData,
   numberToRpcQuantity,
   RpcBlockOutput
 } from "../../../../../src/internal/buidler-evm/provider/output";
+import { rpcQuantityToNumber } from "../../../../../src/internal/core/providers/provider-utils";
 import {
   assertInvalidArgumentsError,
-  assertNotSupported
+  assertLatestBlockNumber
 } from "../../helpers/assertions";
 import { quantityToNumber } from "../../helpers/conversions";
 import { setCWD } from "../../helpers/cwd";
@@ -98,15 +100,317 @@ describe("Evm module", function() {
     });
   });
 
-  describe("evm_revert", async function() {
-    it("is not supported", async function() {
-      await assertNotSupported(this.provider, "evm_revert");
-    });
-  });
+  describe("Snapshot functionality", function() {
+    describe("evm_snapshot", async function() {
+      it("returns the snapshot id starting at 1", async function() {
+        const id1: string = await this.provider.send("evm_snapshot", []);
+        const id2: string = await this.provider.send("evm_snapshot", []);
+        const id3: string = await this.provider.send("evm_snapshot", []);
 
-  describe("evm_snapshot", async function() {
-    it("is not supported", async function() {
-      await assertNotSupported(this.provider, "evm_snapshot");
+        assert.equal(id1, "0x1");
+        assert.equal(id2, "0x2");
+        assert.equal(id3, "0x3");
+      });
+
+      it("Doesn't repeat snapshot ids after revert is called", async function() {
+        const id1: string = await this.provider.send("evm_snapshot", []);
+        const reverted: boolean = await this.provider.send("evm_revert", [id1]);
+        const id2: string = await this.provider.send("evm_snapshot", []);
+
+        assert.equal(id1, "0x1");
+        assert.isTrue(reverted);
+        assert.equal(id2, "0x2");
+      });
+    });
+
+    describe("evm_revert", async function() {
+      it("Returns false for non-existing ids", async function() {
+        const reverted1: boolean = await this.provider.send("evm_revert", [
+          "0x1"
+        ]);
+        const reverted2: boolean = await this.provider.send("evm_revert", [
+          "0x2"
+        ]);
+        const reverted3: boolean = await this.provider.send("evm_revert", [
+          "0x0"
+        ]);
+
+        assert.isFalse(reverted1);
+        assert.isFalse(reverted2);
+        assert.isFalse(reverted3);
+      });
+
+      it("Returns false for already reverted ids", async function() {
+        const id1: string = await this.provider.send("evm_snapshot", []);
+        const reverted: boolean = await this.provider.send("evm_revert", [id1]);
+        const reverted2: boolean = await this.provider.send("evm_revert", [
+          id1
+        ]);
+
+        assert.isTrue(reverted);
+        assert.isFalse(reverted2);
+      });
+
+      it("Deletes previous blocks", async function() {
+        const snapshotId: string = await this.provider.send("evm_snapshot", []);
+        const initialLatestBlock = await this.provider.send(
+          "eth_getBlockByNumber",
+          ["latest", false]
+        );
+
+        await this.provider.send("evm_mine");
+        await this.provider.send("evm_mine");
+        await this.provider.send("evm_mine");
+        await this.provider.send("evm_mine");
+        const latestBlockBeforeReverting = await this.provider.send(
+          "eth_getBlockByNumber",
+          ["latest", false]
+        );
+
+        const reverted: boolean = await this.provider.send("evm_revert", [
+          snapshotId
+        ]);
+        assert.isTrue(reverted);
+
+        const newLatestBlock = await this.provider.send(
+          "eth_getBlockByNumber",
+          ["latest", false]
+        );
+        assert.equal(newLatestBlock.hash, initialLatestBlock.hash);
+
+        const blockByHash = await this.provider.send("eth_getBlockByHash", [
+          bufferToRpcData(latestBlockBeforeReverting.hash),
+          false
+        ]);
+        assert.isNull(blockByHash);
+
+        const blockByNumber = await this.provider.send("eth_getBlockByNumber", [
+          latestBlockBeforeReverting.number,
+          false
+        ]);
+        assert.isNull(blockByNumber);
+      });
+
+      it("Deletes previous transactions", async function() {
+        const [from] = await this.provider.send("eth_accounts");
+
+        const snapshotId: string = await this.provider.send("evm_snapshot", []);
+
+        const txHash = await this.provider.send("eth_sendTransaction", [
+          {
+            from,
+            to: "0x1111111111111111111111111111111111111111",
+            value: numberToRpcQuantity(1),
+            gas: numberToRpcQuantity(100000),
+            gasPrice: numberToRpcQuantity(1),
+            nonce: numberToRpcQuantity(0)
+          }
+        ]);
+
+        const reverted: boolean = await this.provider.send("evm_revert", [
+          snapshotId
+        ]);
+        assert.isTrue(reverted);
+
+        const txHashAfter = await this.provider.send(
+          "eth_getTransactionByHash",
+          [txHash]
+        );
+        assert.isNull(txHashAfter);
+      });
+
+      it("Allows resending the same tx after a revert", async function() {
+        const [from] = await this.provider.send("eth_accounts");
+
+        const snapshotId: string = await this.provider.send("evm_snapshot", []);
+
+        const txParams = {
+          from,
+          to: "0x1111111111111111111111111111111111111111",
+          value: numberToRpcQuantity(1),
+          gas: numberToRpcQuantity(100000),
+          gasPrice: numberToRpcQuantity(1),
+          nonce: numberToRpcQuantity(0)
+        };
+
+        const txHash = await this.provider.send("eth_sendTransaction", [
+          txParams
+        ]);
+
+        const reverted: boolean = await this.provider.send("evm_revert", [
+          snapshotId
+        ]);
+        assert.isTrue(reverted);
+
+        const txHash2 = await this.provider.send("eth_sendTransaction", [
+          txParams
+        ]);
+
+        assert.equal(txHash2, txHash);
+      });
+
+      it("Deletes the used snapshot and the following ones", async function() {
+        const snapshotId1: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+        const snapshotId2: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+        const snapshotId3: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+
+        const revertedTo2: boolean = await this.provider.send("evm_revert", [
+          snapshotId2
+        ]);
+        assert.isTrue(revertedTo2);
+
+        const revertedTo3: boolean = await this.provider.send("evm_revert", [
+          snapshotId3
+        ]);
+        // snapshot 3 didn't exist anymore
+        assert.isFalse(revertedTo3);
+
+        const revertedTo1: boolean = await this.provider.send("evm_revert", [
+          snapshotId1
+        ]);
+        // snapshot 1 still existed
+        assert.isTrue(revertedTo1);
+      });
+
+      it("Resets the blockchain so that new blocks are added with the right numbers", async function() {
+        await this.provider.send("evm_mine");
+        await this.provider.send("evm_mine");
+
+        await assertLatestBlockNumber(this.provider, 2);
+
+        const snapshotId1: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+
+        await this.provider.send("evm_mine");
+
+        await assertLatestBlockNumber(this.provider, 3);
+
+        const revertedTo1: boolean = await this.provider.send("evm_revert", [
+          snapshotId1
+        ]);
+        assert.isTrue(revertedTo1);
+
+        await assertLatestBlockNumber(this.provider, 2);
+
+        await this.provider.send("evm_mine");
+
+        await assertLatestBlockNumber(this.provider, 3);
+
+        await this.provider.send("evm_mine");
+
+        const snapshotId2: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+
+        await this.provider.send("evm_mine");
+
+        const snapshotId3: string = await this.provider.send(
+          "evm_snapshot",
+          []
+        );
+
+        await this.provider.send("evm_mine");
+
+        await assertLatestBlockNumber(this.provider, 6);
+
+        const revertedTo2: boolean = await this.provider.send("evm_revert", [
+          snapshotId2
+        ]);
+        assert.isTrue(revertedTo2);
+
+        await assertLatestBlockNumber(this.provider, 4);
+      });
+
+      it("Resets the date to the right time", async function() {
+        // First, we increase the time by 100 sec
+        await this.provider.send("evm_increaseTime", [100]);
+        const startDate = new Date();
+        await this.provider.send("evm_mine");
+        const snapshotId: string = await this.provider.send("evm_snapshot", []);
+
+        const snapshotedBlock = await this.provider.send(
+          "eth_getBlockByNumber",
+          ["latest", false]
+        );
+
+        assert.equal(
+          snapshotedBlock.timestamp,
+          numberToRpcQuantity(Math.ceil(startDate.valueOf() / 1000) + 100)
+        );
+
+        // TODO: Somehow test this without a sleep
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const reverted: boolean = await this.provider.send("evm_revert", [
+          snapshotId
+        ]);
+        assert.isTrue(reverted);
+
+        await this.provider.send("evm_mine");
+        const afterRevertBlock = await this.provider.send(
+          "eth_getBlockByNumber",
+          ["latest", false]
+        );
+
+        assert.equal(
+          afterRevertBlock.timestamp,
+          numberToRpcQuantity(
+            rpcQuantityToNumber(snapshotedBlock.timestamp) + 1
+          )
+        );
+      });
+
+      it("Restores the previous state", async function() {
+        // This is a very coarse test, as we know that the entire state is
+        // managed by the vm, and is restored as a whole
+        const [from] = await this.provider.send("eth_accounts");
+
+        const balanceBeforeTx = await this.provider.send("eth_getBalance", [
+          from
+        ]);
+
+        const snapshotId: string = await this.provider.send("evm_snapshot", []);
+
+        const txParams = {
+          from,
+          to: "0x1111111111111111111111111111111111111111",
+          value: numberToRpcQuantity(1),
+          gas: numberToRpcQuantity(100000),
+          gasPrice: numberToRpcQuantity(1),
+          nonce: numberToRpcQuantity(0)
+        };
+
+        await this.provider.send("eth_sendTransaction", [txParams]);
+
+        const balanceAfterTx = await this.provider.send("eth_getBalance", [
+          from
+        ]);
+
+        assert.notEqual(balanceAfterTx, balanceBeforeTx);
+
+        const reverted: boolean = await this.provider.send("evm_revert", [
+          snapshotId
+        ]);
+        assert.isTrue(reverted);
+
+        const balanceAfterRevert = await this.provider.send("eth_getBalance", [
+          from
+        ]);
+
+        assert.equal(balanceAfterRevert, balanceBeforeTx);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds to new RPC methods to Buidler EVM: `evm_snapshot` and `evm_revert`.

They accept the same parameters and behave like the Ganache implementation of those methods.