### PR TITLE
Allow extra headers

### DIFF
--- a/packages/buidler-core/src/internal/core/providers/construction.ts
+++ b/packages/buidler-core/src/internal/core/providers/construction.ts
@@ -52,7 +52,7 @@ export function createProvider(
     provider = new HttpProvider(
       httpNetConfig.url!,
       networkName,
-      undefined,
+      httpNetConfig.headers,
       httpNetConfig.timeout
     );
   }

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -49,6 +49,7 @@ export type NetworkConfigAccounts =
 export interface HttpNetworkConfig extends CommonNetworkConfig {
   url?: string;
   timeout?: number;
+  headers?: { [name: string]: string };
   accounts?: NetworkConfigAccounts;
 }
 


### PR DESCRIPTION
The Aragon buidler plugin requires extra headers to identify itself to [Frame](https://frame.sh/)

This PR applies the existing extraHeaders functionality to the user's provided network config

---

If you would prefer this change to target the `master` branch see PR https://github.com/nomiclabs/buidler/pull/501