### PR TITLE
Don't load Buidler EVM if it's not necessary

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/provider/node.ts
@@ -119,13 +119,6 @@ export interface SolidityTracerOptions {
   compilerOutput: CompilerOutput;
 }
 
-export const SUPPORTED_HARDFORKS = [
-  "byzantium",
-  "constantinople",
-  "petersburg",
-  "istanbul",
-];
-
 interface Snapshot {
   id: number;
   date: Date;

--- a/packages/buidler-core/src/internal/constants.ts
+++ b/packages/buidler-core/src/internal/constants.ts
@@ -5,3 +5,10 @@ export const BUIDLEREVM_NETWORK_NAME = "buidlerevm";
 
 export const SOLC_INPUT_FILENAME = "solc-input.json";
 export const SOLC_OUTPUT_FILENAME = "solc-output.json";
+
+export const BUIDLEREVM_SUPPORTED_HARDFORKS = [
+  "byzantium",
+  "constantinople",
+  "petersburg",
+  "istanbul",
+];

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -2,8 +2,10 @@ import * as t from "io-ts";
 import { Context, getFunctionName, ValidationError } from "io-ts/lib";
 import { Reporter } from "io-ts/lib/Reporter";
 
-import { SUPPORTED_HARDFORKS } from "../../buidler-evm/provider/node";
-import { BUIDLEREVM_NETWORK_NAME } from "../../constants";
+import {
+  BUIDLEREVM_NETWORK_NAME,
+  BUIDLEREVM_SUPPORTED_HARDFORKS,
+} from "../../constants";
 import { BuidlerError } from "../errors";
 import { ERRORS } from "../errors-list";
 
@@ -191,10 +193,10 @@ export function getValidationErrors(config: any): string[] {
     if (buidlerNetwork !== undefined) {
       if (
         buidlerNetwork.hardfork !== undefined &&
-        !SUPPORTED_HARDFORKS.includes(buidlerNetwork.hardfork)
+        !BUIDLEREVM_SUPPORTED_HARDFORKS.includes(buidlerNetwork.hardfork)
       ) {
         errors.push(
-          `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.hardfork is not supported. Use one of ${SUPPORTED_HARDFORKS.join(
+          `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.hardfork is not supported. Use one of ${BUIDLEREVM_SUPPORTED_HARDFORKS.join(
             ", "
           )}`
         );


### PR DESCRIPTION
This PR fixes an error in the config validation module that made it load Buidler EVM every time.