### PR TITLE
[web/docs] Upgrade Vuepress from 0.x to 1.x

### DIFF
--- a/docs/.vuepress/components/Plugins.vue
+++ b/docs/.vuepress/components/Plugins.vue
@@ -1,36 +1,41 @@
 <template>
-<div class="content">
-  <h1>Plugins</h1>
-  <p>Plugins are the backbone of Buidler. Buidler's plugins and built-in tasks are built using the same API that you use in your Buidler configuration!</p>
-  <p>Extend Buidler's functionality with the plugins below.</p>
-  <!-- Check out the [Using Plugins Guide]() to learn more.</p> -->
-  <div class="plugins">
-    <div class="plugin" v-for="plugin in plugins">
-      <div>
-        <span class="name">
-          <a :href="plugin.url">{{ plugin.name }}</a>
-        </span>
-        <span class="separator"> | </span>
-        <span class="author">
-          <a :href="plugin.authorUrl">{{ plugin.author }}</a>
-        </span>
-        <!-- <span class="version">{{ plugin.version }}</span> -->
+  <Layout>
+    <template slot="page-top">
+      <div class="content">
+        <h1>Plugins</h1>
+        <p>Plugins are the backbone of Buidler. Buidler's plugins and built-in tasks are built using the same API that you use in your Buidler configuration!</p>
+        <p>Extend Buidler's functionality with the plugins below.</p>
+        <!-- Check out the [Using Plugins Guide]() to learn more.</p> -->
+        <div class="plugins">
+          <div class="plugin" v-for="plugin in plugins">
+            <div>
+              <span class="name">
+                <a :href="plugin.url">{{ plugin.name }}</a>
+              </span>
+              <span class="separator"> | </span>
+              <span class="author">
+                <a :href="plugin.authorUrl">{{ plugin.author }}</a>
+              </span>
+              <!-- <span class="version">{{ plugin.version }}</span> -->
+            </div>
+            <p class="description">{{ plugin.description }}</p>
+            <div class="tags">
+              <div v-for="tag in plugin.tags">{{ tag }}</div>
+            </div>
+          </div>
+        </div>
       </div>
-      <p class="description">{{ plugin.description }}</p>
-      <div class="tags">
-        <div v-for="tag in plugin.tags">{{ tag }}</div>
-      </div>
-    </div>
-  </div>
-</div>
+    </template>
+  </Layout>
 </template>
 
 <script>
+import Layout from "../theme/Layout.vue";
 
 export default {
+  components: { Layout },
   data() {
     return {"plugins": require("../plugins.js")};
   }
-}
-
+};
 </script>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -216,9 +216,13 @@ module.exports = {
     }
   },
   plugins: [
-    [
-      '@vuepress/google-analytics',
-      { ga: "UA-117668706-2" }
-    ]
+    ['@vuepress/google-analytics', { ga: "UA-117668706-2" }],
+    ['vuepress-plugin-container', {
+      type: 'tip',
+      defaultTitle: {
+        '/': 'TIP',
+        '/zh/': '提示',
+      },
+    }]
   ]
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,4 @@
-const defaultSlugify = require("vuepress/lib/markdown/slugify");
+const defaultSlugify = require("@vuepress/shared-utils/lib/slugify");
 const plugins = require("./plugins.js");
 const pluginsChildren = [];
 
@@ -13,8 +13,6 @@ module.exports = {
   title: "Buidler",
   description:
     "Buidler is a task runner for Ethereum smart contract developers.",
-  serviceWorker: false,
-  ga: "UA-117668706-2",
   themeConfig: {
     logo: "/logo.svg",
     nav: [
@@ -216,5 +214,11 @@ module.exports = {
 
       return defaultSlugify(title);
     }
-  }
+  },
+  plugins: [
+    [
+      '@vuepress/google-analytics',
+      { ga: "UA-117668706-2" }
+    ]
+  ]
 };

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -14,11 +14,7 @@
       <slot name="sidebar-bottom" slot="bottom" />
     </Sidebar>
 
-    <div class="custom-layout" v-if="$page.frontmatter.layout">
-      <component :is="$page.frontmatter.layout" />
-    </div>
-
-    <Home v-else-if="$page.frontmatter.home" />
+    <Home v-if="$page.frontmatter.home" />
 
     <Page v-else :sidebar-items="sidebarItems">
       <slot name="page-top" slot="top" />

--- a/docs/.vuepress/theme/Navbar.vue
+++ b/docs/.vuepress/theme/Navbar.vue
@@ -46,7 +46,7 @@
 
 <script>
 import SidebarButton from "./SidebarButton.vue";
-import AlgoliaSearchBox from "@AlgoliaSearchBox";
+import AlgoliaSearchBox from "./AlgoliaSearchBox.vue";
 import SearchBox from "./SearchBox.vue";
 import NavLinks from "./NavLinks.vue";
 

--- a/docs/.vuepress/theme/styles/code.styl
+++ b/docs/.vuepress/theme/styles/code.styl
@@ -1,6 +1,7 @@
 @require './config'
 
