### PR TITLE
buidler-etherscan plugin: increase verification delay 1000 -> 3000.

### DIFF
--- a/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
+++ b/packages/buidler-etherscan/src/etherscan/EtherscanService.ts
@@ -47,7 +47,7 @@ export async function getVerificationStatus(
       })
     );
     if (response.isPending()) {
-      await delay(1000);
+      await delay(3000);
 
       return getVerificationStatus(url, guid);
     }


### PR DESCRIPTION
    * Otherwise the delay between requests is too short, and
    Etherscan API might return an error:
    `Max rate limit reached, please use API Key for higher rate limit`.
