### PR TITLE
Update sample project Solidity version to ^0.6.8

### DIFF
--- a/packages/buidler-core/sample-project/buidler.config.js
+++ b/packages/buidler-core/sample-project/buidler.config.js
@@ -17,6 +17,6 @@ task("accounts", "Prints the list of accounts", async () => {
 module.exports = {
   // This is a sample solc configuration that specifies which version of solc to use
   solc: {
-    version: "0.5.15",
+    version: "0.6.8",
   },
 };

--- a/packages/buidler-core/sample-project/contracts/Greeter.sol
+++ b/packages/buidler-core/sample-project/contracts/Greeter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.6.8;
 
 import "@nomiclabs/buidler/console.sol";
 


### PR DESCRIPTION
Open Zeppelin's contracts are already at `^0.6.0`, and I think it's time to pull ahead here. Especially if you're creating a project from scratch, it's likely that you will choose version 0.6 or above.