-.content
+.content,
+.content__default
   code
     color lighten($textColor, 20%)
     padding 0.25rem 0.5rem
@@ -9,7 +10,8 @@
     background-color rgba(27,31,35,0.05)
     border-radius 3px
 
-.content
+.content,
+.content__default
   pre, pre[class*="language-"]
     line-height 1.4
     padding 1.25rem 1.5rem

--- a/docs/.vuepress/theme/styles/theme.styl
+++ b/docs/.vuepress/theme/styles/theme.styl
@@ -54,7 +54,8 @@ body
   border-right 1px solid $borderColor
   overflow-y auto
 
-.content:not(.custom)
+.theme-container:not(.custom) .content,
+.theme-container:not(.custom) .content__default
   @extend $wrapper
   > *:first-child
     margin-top $navbarAndBannerHeight
@@ -105,7 +106,8 @@ strong
 h1, h2, h3, h4, h5, h6
   font-weight 600
   line-height 1.25
-  .content:not(.custom) > &
+  .theme-container:not(.custom) .content > &,
+  .theme-container:not(.custom) .content__default > &
     margin-top (0.5rem - $navbarAndBannerHeight)
     padding-top ($navbarAndBannerHeight + 1rem)
     margin-bottom 0
@@ -171,7 +173,8 @@ th, td
     .sidebar-mask
       display: block
   &.no-navbar
-    .content:not(.custom) > h1, h2, h3, h4, h5, h6
+    .theme-container:not(.custom) .content > h1, h2, h3, h4, h5, h6,
+    .theme-container:not(.custom) .content__default > h1, h2, h3, h4, h5, h6
       margin-top 1.5rem
       padding-top 0
     .sidebar

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ footer: Copyright © 2018-2019 Nomic Labs LLC
   <div class="example-1">
   <h3>1. Write your contract</h3>
 
-  ```js
+  ```solidity
 
   import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 ---
 home: true 
+pageClass: custom
 heroImage: ./mascots.svg
 actionText: Get Started
 search: false

--- a/docs/buidler-evm/README.md
+++ b/docs/buidler-evm/README.md
@@ -24,7 +24,7 @@ Buidler comes built-in with Buidler EVM, a local Ethereum network designed for d
 
 Buidler EVM can be run as a server or testing node. To do this, you just need to run
 
-```sh
+```
 npx buidler node
 ```
 
@@ -125,7 +125,7 @@ you develop and debug smart contracts.
 
 For example, a successful transaction and a failed call would look like this:
 
-```sh
+```
 eth_sendTransaction
   Contract deployment: Greeter
   Contract address: 0x8858eeb3dfffa017d4bce9801d340d36cf895ccf

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -14,13 +14,17 @@ Tasks can call other tasks, allowing complex workflows to be defined. Users and 
 
 The recommended way of using Buidler is through a local installation in your project. This way your environment will be reproducible and you will avoid future version conflicts. To use it in this way you will need to prepend `npx` to run it (i.e. `npx buidler`). To install locally initialize your `npm` project using `npm init` and follow the instructions. Once ready run:
 
-    npm install --save-dev @nomiclabs/buidler
+```
+npm install --save-dev @nomiclabs/buidler
+```
 
 ### Global installation
 
 Be careful about inconsistent behavior across different projects that use different Buidler versions.
 
-    npm install --global @nomiclabs/buidler
+```
+npm install --global @nomiclabs/buidler
+```
     
 If you choose to install Buidler globally, you have to do the same for its plugins and their dependencies.
 
@@ -57,7 +61,7 @@ The sample project uses the `buidler-truffle5`, which makes Buidler compatible w
 tests built for Truffle. You can learn more about it [in this guide](../guides/truffle-testing.md). 
 For now, all you need to know is that you may need to install some dependencies with
  
-```bash
+```
 npm install --save-dev @nomiclabs/buidler-truffle5 @nomiclabs/buidler-web3 web3
 ```
 
@@ -145,7 +149,7 @@ $ npx buidler accounts
 
 Next, if you take a look at `contracts/`, you should be able to find `Greeter.sol:`
 
-```js
+```solidity
 pragma solidity ^0.5.1;
 
 import "@nomiclabs/buidler/console.sol";
