### PR TITLE
Fix error when getting past logs

### DIFF
--- a/config/tslint/tslint.json
+++ b/config/tslint/tslint.json
@@ -15,6 +15,12 @@
     "no-console": false,
     "only-arrow-functions": false,
     "prefer-template": true,
+    "strict-comparisons": [
+      true,
+      {
+        "allow-object-equal-comparison": true
+      }
+    ],
     "variable-name": [
       true,
       "check-format",

--- a/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
@@ -957,7 +957,7 @@ export class BuidlerNode extends EventEmitter {
     const logs: RpcLogOutput[] = [];
     for (
       let i = filterParams.fromBlock;
-      i <= filterParams.toBlock;
+      i.lte(filterParams.toBlock);
       i = i.addn(1)
     ) {
       const block = await this._getBlock(new BN(i));
@@ -1237,7 +1237,7 @@ export class BuidlerNode extends EventEmitter {
     }
 
     this._filters.forEach((filter, key) => {
-      if (filter.deadline < new Date()) {
+      if (filter.deadline.valueOf() < new Date().valueOf()) {
         this._filters.delete(key);
       }
 


### PR DESCRIPTION
This PR fix a bug reported that prevented Buidler EVM to return past logs in some cases.

The cause of the bug was that `<=` was being used to compare two `BN.js` instances. This PR fixes it and enables a tslint rule to prevent this mistake to happen again.