### PR TITLE
Enable buidler evm to support exact timestamp testing

### DIFF
--- a/docs/buidler-evm/README.md
+++ b/docs/buidler-evm/README.md
@@ -227,9 +227,10 @@ To customise it, take a look at [the configuration section](/config/#buidler-evm
 #### Special testing/debugging methods
 
 - `evm_increaseTime` – same as Ganache.
-- `evm_mine` – same as Ganache, except it doesn’t accept a timestamp.
+- `evm_mine` – same as Ganache
 - `evm_revert` – same as Ganache.
 - `evm_snapshot` – same as Ganache.
+- `evm_setNextBlockTimestamp` - set the timestamp to be used for the next block, if next block is mined with a timestamp, this set will be resetted, on the other hand, it is only effective for only 1 next block.
 
 ### Unsupported methods
 

--- a/packages/buidler-core/src/internal/buidler-evm/provider/input.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/input.ts
@@ -316,6 +316,5 @@ export function validateParams(params: any[], ...types: Array<t.Type<any>>) {
 
     decoded.push(result.value);
   }
-
   return decoded;
 }

--- a/packages/buidler-core/src/internal/buidler-evm/provider/modules/evm.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/modules/evm.ts
@@ -1,7 +1,11 @@
 import { BN } from "ethereumjs-util";
 import * as t from "io-ts";
 
-import { MethodNotFoundError, MethodNotSupportedError } from "../errors";
+import {
+  InvalidInputError,
+  MethodNotFoundError,
+  MethodNotSupportedError
+} from "../errors";
 import { rpcQuantity, validateParams } from "../input";
 import { BuidlerNode } from "../node";
 import { numberToRpcQuantity } from "../output";
@@ -19,6 +23,11 @@ export class EvmModule {
       case "evm_increaseTime":
         return this._increaseTimeAction(...this._increaseTimeParams(params));
 
+      case "evm_setNextBlockTimestamp":
+        return this._setNextBlockTimestampAction(
+          ...this._setNextBlockTimestampParams(params)
+        );
+
       case "evm_mine":
         return this._mineAction(...this._mineParams(params));
 
@@ -30,6 +39,29 @@ export class EvmModule {
     }
 
     throw new MethodNotFoundError(`Method ${method} not found`);
+  }
+
+  // evm_setNextBlockTimestamp
+
+  private _setNextBlockTimestampParams(params: any[]): [number] {
+    return validateParams(params, t.number);
+  }
+
+  private async _setNextBlockTimestampAction(
+    timestamp: number
+  ): Promise<string> {
+    const latestBlock = await this._node.getLatestBlock();
+    const increment = new BN(timestamp).sub(
+      new BN(latestBlock.header.timestamp)
+    );
+    if (increment.lte(new BN(0))) {
+      throw new InvalidInputError(
+        `Timestamp ${timestamp} is lower than previous block's timestamp` +
+          `${new BN(latestBlock.header.timestamp).toNumber()}`
+      );
+    }
+    await this._node.setNextBlockTimestamp(new BN(timestamp));
+    return timestamp.toString();
   }
 
   // evm_increaseTime
