### PR TITLE
Support RegExps in config fields

### DIFF
--- a/packages/buidler-core/src/internal/core/config/config-resolution.ts
+++ b/packages/buidler-core/src/internal/core/config/config-resolution.ts
@@ -113,7 +113,11 @@ function deepFreezeUserConfig(
   config: any,
   propertyPath: Array<string | number | symbol> = []
 ) {
-  if (typeof config !== "object" || config === null) {
+  if (
+    typeof config !== "object" ||
+    config instanceof RegExp ||
+    config === null
+  ) {
     return config;
   }
 

--- a/packages/buidler-core/test/fixture-projects/project-with-complex-config-types/buidler.config.js
+++ b/packages/buidler-core/test/fixture-projects/project-with-complex-config-types/buidler.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  regexp: /asd/,
+  func: () => 123,
+};

--- a/packages/buidler-core/test/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/test/internal/core/config/config-loading.ts
@@ -151,4 +151,22 @@ describe("config loading", function () {
       );
     });
   });
+
+  describe("Config loading results", function () {
+    describe("Complex types", function () {
+      useFixtureProject("project-with-complex-config-types");
+      useEnvironment();
+
+      it("Should support regexps", function () {
+        const config: any = this.env.config;
+        assert.instanceOf(config.regexp, RegExp);
+      });
+
+      it("Should support functions", function () {
+        const config: any = this.env.config;
+        assert.instanceOf(config.func, Function);
+        assert.equal(config.func(), 123);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR just adds regression tests for now. It shows that Buidler doesn't support `RegExp` values as part of its config. They somehow get converted to empty objects.

I'm pretty sure the error is in [this function](https://github.com/nomiclabs/buidler/blob/development/packages/buidler-core/src/internal/core/config/config-loading.ts#L16). If anyone wants to try and fix this, feel free to ping me here or in our [Telgram support group](http://t.me/BuidlerSupport)