### PR TITLE
docs: update ethers API for getSigners

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -143,12 +143,13 @@ An example for tests:
 
 ```typescript
 import { ethers } from "@nomiclabs/buidler";
+import { Signer } from "ethers";
 
 describe("Token", function() {
-  let accounts: string[];
+  let accounts: Signer[];
 
   beforeEach(async function() {
-    accounts = await ethers.eth.getSigners();
+    accounts = await ethers.getSigners();
   });
 
   it("should do something right", async function() {


### PR DESCRIPTION
At least as of ethers@4.0.47 and buidler@1.3.3, the "eth" property doesn't exist anymore within the "ethers" object imported from @nomiclabs/buidler.