### PR TITLE
Make the Waffle plugin's BRE extension lazy

### DIFF
--- a/packages/buidler-waffle/src/index.ts
+++ b/packages/buidler-waffle/src/index.ts
@@ -1,14 +1,19 @@
 import { extendEnvironment, usePlugin } from "@nomiclabs/buidler/config";
-
-import { WaffleMockProviderAdapter } from "./waffle-provider-adapter";
+import { lazyObject } from "@nomiclabs/buidler/plugins";
 
 export default function() {
   extendEnvironment(bre => {
     // We can't actually implement a MockProvider because of its private
     // properties, so we cast it here 😢
-    bre.waffle = {
-      provider: new WaffleMockProviderAdapter(bre.network) as any
-    };
+    bre.waffle = lazyObject(() => {
+      const {
+        WaffleMockProviderAdapter
+      } = require("./waffle-provider-adapter");
+
+      return {
+        provider: new WaffleMockProviderAdapter(bre.network) as any
+      };
+    });
   });
 
   usePlugin("@nomiclabs/buidler-ethers");


### PR DESCRIPTION
This PR fixes a problem with the Waffle plugin.

Waffle's provider was being created in the BRE extender function, which makes a `net_version` request. This was triggering Buidler EVM's intialization before the compilation process finished.

This PR makes the extension a `lazyObject`.