### PR TITLE
Update Solidity parser

### DIFF
--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@nomiclabs/ethereumjs-vm": "^4.1.1",
+    "@solidity-parser/parser": "^0.5.2",
     "@types/bn.js": "^4.11.5",
     "@types/lru-cache": "^5.1.0",
     "abort-controller": "^3.0.0",
@@ -106,7 +107,6 @@
     "semver": "^6.3.0",
     "slash": "^3.0.0",
     "solc": "0.5.15",
-    "solidity-parser-antlr": "^0.4.2",
     "source-map-support": "^0.5.13",
     "ts-essentials": "^2.0.7",
     "tsort": "0.0.1",

--- a/packages/buidler-core/src/internal/solidity/imports.ts
+++ b/packages/buidler-core/src/internal/solidity/imports.ts
@@ -4,7 +4,7 @@ const log = debug("buidler:core:solidity:imports");
 
 export function getImports(fileContent: string): string[] {
   try {
-    const parser = require("solidity-parser-antlr");
+    const parser = require("@solidity-parser/parser");
     const ast = parser.parse(fileContent, { tolerant: true });
 
     const importedFiles: string[] = [];


### PR DESCRIPTION
This PR changes our Solidity parser to @fvictorio's fork. 

This should fix our import extraction logic. While we have a fallback implementation, it's not very accurate and gives false positives very easily. Having a up-to-date parser is clearly better.

Note that this parser is a fork of Consensys Dilligence's fork of Fede Bond's parser, and is also used by solidity-coverage.