### PR TITLE
Update console.log to solc v0.6.8

### DIFF
--- a/packages/buidler-core/console.sol
+++ b/packages/buidler-core/console.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >= 0.5.0 <0.7.0;
 
 library console {


### PR DESCRIPTION
* see https://forum.openzeppelin.com/t/solidity-0-6-8-introduces-spdx-license-identifiers/2859 for details