### PR TITLE
Fix Web3 installation in the sample project

### DIFF
--- a/packages/buidler-core/src/internal/cli/project-creation.ts
+++ b/packages/buidler-core/src/internal/cli/project-creation.ts
@@ -16,7 +16,7 @@ const QUIT_ACTION = "Quit";
 const SAMPLE_PROJECT_DEPENDENCIES = [
   "@nomiclabs/buidler-truffle5",
   "@nomiclabs/buidler-web3",
-  "web3"
+  "web3@^1.2.0"
 ];
 
 async function removeProjectDirIfPresent(projectRoot: string, dirName: string) {


### PR DESCRIPTION
Web3.js has released an RC version as `latest`. This breaks the sample project installation, because Buidler validates its plugins' dependencies, and the RC version fails that validation.

This PR fixes this situation by installing `web3@^1.2.0` instead of `web3`.