### PR TITLE
Tests setup improvement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,16 @@ This will keep everything compiled, and these problems will be avoided.
 
 All tests are written using [mocha](https://mochajs.org) and [chai](https://www.chaijs.com).
 
-You can run a package's tests by executing `npm test` inside its folder. Or you can run all the tests at once with
-`npm test` from the root folder.
+### Per-package
+You can run a package's tests by executing `npm test` inside its folder.
+
+_Note_: for package (buidler-vyper)[./packages/buidler-vyper] case, a running instance of Docker Desktop is required, with `ethereum/vyper` image pulled. To install it, run:
+```
+docker pull ethereum/vyper:0.1.0b10
+```
+
+### Entire project
+You can run all the tests at once by running `npm test` from the root folder. Requires `ethereum/vyper` docker instance installed for package (buidler-vyper)[./packages/buidler-vyper], see previous section for details.
 
 ## Code formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ All tests are written using [mocha](https://mochajs.org) and [chai](https://www.
 ### Per-package
 You can run a package's tests by executing `npm test` inside its folder.
 
-_Note_: for package (buidler-vyper)[./packages/buidler-vyper] case, a running instance of Docker Desktop is required, with `ethereum/vyper` image pulled. To install it, run:
+_Note_: for package [buidler-vyper](./packages/buidler-vyper) case, a running instance of Docker Desktop is required, with `ethereum/vyper` image pulled. To install it, run:
 ```
 docker pull ethereum/vyper:0.1.0b10
 ```
 
 ### Entire project
-You can run all the tests at once by running `npm test` from the root folder. Requires `ethereum/vyper` docker instance installed for package (buidler-vyper)[./packages/buidler-vyper], see previous section for details.
+You can run all the tests at once by running `npm test` from the root folder. Requires `ethereum/vyper` docker instance installed for package [buidler-vyper](./packages/buidler-vyper), see previous section for details.
 
 ## Code formatting
 

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -11,8 +11,13 @@ const isGithubActions = process.env.GITHUB_WORKFLOW !== undefined;
 const isLinux = os.type() === "Linux";
 const isWindows = os.type() === "Windows_NT";
 
+// only Build tests in local environment
 const shouldBuildTests = !isGithubActions;
-const shouldIgnoreVyperTests = isGithubActions && !isLinux;
+
+// only run Vyper tests in Linux CI environment, and ignore if using a Windows machine (since Docker Desktop is required, only available windows Pro)
+const shouldIgnoreVyperTests = isGithubActions && !isLinux || isWindows;
+
+// Solpp tests don't work in Windows
 const shouldIgnoreSolppTests = isWindows;
 
 shell.exec("npm run build");


### PR DESCRIPTION
* Document Docker Desktop requirement for `buidler-vyper` package tests.
* Ignore Vyper tests for Windows environment, since Docker Desktop is not available unless using Windows 10 Pro version.

✅ Tested on Windows 10 