### PR TITLE
Make json ArgumentType accept anything but undefined

### DIFF
--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -272,9 +272,8 @@ export const json: ArgumentType<any> = {
     }
   },
   /**
-   * Check if argument value is of type "json"
-   * "json" validation succeeds if it is of "object map"-like structure or of "array" structure
-   * ie. this excludes 'null', function, numbers, date, regexp, etc.
+   * Check if argument value is of type "json". We consider everything except
+   * undefined to be json.
    *
    * @param argName {string} argument's name - used for context in case of error.
    * @param value {any} argument's value to validate.
@@ -282,12 +281,7 @@ export const json: ArgumentType<any> = {
    * @throws BDLR301 if value is not of type "json"
    */
   validate: (argName: string, value: any): void => {
-    const valueTypeString = Object.prototype.toString.call(value);
-    const isJsonValue =
-      valueTypeString === "[object Object]" ||
-      valueTypeString === "[object Array]";
-
-    if (!isJsonValue) {
+    if (value === undefined) {
       throw new BuidlerError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
         value,
         name: argName,

--- a/packages/buidler-core/test/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/test/internal/core/params/argumentTypes.ts
@@ -292,5 +292,15 @@ describe("argumentTypes", () => {
     it("Should parse a string", () => {
       assert.deepEqual(types.json.parse("j", '"a"'), "a");
     });
+
+    it("Should accept anything except undefined as valid", () => {
+      assert.doesNotThrow(() => types.json.validate!("json", 1));
+      assert.doesNotThrow(() => types.json.validate!("json", "asd"));
+      assert.doesNotThrow(() => types.json.validate!("json", [1]));
+      assert.doesNotThrow(() => types.json.validate!("json", { a: 123 }));
+      assert.doesNotThrow(() => types.json.validate!("json", null));
+
+      assert.throws(() => types.json.validate!("json", undefined));
+    });
   });
 });

--- a/packages/buidler-core/test/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/test/internal/core/runtime-environment.ts
@@ -106,12 +106,6 @@ describe("Environment", () => {
         "some default",
         types.string
       )
-      .addOptionalParam(
-        "optJsonParam",
-        "an opt 'json' param",
-        JSON.stringify({ a: 1 }),
-        types.json
-      )
       .addOptionalVariadicPositionalParam(
         "variadicOptStrParam",
         "an opt variadic 'str' param",
@@ -223,7 +217,6 @@ describe("Environment", () => {
           optIntParam: { valid: 10, invalid: 1.2 },
           optFloatParam: { valid: 1.2, invalid: NaN },
           optStringParam: { valid: "a string", invalid: 123 },
-          optJsonParam: { valid: { a: 20 }, invalid: 1234 },
           optFileParam: { valid: __filename, invalid: __dirname },
           variadicOptStrParam: { valid: ["a", "b"], invalid: ["a", 1] },
         };


### PR DESCRIPTION
We accidentally introduced a small breaking change in 1.3.0. Before that version was released, arguments passed to Buidler tasks weren't validated. The only thing Buidler knew how to do was parsing strings into those values.

Starting with Buidler 1.3.0, we introduced runtime type validations when running tasks programmatically. This validation logic was off for the json type, as some values that could be parsed from strings into jsons, were accepted by the validation strategy.

This PR fixes this, by accepting anything but `undefined` as a valid `json` argument.

Thanks @gitpusha for reporting this issue.