@@ -174,7 +178,7 @@ contract Greeter {
 
 To compile it, simply run:
 
-```bash
+```
 npx buidler compile
 ```
 

--- a/docs/guides/create-task.md
+++ b/docs/guides/create-task.md
@@ -45,7 +45,7 @@ Tasks in Buidler are asynchronous JavaScript functions that get access to the [
 
 For our example we will use Web3.js to interact with our contracts, so we will install the [Web3.js plugin](https://github.com/nomiclabs/buidler/tree/master/packages/buidler-web3), which injects a Web3.js instance into the Buidler environment:
 
-```bash
+```
 npm install --save-dev @nomiclabs/buidler-web3 web3
 ```
 

--- a/docs/guides/ganache-tests.md
+++ b/docs/guides/ganache-tests.md
@@ -12,7 +12,7 @@ You don't need to do anything especial to use Ganache if you don't want to.
 
 Just start Ganache and run Buidler with
 
-```cmd
+```
 npx buidler --network localhost test
 ```
 
@@ -26,7 +26,7 @@ starts and stops Ganache before and after running your tests and scripts.
 
 To use it, you have to install it with `npm`
 
-```cmd
+```
 npm install --save-dev @nomiclabs/buidler-ganache
 ```
 
@@ -38,6 +38,6 @@ usePlugin("@nomiclabs/buidler-ganache");
 
 Finally, you can run your tests with
  
-```cmd
+```
 npx buidler --network ganache test
 ```

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -9,13 +9,13 @@ and automatically enables TypeScript support.
 
 To install them, open your terminal, go to your Buidler project, and run:
 
-```sh
+```
 npm install --save-dev ts-node typescript
 ```
 
 You also need these packages:
 
-```sh
+```
 npm install --save-dev chai @types/node @types/mocha @types/chai
 ```
 
@@ -37,7 +37,7 @@ drwxr-xr-x    3 fzeoli  staff      96 Jul 30 15:27 test
 
 Now we are going to rename the config file from `buidler.config.js` to `buidler.config.ts`, run:
 
-```sh
+```
 mv buidler.config.js buidler.config.ts
 ```
 

--- a/docs/guides/vscode-tests.md
+++ b/docs/guides/vscode-tests.md
@@ -16,7 +16,7 @@ install it and create a file named `.mocharc.json` in your project's root direct
 
 Finally, make sure you have the latest version of Mocha by running:
 
-```sh
+```
 npm install --save-dev mocha
 ```
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,11 @@
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.1.27",
     "typedoc-plugin-no-inherit": "^1.1.6",
-    "vuepress": "^0.14.11",
+    "vuepress": "^1.4.1",
     "webpack": "^4.28.4"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@vuepress/plugin-google-analytics": "^1.4.1"
+  }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "typedoc-plugin-markdown": "^1.1.27",
     "typedoc-plugin-no-inherit": "^1.1.6",
     "vuepress": "^1.4.1",
+    "vuepress-plugin-container": "^2.1.3",
     "webpack": "^4.28.4"
   },
   "private": true,

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -9,7 +9,7 @@ Node allows by default and crash.
 
 If you are experiencing this problem, you can use Buidler's `--max-memory` argument:
 
-```sh
+```
 npx buidler --max-memory 4096 compile
 ```
 

--- a/docs/tutorial/debugging-with-buidler-evm.md
+++ b/docs/tutorial/debugging-with-buidler-evm.md
@@ -6,7 +6,7 @@ When running your contracts and tests on **Buidler EVM** you can print logging m
 
 This is what it looks like:
 
-```c{3}
+```solidity{3}
 pragma solidity ^0.5.15;
 
 import "@nomiclabs/buidler/console.sol";
@@ -18,7 +18,7 @@ contract Token {
 
 Add some `console.log` to the `transfer()` function as if you were using it in JavaScript:
 
-```c{2,3}
+```solidity{2,3}
 function transfer(address to, uint256 amount) external {
     console.log("Sender balance is %s tokens", balances[msg.sender]);
     console.log("Trying to send %s tokens to %s", amount, to);

--- a/docs/tutorial/writing-and-compiling-contracts.md
+++ b/docs/tutorial/writing-and-compiling-contracts.md
@@ -22,7 +22,7 @@ Paste the code below into the file and take a minute to read the code. It's simp
 To get syntax highlighting you should add Solidity support to your text editor. Just look for Solidity or Ethereum plugins. We recommend using Visual Studio Code or Sublime Text 3.
 ::: 
 
-```c
+```solidity
 // Solidity files have to start with this pragma.
 // It will be used by the Solidity compiler to validate its version.
 pragma solidity ^0.5.15;


### PR DESCRIPTION
The title is self explanatory but there are some things to consider:

- I followed [this guide](https://florimond.dev/blog/articles/2019/06/vuepress-upgrade-1-0/) and [the official migration guide](https://v1.vuepress.vuejs.org/miscellaneous/migration-guide.html)
- `::: tips :::` now require a plugin to work which I installed, same as `ga`
- the `.content` class which we're using for defining styles now has a `__default` sufix. Didn't find a reason for this but had to add some new selectors to `styles.styl`
- [Custom Layouts](https://v1.vuepress.vuejs.org/theme/default-theme-config.html#custom-page-class) behaviour changed, I had to edit both `Plugins.vue` and `Layout.vue` in order to make the `/plugins` section work (part of this is explained [here](https://florimond.dev/blog/articles/2019/06/vuepress-upgrade-1-0/))


The docs are now ready to use all Vuepress 1.x features and [plugins](https://github.com/vuepressjs/awesome-vuepress#plugins) (such as tabs for code), but if we're to re-design the website and docs, I fully recommend to do a fresh install of Vuepress before coding it. 

Also next time we should avoid [ejecting](https://v1.vuepress.vuejs.org/theme/default-theme-config.html#ejecting) the default theme because it was very painful to understand what was happening after upgrading.