### PR TITLE
Add regexp-based imports extraction as a fallback

### DIFF
--- a/packages/buidler-core/src/internal/solidity/imports.ts
+++ b/packages/buidler-core/src/internal/solidity/imports.ts
@@ -1,12 +1,40 @@
+import debug from "debug";
+
+const log = debug("buidler:core:solidity:imports");
+
 export function getImports(fileContent: string): string[] {
-  const parser = require("solidity-parser-antlr");
-  const ast = parser.parse(fileContent, { tolerant: true });
+  try {
+    const parser = require("solidity-parser-antlr");
+    const ast = parser.parse(fileContent, { tolerant: true });
 
-  const importedFiles: string[] = [];
+    const importedFiles: string[] = [];
 
-  parser.visit(ast, {
-    ImportDirective: (node: { path: string }) => importedFiles.push(node.path)
-  });
+    parser.visit(ast, {
+      ImportDirective: (node: { path: string }) => importedFiles.push(node.path)
+    });
 
-  return importedFiles;
+    return importedFiles;
+  } catch (error) {
+    log("Failed to parse Solidity file to extract its imports\n", error);
+    return findImportsWithRegexps(fileContent);
+  }
+}
+
+function findImportsWithRegexps(fileContent: string): string[] {
+  const importsRegexp: RegExp = /import\s+(?:(?:"([^;]*)"|'([^;]*)')(?:;|\s+as\s+[^;]*;)|.+from\s+(?:"(.*)"|'(.*)');)/g;
+
+  let imports: string[] = [];
+  let result: RegExpExecArray | null;
+
+  while (true) {
+    result = importsRegexp.exec(fileContent);
+    if (result === null) {
+      return imports;
+    }
+
+    imports = [
+      ...imports,
+      ...result.slice(1).filter((m: any) => m !== undefined)
+    ];
+  }
 }

--- a/packages/buidler-core/test/internal/solidity/imports.ts
+++ b/packages/buidler-core/test/internal/solidity/imports.ts
@@ -61,4 +61,18 @@ import "./1.sol";
 
     assert.deepEqual(imports, ["./asd.sol", "./1.sol"]);
   });
+
+  it("Should work when the parser doesn't detect some invalid syntax and the visitor breaks", () => {
+    const imports = getImports(`
+      import "a.sol";
+
+      contract C {
+        fallback () function {
+
+        }
+      }
+    `);
+
+    assert.deepEqual(imports, ["a.sol"]);
+  });
 });


### PR DESCRIPTION
We are using a parser to extract Solidity imports. This sometimes fails, mostly when the parser fails to detect invalid syntax.

This PR adds a fallback method to extract the imports using a regexp.