### PR TITLE
Add quotes package version

### DIFF
--- a/packages/buidler-core/src/internal/core/errors-list.ts
+++ b/packages/buidler-core/src/internal/core/errors-list.ts
@@ -632,7 +632,7 @@ Please follow Buidler's instructions to resolve this.`
     MISSING_DEPENDENCY: {
       number: 801,
       message: `Plugin %plugin% requires %dependency% to be installed.
-%extraMessage%Please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%`,
+%extraMessage%Please run: npm install --save-dev%extraFlags% "%dependency%@%versionSpec%"`,
       title: "Plugin dependencies not installed",
       description: `You are trying to use a plugin with unmet dependencies. 
 
@@ -641,7 +641,7 @@ Please follow Buidler's instructions to resolve this.`
     DEPENDENCY_VERSION_MISMATCH: {
       number: 802,
       message: `Plugin %plugin% requires %dependency% version %versionSpec% but got %installedVersion%.
-%extraMessage%If you haven't installed %dependency% manually, please run: npm install --save-dev%extraFlags% %dependency%@%versionSpec%
+%extraMessage%If you haven't installed %dependency% manually, please run: npm install --save-dev%extraFlags% "%dependency%@%versionSpec%"
 If you have installed %dependency% yourself, please reinstall it with a valid version.`,
       title: "Plugin dependencies's version mismatch",
       description: `You are trying to use a plugin that requires a different version of one of its dependencies. 


### PR DESCRIPTION
When a plugin requires another one to be installed, the error message says:

```
npm install --save-dev @nomiclabs/buidler-web3@^1.2.0
```

which is nice because you can easily copy and paste it (well, unless you use yarn, but that's something for a different issue). The problem is that this doesn't work in zsh if you have `extendedglob` enabled.

This PR just surrounds the package and version with double quotes. Maybe a better solution is to check if there's a caret in the version and add quotes just in that case... but that seems more involved, so I went with the easy solution.