### PR TITLE
Fix ci run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,13 @@
 name: CI
 
 on:
-  push
+  push:
+    branches:
+      - master
+      - development
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - development
+      # We want to build "wip*" branches since they are not intended for PRs.
+      - "[Ww][Ii][Pp]*"
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
Run CI triggers on:
1. Push to main branches (master, development) + auxiliar "wip*"-prefixed brances (for internal use)
2. Pull Request from any branch, internal or external (forks)

The only issue is that we won't get checks on regular feature/fix/wip branches until a PR is created.. We'll see if we can find a better alternative from the GH community (on [this post](https://github.community/t5/GitHub-Actions/Duplicate-checks-on-quot-push-quot-and-quot-pull-request-quot/m-p/52171#M8425) I've created)