### PR TITLE
Verify deployed vs local bytecode before publishing on Etherscan

### DIFF
--- a/packages/buidler-core/src/builtin-tasks/compile.ts
+++ b/packages/buidler-core/src/builtin-tasks/compile.ts
@@ -64,7 +64,7 @@ async function getSolcOutputFromCache(config: ResolvedBuidlerConfig) {
   await fsExtra.ensureDir(config.paths.cache);
 
   return fsExtra.readJSON(path.join(config.paths.cache, SOLC_OUTPUT_FILENAME), {
-    encoding: "utf8"
+    encoding: "utf8",
   });
 }
 

--- a/packages/buidler-core/src/builtin-tasks/task-names.ts
+++ b/packages/buidler-core/src/builtin-tasks/task-names.ts
@@ -7,6 +7,7 @@ export const TASK_COMPILE_GET_SOURCE_PATHS = "compile:get-source-paths";
 export const TASK_COMPILE_GET_RESOLVED_SOURCES = "compile:get-resolved-sources";
 export const TASK_COMPILE_GET_DEPENDENCY_GRAPH = "compile:get-dependency-graph";
 export const TASK_COMPILE_GET_COMPILER_INPUT = "compile:get-compiler-input";
+export const TASK_COMPILE_GET_COMPILER_OUTPUT = "compile:get-compiler-output";
 export const TASK_COMPILE_RUN_COMPILER = "compile:run-compiler";
 export const TASK_COMPILE_COMPILE = "compile:compile";
 export const TASK_COMPILE_CHECK_CACHE = "compile:cache";

