### PR TITLE
Fix buidler-ganache tests

### DIFF
--- a/packages/buidler-ganache/package.json
+++ b/packages/buidler-ganache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-ganache",
-  "version": "1.3.3-rc.0",
+  "version": "1.3.2",
   "description": "Buidler plugin for managing Ganache",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-ganache",
   "repository": "github:nomiclabs/buidler",
@@ -39,7 +39,7 @@
     "ts-interface-checker": "^0.1.9"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.3.3-rc.0",
+    "@nomiclabs/buidler": "^1.3.2",
     "@types/chai": "^4.2.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.1.0",
@@ -49,6 +49,6 @@
     "typescript": "~3.8.3"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.3.3-rc.0"
+    "@nomiclabs/buidler": "^1.3.2"
   }
 }

--- a/packages/buidler-ganache/package.json
+++ b/packages/buidler-ganache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-ganache",
-  "version": "1.3.2",
+  "version": "1.3.3-rc.0",
   "description": "Buidler plugin for managing Ganache",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-ganache",
   "repository": "github:nomiclabs/buidler",
@@ -39,14 +39,16 @@
     "ts-interface-checker": "^0.1.9"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.3.2",
+    "@nomiclabs/buidler": "^1.3.3-rc.0",
     "@types/chai": "^4.2.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.1.0",
     "chai": "^4.2.0",
-    "ts-interface-builder": "^0.2.0"
+    "ts-interface-builder": "^0.2.0",
+    "ts-node": "^8.1.0",
+    "typescript": "~3.8.3"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.3.2"
+    "@nomiclabs/buidler": "^1.3.3-rc.0"
   }
 }


### PR DESCRIPTION
This PR fixes buidler-ganache's tests by reinstalling some dependencies that are needed to run them.