### PR TITLE
Fix out-of-bound log filters

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
@@ -1565,21 +1565,25 @@ If you are using a wallet or dapp, try resetting your wallet's accounts.`
     filterParams: FilterParams,
     isFilter: boolean
   ): Promise<FilterParams> {
-    if (
-      filterParams.fromBlock === LATEST_BLOCK ||
-      filterParams.toBlock === LATEST_BLOCK
-    ) {
-      const block = await this.getLatestBlock();
-      if (filterParams.fromBlock === LATEST_BLOCK) {
-        filterParams.fromBlock = new BN(block.header.number);
-      }
+    const latestBlockNumber = await this.getLatestBlockNumber();
+    const newFilterParams = { ...filterParams };
 
-      if (!isFilter && filterParams.toBlock === LATEST_BLOCK) {
-        filterParams.toBlock = new BN(block.header.number);
-      }
+    if (newFilterParams.fromBlock === LATEST_BLOCK) {
+      newFilterParams.fromBlock = latestBlockNumber;
     }
 
-    return filterParams;
+    if (!isFilter && newFilterParams.toBlock === LATEST_BLOCK) {
+      newFilterParams.toBlock = latestBlockNumber;
+    }
+
+    if (newFilterParams.toBlock.gt(latestBlockNumber)) {
+      newFilterParams.toBlock = latestBlockNumber;
+    }
+    if (newFilterParams.fromBlock.gt(latestBlockNumber)) {
+      newFilterParams.fromBlock = latestBlockNumber;
+    }
+
+    return newFilterParams;
   }
 
   private _newDeadline(): Date {

--- a/packages/buidler-core/test/internal/buidler-evm/provider/modules/eth.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/provider/modules/eth.ts
@@ -1472,6 +1472,24 @@ describe("Eth module", function() {
             1
           );
         });
+
+        it("should accept out of bound block numbers", async function() {
+          const logs = await this.provider.send("eth_getLogs", [
+            {
+              address: "0x0000000000000000000000000000000000000000",
+              fromBlock: "0x1111"
+            }
+          ]);
+          assert.lengthOf(logs, 0);
+
+          const logs2 = await this.provider.send("eth_getLogs", [
+            {
+              address: "0x0000000000000000000000000000000000000000",
+              toBlock: "0x1111"
+            }
+          ]);
+          assert.lengthOf(logs2, 0);
+        });
       });
 
       describe("eth_getProof", async function() {


### PR DESCRIPTION
This PR fixes a bug that made Buidler EVM fail if a `fromBlock` or `toBlock` larger than the latest block's number was used.

fixes #484