--- a/packages/buidler-etherscan/README.md
+++ b/packages/buidler-etherscan/README.md
@@ -49,7 +49,7 @@ module.exports = {
 Lastly, run the `verify-contract` task like so:
 
 ```bash
-npx buidler verify-contract --contract-name MyContract --address DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
+npx buidler verify-contract --address DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
 ```
 
 ## TypeScript support

--- a/packages/buidler-etherscan/package.json
+++ b/packages/buidler-etherscan/package.json
@@ -36,6 +36,7 @@
     "README.md"
   ],
   "dependencies": {
+    "debug": "^4.1.1",
     "ethereumjs-abi": "^0.6.8",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@nomiclabs/buidler": "^1.3.2",
     "@types/chai": "^4.2.0",
+    "@types/debug": "^4.1.4",
     "@types/ethereumjs-abi": "^0.6.3",
     "@types/nock": "^9.3.1",
     "@types/request": "^2.48.1",

--- a/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
@@ -1,7 +1,10 @@
 import { BuidlerPluginError } from "@nomiclabs/buidler/plugins";
+import debug from "debug";
 import request from "request-promise";
 
 import { EtherscanRequestParameters } from "./EtherscanVerifyContractRequest";
+
+const log = debug("buidler:etherscan:etherscan-service");
 
 async function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -12,10 +15,14 @@ export async function verifyContract(
   req: EtherscanRequestParameters
 ): Promise<EtherscanResponse> {
   try {
+    log("verifyContract url=%s req=%o", url, req);
+
     const response = new EtherscanResponse(
       // tslint:disable-next-line: await-promise
       await request.post(url, { form: req, json: true })
     );
+
+    log("verifyContract: response=%o", response);
 
     if (!response.isOk()) {
       throw new BuidlerPluginError(response.message);
@@ -32,24 +39,31 @@ export async function verifyContract(
 
 export async function getVerificationStatus(
   url: string,
+  apikey: string,
   guid: string
 ): Promise<EtherscanResponse> {
   try {
+    log("getVerificationStatus url=%s apikey=%s guid=%s", url, apikey, guid);
+
     const response = new EtherscanResponse(
       // tslint:disable-next-line: await-promise
       await request.get(url, {
         json: true,
         qs: {
+          apikey,
           module: "contract",
           action: "checkverifystatus",
           guid,
         },
       })
     );
+
+    log("getVerificationStatus: response=%o", response);
+
     if (response.isPending()) {
       await delay(3000);
 
-      return getVerificationStatus(url, guid);
+      return getVerificationStatus(url, apikey, guid);
     }
     if (!response.isOk()) {
       throw new BuidlerPluginError(response.message);
@@ -60,6 +74,66 @@ export async function getVerificationStatus(
     throw new BuidlerPluginError(
       `Failed to verify contract. Reason: ${error.message}`
     );
+  }
+}
+
+export async function getCode(
+  url: string,
+  apikey: string,
+  address: string
+): Promise<EtherscanGetResponse> {
+  try {
+    log("getCode url=%s apikey=%s address=%s", url, apikey, address);
+
+    const response = new EtherscanGetResponse(
+      // tslint:disable-next-line: await-promise
+      await request.get(url, {
+        qs: {
+          module: "proxy",
+          action: "eth_getCode",
+          address,
+          tag: "latest",
+          apikey
+        }
+      })
+    );
+
+    log("getCode: response=%o", response);
+
+    if (response.isPending()) {
+      await delay(1000);
+
+      return getCode(url, apikey, address);
+    }
+    if (!response.isOk()) {
+      throw new BuidlerPluginError(JSON.stringify(response.error));
+    }
+
+    return response;
+  } catch (error) {
+    throw new BuidlerPluginError(
+      `Failed to get contract code. Reason: ${error.message}`
+    );
+  }
+}
+
+export class EtherscanGetResponse {
+  public readonly error: string;
+
+  public readonly result: string;
+
+  public constructor(responseJson: any) {
+    const response = JSON.parse(responseJson);
+    this.error = response.error;
+    this.result = response.result;
+  }
+
+  public isPending() {
+    return this.result === "Pending in queue";
+  }
+
+  public isOk() {
+    return this.error === undefined;
   }
 }
 

--- a/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
@@ -93,8 +93,8 @@ export async function getCode(
           action: "eth_getCode",
           address,
           tag: "latest",
-          apikey
-        }
+          apikey,
+        },
       })
     );
 

--- a/packages/buidler-etherscan/src/index.ts
+++ b/packages/buidler-etherscan/src/index.ts
@@ -1,6 +1,6 @@
 import {
   TASK_COMPILE,
-  TASK_COMPILE_GET_COMPILER_INPUT
+  TASK_COMPILE_GET_COMPILER_INPUT,
 } from "@nomiclabs/buidler/builtin-tasks/task-names";
 import { task } from "@nomiclabs/buidler/config";
 import { getArtifactFromContractOutput } from "@nomiclabs/buidler/internal/artifacts";
@@ -13,7 +13,7 @@ import {
   EtherscanGetResponse,
   getCode,
   getVerificationStatus,
-  verifyContract
+  verifyContract,
 } from "./etherscan/EtherscanService";
 import { toRequest } from "./etherscan/EtherscanVerifyContractRequest";
 import { getLongVersion } from "./solc/SolcVersions";
@@ -119,7 +119,7 @@ task("verify-contract", "Verifies contract on etherscan")
           abi,
           taskArgs.constructorArguments
         ),
-        libraries: taskArgs.libraries
+        libraries: taskArgs.libraries,
       });
 
       console.log(

--- a/packages/buidler-etherscan/test/integration/PluginTests.ts
+++ b/packages/buidler-etherscan/test/integration/PluginTests.ts
@@ -9,11 +9,11 @@ import path from "path";
 import { useEnvironment } from "../helpers";
 
 async function delay(timeout: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, timeout));
+  return new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
 // These are skipped because they can't currently be run in CI
