### PR TITLE
Allow using buidler-web3 with older web3 versions

### DIFF
--- a/packages/buidler-web3/package.json
+++ b/packages/buidler-web3/package.json
@@ -36,11 +36,11 @@
     "@nomiclabs/buidler": "^1.3.3",
     "@types/chai": "^4.2.0",
     "chai": "^4.2.0",
-    "web3": "^1.2.0"
+    "web3": "^1.0.0-beta.36"
   },
   "peerDependencies": {
     "@nomiclabs/buidler": "^1.3.3",
-    "web3": "^1.2.0"
+    "web3": "^1.0.0-beta.36"
   },
   "dependencies": {
     "@types/bignumber.js": "^5.0.0"


### PR DESCRIPTION
This PR just changes the minimum version of `Web3` required to use `@nomiclabs/buidler-web3`.

Thanks @felix2feng for reporting and testing this 🙌