### PR TITLE
Add web3 type extension in sample tsconfig.json

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -94,7 +94,8 @@ Next, create a file `tsconfig.json` in your project directory and put the follow
   },
   "include": ["./scripts", "./test"],
   "files": [
-    "./buidler.config.ts"
+    "./buidler.config.ts",
+    "./node_modules/@nomiclabs/buidler-web3/src/type-extensions.d.ts"
   ]
 }
 ```


### PR DESCRIPTION
Add the web3 type extension file to the `tsconfig.json` in the example.

I was checking the typescript integration and ran into the `Property 'web3' does not exist on type 'BuidlerRuntimeEnvironment'` error. While this is easy to fix and explained two sections later, I think some people reading these docs might do what I was doing: blindly copying the snippets to get it to work. This way the integration will work (kind of) out of the box.