### PR TITLE
Workaround buidler-waffle source maps issue

### DIFF
--- a/packages/buidler-waffle/src/index.ts
+++ b/packages/buidler-waffle/src/index.ts
@@ -3,12 +3,6 @@ import { lazyObject } from "@nomiclabs/buidler/plugins";
 import path from "path";
 
 function initializeWaffleMatchers(projectRoot: string) {
-  const wafflePath = require.resolve("ethereum-waffle");
-  const waffleChaiPath = require.resolve("@ethereum-waffle/chai", {
-    paths: [wafflePath],
-  });
-  const { waffleChai } = require(waffleChaiPath);
-
   try {
     let chaiPath = require.resolve("chai");
 
@@ -21,6 +15,7 @@ function initializeWaffleMatchers(projectRoot: string) {
     }
 
     const chai = require(chaiPath);
+    const { waffleChai } = require("./waffle-chai");
 
     chai.use(waffleChai);
   } catch (error) {

--- a/packages/buidler-waffle/src/waffle-chai.ts
+++ b/packages/buidler-waffle/src/waffle-chai.ts
@@ -1,0 +1,62 @@
+// This file only exists to workaround this: https://github.com/EthWorks/Waffle/issues/281
+
+import path from "path";
+
+/// <reference types="chai" />
+
+export function waffleChai(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
+  const wafflePath = require.resolve("ethereum-waffle");
+  const waffleChaiPath = path.dirname(
+    require.resolve("@ethereum-waffle/chai", {
+      paths: [wafflePath],
+    })
+  );
+
+  const { supportBigNumber } = require(`${waffleChaiPath}/matchers/bigNumber`);
+  const {
+    supportChangeBalance,
+  } = require(`${waffleChaiPath}/matchers/changeBalance`);
+  const {
+    supportChangeBalances,
+  } = require(`${waffleChaiPath}/matchers/changeBalances`);
+  const { supportEmit } = require(`${waffleChaiPath}/matchers/emit`);
+  const {
+    supportProperAddress,
+  } = require(`${waffleChaiPath}/matchers/properAddress`);
+  const { supportProperHex } = require(`${waffleChaiPath}/matchers/properHex`);
+  const {
+    supportProperPrivateKey,
+  } = require(`${waffleChaiPath}/matchers/properPrivateKey`);
+  const { supportReverted } = require(`${waffleChaiPath}/matchers/reverted`);
+  const {
+    supportRevertedWith,
+  } = require(`${waffleChaiPath}/matchers/revertedWith`);
+
+  supportBigNumber(chai.Assertion, utils);
+  supportReverted(chai.Assertion);
+  supportRevertedWith(chai.Assertion);
+  supportEmit(chai.Assertion);
+  supportProperAddress(chai.Assertion);
+  supportProperPrivateKey(chai.Assertion);
+  supportProperHex(chai.Assertion);
+  supportChangeBalance(chai.Assertion);
+  supportChangeBalances(chai.Assertion);
+  supportCalledOnContract(chai.Assertion);
+  supportCalledOnContractWith(chai.Assertion);
+}
+
+function supportCalledOnContract(Assertion: Chai.AssertionStatic) {
+  Assertion.addMethod("calledOnContract", function (contract: any) {
+    throw new Chai.AssertionError(
+      "Waffle's calledOnContract is not supported by Buidler"
+    );
+  });
+}
+
+function supportCalledOnContractWith(Assertion: Chai.AssertionStatic) {
+  Assertion.addMethod("calledOnContractWith", function (contract: any) {
+    throw new Chai.AssertionError(
+      "Waffle's calledOnContractWith is not supported by Buidler"
+    );
+  });
+}


### PR DESCRIPTION
This PR is a workaround an issue with buidler-waffle that leads to source maps not working and line numbers being off.

To learn more about this issue: https://github.com/EthWorks/Waffle/issues/281