### PR TITLE
Fix console.log in internal txs made from constructors

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/consoleLogger.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/consoleLogger.ts
@@ -90,11 +90,14 @@ export class ConsoleLogger {
 
   private _collectExecutionLogs(trace: EvmMessageTrace, logs: ConsoleLogs) {
     for (const messageTrace of trace.steps) {
-      if (isEvmStep(messageTrace) || !isCallTrace(messageTrace)) {
+      if (isEvmStep(messageTrace) || isPrecompileTrace(messageTrace)) {
         continue;
       }
 
-      if (bufferToHex(messageTrace.address) === CONSOLE_ADDRESS.toLowerCase()) {
+      if (
+        isCallTrace(messageTrace) &&
+        bufferToHex(messageTrace.address) === CONSOLE_ADDRESS.toLowerCase()
+      ) {
         const log = this._maybeConsoleLog(messageTrace);
         if (log !== undefined) {
           logs.push(log);

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/console-logs/multiple-messages/multiple-creates/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/console-logs/multiple-messages/multiple-creates/c.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "./../../../../../../../../console.sol";
+
+contract D {
+  constructor() public {
+    console.log("D");
+  }
+}
+
+contract C {
+
+	constructor() public {
+		console.log("C1");
+    new D();
+    console.log("C2");
+	}
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/console-logs/multiple-messages/multiple-creates/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/console-logs/multiple-messages/multiple-creates/test.json
@@ -1,0 +1,11 @@
+{
+  "description": "Should output console.log of other contracts in their constructor",
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"],
+      "consoleLogs": [["C1"], ["D"], ["C2"]]
+    }
+  ]
+}


### PR DESCRIPTION
Another iteration of #427, this time covering internal txs made from constructors