### PR TITLE
Http headers config polishing

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -89,6 +89,8 @@ This kind of networks are configured with objects with the following fields:
 
 - `accounts`: This field controls which accounts Buidler uses. It can use the node's accounts (by setting it to `"remote"`), a list of local accounts (by setting it to an array of hex-encoded private keys), or use an [HD Wallet](#hd-wallet-config). Default value: `"remote"`.
 
+- `httpHeaders`: You can use this field to set extra HTTP Headers to be used when making JSON-RPC requests. It accepts a JavaScript object which maps header names to their values. Default value: `undefined`.
+
 ### HD Wallet config
 
 To use an HD Wallet with Buidler you should set your network's `accounts` field to an object with the following fields:

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -321,6 +321,17 @@ export function getValidationErrors(config: any): string[] {
           )
         );
       }
+
+      const netConfigResult = HttpNetworkConfig.decode(netConfig);
+      if (netConfigResult.isLeft()) {
+        errors.push(
+          getErrorMessage(
+            `BuidlerConfig.networks.${networkName}`,
+            netConfig,
+            "HttpNetworkConfig"
+          )
+        );
+      }
     }
   }
 

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -110,6 +110,8 @@ const NetworkConfigAccounts = t.union([
   OtherAccountsConfig
 ]);
 
+const HttpHeaders = t.record(t.string, t.string, "httpHeaders");
+
 const HttpNetworkConfig = t.type({
   chainId: optional(t.number),
   from: optional(t.string),
@@ -117,7 +119,8 @@ const HttpNetworkConfig = t.type({
   gasPrice: optional(t.union([t.literal("auto"), t.number])),
   gasMultiplier: optional(t.number),
   url: optional(t.string),
-  accounts: optional(NetworkConfigAccounts)
+  accounts: optional(NetworkConfigAccounts),
+  httpHeaders: optional(HttpHeaders)
 });
 
 const NetworkConfig = t.union([BuidlerNetworkConfig, HttpNetworkConfig]);

--- a/packages/buidler-core/src/internal/core/providers/construction.ts
+++ b/packages/buidler-core/src/internal/core/providers/construction.ts
@@ -52,7 +52,7 @@ export function createProvider(
     provider = new HttpProvider(
       httpNetConfig.url!,
       networkName,
-      httpNetConfig.headers,
+      httpNetConfig.httpHeaders,
       httpNetConfig.timeout
     );
   }

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -49,7 +49,7 @@ export type NetworkConfigAccounts =
 export interface HttpNetworkConfig extends CommonNetworkConfig {
   url?: string;
   timeout?: number;
-  headers?: { [name: string]: string };
+  httpHeaders?: { [name: string]: string };
   accounts?: NetworkConfigAccounts;
 }
 

--- a/packages/buidler-core/test/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/test/internal/core/config/config-validation.ts
@@ -496,6 +496,96 @@ describe("Config validation", function() {
           });
         });
 
+        describe("HttpHeaders", function() {
+          it("Should be optional", function() {
+            const errors = getValidationErrors({
+              networks: {
+                custom: {
+                  url: "http://localhost"
+                }
+              }
+            });
+            assert.isEmpty(errors);
+          });
+
+          it("Should accept a mapping of strings to strings", function() {
+            const errors = getValidationErrors({
+              networks: {
+                custom: {
+                  url: "http://localhost",
+                  httpHeaders: {
+                    a: "asd",
+                    b: "a"
+                  }
+                }
+              }
+            });
+            assert.isEmpty(errors);
+          });
+
+          it("Should reject other types", function() {
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    custom: {
+                      url: "http://localhost",
+                      httpHeaders: 123
+                    }
+                  }
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    custom: {
+                      url: "http://localhost",
+                      httpHeaders: "123"
+                    }
+                  }
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+          });
+
+          it("Should reject non-string values", function() {
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    custom: {
+                      url: "http://localhost",
+                      httpHeaders: {
+                        a: "a",
+                        b: 123
+                      }
+                    }
+                  }
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    custom: {
+                      url: "http://localhost",
+                      httpHeaders: {
+                        a: "a",
+                        b: false
+                      }
+                    }
+                  }
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+          });
+        });
+
         describe("Accounts field", function() {
           it("Shouldn't work with invalid types", function() {
             expectBuidlerError(


### PR DESCRIPTION
This PR does a few small improvements to #502:
- It renames `headers` to `httpHeaders`.
- Documents this new option.
- Adds validation logic for it.
