### PR TITLE
buidler-core: move '--recursive' files opt from 'mocha.opts' to 'pack…

### DIFF
--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -31,8 +31,8 @@
     "lint": "npm run lint-src && npm run lint-tests",
     "lint-tests": "node -r ts-node/register ../../node_modules/tslint/bin/tslint --config tslint.json --project ./tsconfig.json",
     "lint-src": "node -r ts-node/register ../../node_modules/tslint/bin/tslint --config tslint.json --project src/tsconfig.json",
-    "test": "node ../../node_modules/mocha/bin/mocha",
-    "coverage": "node ../../node_modules/nyc/bin/nyc.js ../../node_modules/mocha/bin/mocha",
+    "test": "node ../../node_modules/mocha/bin/mocha --recursive test/**/*.ts ",
+    "coverage": "node ../../node_modules/nyc/bin/nyc.js ../../node_modules/mocha/bin/mocha --recursive test/**/*.ts",
     "build": "node ../../node_modules/typescript/bin/tsc --build src",
     "build-test": "node ../../node_modules/typescript/bin/tsc --build .",
     "clean": "node ../../node_modules/rimraf/bin.js builtin-tasks internal *.d.ts *.map *.js build-test tsconfig.tsbuildinfo"

--- a/packages/buidler-core/test/mocha.opts
+++ b/packages/buidler-core/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ts-node/register
 --require source-map-support/register
---recursive test/**/*.ts --exclude test/fixture-projects/**/*.ts --exclude test/fixture-projects/**/*.js --exclude test/helpers/**/*.ts
+--exclude test/fixture-projects/**/*.ts --exclude test/fixture-projects/**/*.js --exclude test/helpers/**/*.ts
 --timeout 25000


### PR DESCRIPTION
…age.json' 'test' script.

    * this enables running specific mocha tests without enforcing
    ts-node parsing of ALL test files, since the .opts config is always loaded.
    * individual test run time goes from about ~35 seconds to ~4 seconds.
    * global test run time is unaffected, so this is only useful for local testing.