### PR TITLE
Test dev perf enhancements III (global test run in parallel)

### DIFF
--- a/packages/buidler-core/test/internal/core/typescript-support.ts
+++ b/packages/buidler-core/test/internal/core/typescript-support.ts
@@ -17,7 +17,7 @@ describe("Typescript support", function() {
     it("Should fail if an implicit any is used and the tsconfig forbids them", function() {
       // If we run this test in transpilation only mode, it will fail
       if (process.env.TS_NODE_TRANSPILE_ONLY === "true") {
-        return;
+        this.skip();
       }
 
       assert.throws(

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -44,7 +44,10 @@ if (shouldIgnoreSolppTests) {
 const nodeArgs = process.argv.slice(2);
 const testArgs = nodeArgs.length > 0 && `-- ${nodeArgs.join(" ")}`;
 
-const testRunCommand = `npm run test ${testArgs || ""}`;
+// default unlimited timeout for tests as we are running most of them in parallel.
+const defaultTestArgs = '-- --timeout "0"';
+
+const testRunCommand = `npm run test ${testArgs || defaultTestArgs}`;
 
 function packagesToGlobStr(packages) {
   return packages.length === 1 ? packages[0] : `{${packages.join(",")}}`;
@@ -54,6 +57,31 @@ const ignoredPackagesFilter =
   Array.isArray(ignoredPackages) && ignoredPackages.length > 0
     ? `--ignore "${packagesToGlobStr(ignoredPackages)}"`
     : "";
+
+// ** setup packages to be run in parallel and in series ** //
+
+// Packages requiring a running ganache instance are run in series
+// as an attempt to not overload the process resulting in a slower
+// operation.  The rest of packages, are all run in parallel.
+const ganacheDependantPackages = [
+  "@nomiclabs/buidler-ethers",
+  "@nomiclabs/buidler-etherscan",
+  "@nomiclabs/buidler-truffle4",
+  "@nomiclabs/buidler-truffle5",
+  "@nomiclabs/buidler-web3",
+  "@nomiclabs/buidler-web3-legacy"
+].filter(p => !ignoredPackages.includes(p));
+
+const ignoredPackagesGlobStr = packagesToGlobStr(ignoredPackages);
+const ganacheDependantPackagesGlobStr = packagesToGlobStr(
+  ganacheDependantPackages
+);
+
+const parallelPackageFilter = `${ignoredPackagesFilter} --ignore "${ganacheDependantPackagesGlobStr}"`;
+const seriesPackageFilter = ` ${ignoredPackagesFilter} --scope "${ganacheDependantPackagesGlobStr}"`;
+
+const lernaExecParallel = `npx lerna exec --parallel ${parallelPackageFilter} -- ${testRunCommand}`;
+const lernaExecSeries = `npx lerna exec --concurrency 1 --stream ${seriesPackageFilter} -- ${testRunCommand}`;
 
 const {
   cleanup,
@@ -69,6 +97,33 @@ async function useGanacheInstance() {
   }
 }
 
+function shellExecAsync(cmd, opts = {}) {
+  return new Promise(function(resolve, reject) {
+    // Execute the command, reject if we exit non-zero (i.e. error)
+    shell.exec(cmd, opts, function(code, stdout, stderr) {
+      if (code !== 0) return reject(new Error(stderr));
+      return resolve(stdout);
+    });
+  });
+}
+
+async function runTests() {
+  console.log("Running: ", { lernaExecParallel }, { lernaExecSeries });
+
+  // Measure execution times
+  console.time("Total test time");
+  console.time("parallel exec");
+  console.time("series exec");
+  await Promise.all([
+    shellExecAsync(lernaExecParallel).then(() =>
+      console.timeEnd("parallel exec")
+    ),
+    shellExecAsync(lernaExecSeries).then(() => console.timeEnd("series exec"))
+  ]);
+
+  console.timeEnd("Total test time");
+}
+
 async function main() {
   /* Ensure a ganache instance is running */
   const ganacheInstance = await useGanacheInstance();
@@ -80,13 +135,7 @@ async function main() {
 
   try {
     /* Run all tests */
-    console.time("test all");
-    shell.exec(
-      `npx lerna exec ${ignoredPackagesFilter} --no-private ` +
-        ` --concurrency 1  ` +
-        ` -- ${testRunCommand}`
-    );
-    console.timeEnd("test all");
+    await runTests();
   } finally {
     /* Cleanup ganache instance */
     if (ganacheInstance) {


### PR DESCRIPTION
Run non-ganache-dependant packages tests in parallel.

The ganache-dependant packages are run in series, to prevent overloading the local ganache instance with requests. 

This is an just experimental or "proposal" PR. The intention is to discuss if the tradeoff of a faster global test execution time, is worth the "sacrifice" in clarity of the test logs (they will be unavoidably interleaved). However, maybe this is not too bad considering that the important stuff is still visible, such as a failing test and context info on which/where/why the test failed. Also, as a matter of thought, maybe we can think on reducing the amount of logs by using a different test reporter, such as the builtin "dot" reporter - we probably don't need to see over and over the names of the tests that do pass.
On the other hand, the test time is just one metric among many others such as build time, install time, etc, and maybe the difference is not a big deal to justify this sacrifice.
