### PR TITLE
Use a random chain and network id

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -40,7 +40,7 @@ they fail. Learn more about it [here](../buidler-evm).
 
 You can set the following fields on the `buidlerevm` config:
 
-- `chainId`: The chan id number used by Buidler EVM's blockchain. Default value: `31337`.
+- `chainId`: The chan id number used by Buidler EVM's blockchain. Default value: A random number ending in `1337`.
 
 - `from`: The address to use as default sender. If not present the first account of the Buidler EVM is used.
 

--- a/packages/buidler-core/src/internal/core/config/default-config.ts
+++ b/packages/buidler-core/src/internal/core/config/default-config.ts
@@ -8,7 +8,7 @@ const DEFAULT_BUIDLER_NETWORK_CONFIG: BuidlerNetworkConfig = {
   blockGasLimit: 9500000,
   gas: 9500000,
   gasPrice: BUIDLEREVM_DEFAULT_GAS_PRICE,
-  chainId: 31337,
+  chainId: Math.round(Math.random() * 1000000) * 10000 + 1337,
   throwOnTransactionFailures: true,
   throwOnCallFailures: true,
   allowUnlimitedContractSize: false,


### PR DESCRIPTION
This PR changes Buidler EVM's default config to use a random network and chain id. By doing this, resetting accounts in MM can be as easy as switching networks back and forth.