-describe.skip("Plugin integration tests", function() {
+describe.skip("Plugin integration tests", function () {
   this.timeout(1000000);
 
   const DEPLOY_SLEEP_TIME = 10000;
@@ -29,7 +29,7 @@ describe.skip("Plugin integration tests", function() {
 
     this.afterEach(() => restoreContract(placeholder));
 
-    it("Test verifying deployed contract on etherscan", async function() {
+    it("Test verifying deployed contract on etherscan", async function () {
       await this.env.run(TASK_COMPILE, { force: false });
 
       const { bytecode, abi } = await readArtifact(
@@ -39,7 +39,7 @@ describe.skip("Plugin integration tests", function() {
       const amount = "20";
 
       const deployedAddress = await deployContract(abi, `${bytecode}`, [
-        amount
+        amount,
       ]);
 
       // Sleep for a while to avoid Etherscan API race condition on last deployed contract
@@ -51,7 +51,7 @@ describe.skip("Plugin integration tests", function() {
           libraries: JSON.stringify({
             // SafeMath: "0x292FFB096f7221c0C879c21535058860CcA67f58"
           }),
-          constructorArguments: [amount]
+          constructorArguments: [amount],
         });
 
         assert.isTrue(true);
@@ -62,7 +62,7 @@ describe.skip("Plugin integration tests", function() {
       return true;
     });
 
-    it("Should verify deployed inner contract on etherscan", async function() {
+    it("Should verify deployed inner contract on etherscan", async function () {
       await this.env.run(TASK_COMPILE, { force: false });
 
       const { bytecode, abi } = await readArtifact(
@@ -79,7 +79,7 @@ describe.skip("Plugin integration tests", function() {
         await this.env.run("verify-contract", {
           address: deployedAddress,
           libraries: JSON.stringify({}),
-          constructorArguments: []
+          constructorArguments: [],
         });
 
         assert.isTrue(true);
@@ -90,7 +90,7 @@ describe.skip("Plugin integration tests", function() {
       return true;
     });
 
-    it("Should verify deployed contract with name clash on etherscan", async function() {
+    it("Should verify deployed contract with name clash on etherscan", async function () {
       await this.env.run(TASK_COMPILE, { force: false });
 
       const { bytecode, abi } = await readArtifact(
@@ -106,7 +106,7 @@ describe.skip("Plugin integration tests", function() {
         await this.env.run("verify-contract", {
           address: deployedAddress,
           libraries: JSON.stringify({}),
-          constructorArguments: []
+          constructorArguments: [],
         });
 
         assert.isTrue(true);
@@ -118,11 +118,11 @@ describe.skip("Plugin integration tests", function() {
 
   describe("Using a Buidler project with circular dependencies", () => {
     useEnvironment(path.join(__dirname, "..", "buidler-project-circular-dep"));
-    it("Fails with an error message indicating to use Etherscan's GUI", async function() {
+    it("Fails with an error message indicating to use Etherscan's GUI", async function () {
       this.env
         .run("verify-contract", {
           address: "0x0",
-          constructorArguments: []
+          constructorArguments: [],
         })
         .catch((e: any) => assert.instanceOf(e, BuidlerPluginError));
     });

--- a/packages/buidler-etherscan/test/integration/PluginTests.ts
+++ b/packages/buidler-etherscan/test/integration/PluginTests.ts
@@ -122,7 +122,6 @@ describe.skip("Plugin integration tests", function() {
       this.env
         .run("verify-contract", {
           address: "0x0",
-          contractName: "TestContract",
           constructorArguments: []
         })
         .catch((e: any) => assert.instanceOf(e, BuidlerPluginError));


### PR DESCRIPTION
This PR implements the changes proposed in #441 in order to:
- compare the deployed vs local bytecode before trying to verify a contract on Etherscan
- thanks to bytecode matching, get rid of `contractName` parameter in `verify-contract` task

Fixes #441 

Additional content:
- bugfix: add Etherscan API key now required in also `checkverifystatus` API
- bugfix: add delay in tests to prevent alleged Etherscan API race condition causing temporary verification failure
- add debug log traces to `buidler-etherscan` package