@@ -47,12 +79,37 @@ export class EvmModule {
 
   // evm_mine
 
-  private _mineParams(params: any[]): [] {
-    return validateParams(params);
+  private _mineParams(params: any[]): [number] {
+    if (params.length === 0) {
+      params.push(0);
+    }
+    return validateParams(params, t.number);
   }
 
-  private async _mineAction(): Promise<string> {
-    await this._node.mineEmptyBlock();
+  private async _advanceTimeOffsetAccordingToTimestamp(timestamp: BN) {
+    const latestBlock = await this._node.getLatestBlock();
+    const increment = new BN(timestamp).sub(
+      new BN(latestBlock.header.timestamp)
+    );
+    if (increment.lte(new BN(0))) {
+      throw new InvalidInputError(
+        `Timestamp ${timestamp} is lower than previous block's timestamp`
+      );
+    }
+    await this._node.increaseTime(increment);
+  }
+
+  private async _mineAction(timestamp: number): Promise<string> {
+    if (timestamp !== 0) {
+      await this._advanceTimeOffsetAccordingToTimestamp(new BN(timestamp));
+    } else {
+      const nextBlockTimestamp = await this._node.getNextBlockTimestamp();
+      if (!nextBlockTimestamp.eq(new BN(0))) {
+        timestamp = nextBlockTimestamp.toNumber();
+        await this._advanceTimeOffsetAccordingToTimestamp(new BN(timestamp));
+      }
+    }
+    await this._node.mineEmptyBlock(new BN(timestamp));
     return numberToRpcQuantity(0);
   }
 

--- a/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
@@ -361,11 +361,6 @@ export class BuidlerNode extends EventEmitter {
 
     const block = await this._getNextBlockTemplate();
 
-    const timestamp = await this._getNextUsableBlockTimestamp();
-    if (!timestamp.eq(new BN(0))) {
-      await this._setBlockTimestamp(block, timestamp);
-    }
-
     const needsTimestampIncrease = await this._timestampClashesWithPreviousBlockOne(
       block
     );
@@ -421,9 +416,11 @@ export class BuidlerNode extends EventEmitter {
 
   public async mineEmptyBlock(timestamp: BN) {
     const block = await this._getNextBlockTemplate();
+
     if (!timestamp.eq(new BN(0))) {
       await this._setBlockTimestamp(block, timestamp);
     }
+
     const needsTimestampIncrease = await this._timestampClashesWithPreviousBlockOne(
       block
     );
@@ -1266,12 +1263,12 @@ export class BuidlerNode extends EventEmitter {
     return latestBlockTimestamp.eq(blockTimestamp);
   }
 
-  private async _setBlockTimestamp(block: Block, timestamp: BN) {
-    block.header.timestamp = new BN(timestamp);
-  }
-
   private async _increaseBlockTimestamp(block: Block) {
     block.header.timestamp = new BN(block.header.timestamp).addn(1);
+  }
+
+  private async _setBlockTimestamp(block: Block, timestamp: BN) {
+    block.header.timestamp = new BN(timestamp);
   }
 
   private async _validateTransaction(tx: Transaction) {

--- a/packages/buidler-core/test/internal/buidler-evm/provider/modules/evm.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/provider/modules/evm.ts
@@ -1,19 +1,55 @@
 import { assert } from "chai";
-import { zeroAddress } from "ethereumjs-util";
+import {
+  bufferToHex,
+  privateToAddress,
+  toBuffer,
+  zeroAddress
+} from "ethereumjs-util";
 
 import {
   bufferToRpcData,
   numberToRpcQuantity,
   RpcBlockOutput
 } from "../../../../../src/internal/buidler-evm/provider/output";
+import { getCurrentTimestamp } from "../../../../../src/internal/buidler-evm/provider/utils";
 import { rpcQuantityToNumber } from "../../../../../src/internal/core/providers/provider-utils";
+import { EthereumProvider } from "../../../../../src/types";
 import {
   assertInvalidArgumentsError,
-  assertLatestBlockNumber
+  assertLatestBlockNumber,
+  assertQuantity
 } from "../../helpers/assertions";
+import { EXAMPLE_CONTRACT } from "../../helpers/contracts";
 import { quantityToNumber } from "../../helpers/conversions";
 import { setCWD } from "../../helpers/cwd";
-import { PROVIDERS } from "../../helpers/useProvider";
+import {
+  DEFAULT_ACCOUNTS,
+  DEFAULT_BLOCK_GAS_LIMIT,
+  PROVIDERS
+} from "../../helpers/useProvider";
+
+const DEFAULT_ACCOUNTS_ADDRESSES = DEFAULT_ACCOUNTS.map(account =>
+  bufferToHex(privateToAddress(toBuffer(account.privateKey))).toLowerCase()
+);
+
+async function deployContract(
+  provider: EthereumProvider,
+  deploymentCode: string
+) {
+  const hash = await provider.send("eth_sendTransaction", [
+    {
+      from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+      data: deploymentCode,
+      gas: numberToRpcQuantity(DEFAULT_BLOCK_GAS_LIMIT)
+    }
+  ]);
+
+  const { contractAddress } = await provider.send("eth_getTransactionReceipt", [
+    hash
+  ]);
+
+  return contractAddress;
+}
 
 describe("Evm module", function() {
   PROVIDERS.forEach(provider => {
@@ -80,6 +116,81 @@ describe("Evm module", function() {
         });
       });
 
+      describe("evm_setNextBlockTimestamp", async function() {
+        it("should set next block timestamp and the next EMPTY block will be mined with that timestamp", async function() {
+          const timestamp = getCurrentTimestamp() + 60;
+
+          await this.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+          await this.provider.send("evm_mine", []);
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            ["latest", false]
+          );
+
+          assertQuantity(block.timestamp, timestamp);
+        });
+        it("should set next block timestamp and the next tx will be mined with that timestamp", async function() {
+          const timestamp = getCurrentTimestamp() + 70;
+
+          await this.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+          await deployContract(
+            this.provider,
+            `0x${EXAMPLE_CONTRACT.bytecode.object}`
+          );
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            ["latest", false]
+          );
+
+          assertQuantity(block.timestamp, timestamp);
+        });
+        it("should be able to set and replace an existing 'next block timestamp'", async function() {
+          const timestamp = getCurrentTimestamp() + 60;
+
+          await this.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+          await this.provider.send("evm_setNextBlockTimestamp", [
+            timestamp + 10
+          ]);
+          await this.provider.send("evm_mine", []);
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            ["latest", false]
+          );
+
+          assertQuantity(block.timestamp, timestamp + 10);
+        });
+        it("should be reset after the next block is mined", async function() {
+          const timestamp = getCurrentTimestamp() + 60;
+
+          await this.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+          await this.provider.send("evm_mine", []);
+          await this.provider.send("evm_mine", []);
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            ["latest", false]
+          );
+
+          assert.isTrue(quantityToNumber(block.timestamp) > timestamp);
+        });
+        it("should be overriden if next EMPTY block is mined with timestamp", async function() {
+          const timestamp = getCurrentTimestamp() + 90;
+
+          await this.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+          await this.provider.send("evm_mine", [timestamp + 100]);
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            ["latest", false]
+          );
+
+          assertQuantity(block.timestamp, timestamp + 100);
+        });
+      });
+
       describe("evm_mine", async function() {
         it("should mine an empty block", async function() {
           await this.provider.send("evm_mine");
@@ -99,6 +210,30 @@ describe("Evm module", function() {
           );
 
           assert.isEmpty(block2.transactions);
+        });
+        it("should mine an empty block with exact timestamp", async function() {
+          const timestamp = getCurrentTimestamp() + 60;
+          await this.provider.send("evm_mine", [timestamp]);
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            [numberToRpcQuantity(1), false]
+          );
+
+          assertQuantity(block.timestamp, timestamp);
+        });
+        it("should mine an empty block with the timestamp and other later blocks have higher timestamp", async function() {
+          const timestamp = getCurrentTimestamp() + 60;
+          await this.provider.send("evm_mine", [timestamp]);
+          await this.provider.send("evm_mine");
+          await this.provider.send("evm_mine");
+
+          const block: RpcBlockOutput = await this.provider.send(
+            "eth_getBlockByNumber",
+            [numberToRpcQuantity(2), false]
+          );
+
+          assert.isTrue(quantityToNumber(block.timestamp) > timestamp);
         });
       });
 


### PR DESCRIPTION
**Changes:**

1. Allow evm_mine to accept a timestamp param to mine an empty block at the exact timestamp.
2. Add new evm_setNextBlockTimestamp to register a timestamp for the next block to be mined at.
3. Add the doc for evm_setNextBlockTimestamp.
4. Add relevant tests for those changes.

**Noted behaviors:**
Regarding `evm_setNextBlockTimestamp`, it requires one and only one timestamp param. It set the timestamp as a field named `_nextBlockTimestamp` of the `node`, this field is taken and restored as per snapshot operations, just like `blockTimeOffsetInSeconds`. Once the `_nextBlockTimestamp` is set, the next block will be mined with the timestamp set to its value, EXCEPT if the next block is mined with `evm_mine(timestamp`. Whenever a new block is mined, `_nextBlockTimestamp` is reset to 0 as its null state.

**Usecase:**
For smart contracts that have block timestamp logic, it is necessary to test its edge cases where a transaction is mined at an exact timestamp.