### PR TITLE
[buidler-ethers] Use network's config default gas value if present

### DIFF
--- a/packages/buidler-ethers/src/helpers.ts
+++ b/packages/buidler-ethers/src/helpers.ts
@@ -1,6 +1,10 @@
 import { readArtifact } from "@nomiclabs/buidler/plugins";
-import { BuidlerRuntimeEnvironment } from "@nomiclabs/buidler/types";
+import {
+  BuidlerRuntimeEnvironment,
+  NetworkConfig,
+} from "@nomiclabs/buidler/types";
 import { ethers } from "ethers";
+import { bigNumberify } from "ethers/utils";
 
 export async function getSigners(bre: BuidlerRuntimeEnvironment) {
   const accounts = await bre.ethers.provider.listAccounts();
@@ -49,14 +53,13 @@ export async function getContractFactoryByName(
   name: string,
   signer?: ethers.Signer
 ) {
-  if (signer === undefined) {
-    const signers = await bre.ethers.signers();
-    signer = signers[0];
-  }
-
   const artifact = await readArtifact(bre.config.paths.artifacts, name);
-  const bytecode = artifact.bytecode;
-  return new bre.ethers.ContractFactory(artifact.abi, bytecode, signer);
+  return getContractFactoryByAbiAndBytecode(
+    bre,
+    artifact.abi,
+    artifact.bytecode,
+    signer
+  );
 }
 
 export async function getContractFactoryByAbiAndBytecode(
@@ -70,7 +73,12 @@ export async function getContractFactoryByAbiAndBytecode(
     signer = signers[0];
   }
 
-  return new bre.ethers.ContractFactory(abi, bytecode, signer);
+  const abiWithAddedGas = addGasToAbiMethodsIfNecessary(
+    bre.network.config,
+    abi
+  );
+
+  return new bre.ethers.ContractFactory(abiWithAddedGas, bytecode, signer);
 }
 
 export async function getContractAt(
@@ -89,5 +97,47 @@ export async function getContractAt(
     signer = signers[0];
   }
 
-  return new bre.ethers.Contract(address, nameOrAbi, signer);
+  const abiWithAddedGas = addGasToAbiMethodsIfNecessary(
+    bre.network.config,
+    nameOrAbi
+  );
+
+  return new bre.ethers.Contract(address, abiWithAddedGas, signer);
+}
+
+// This helper adds a `gas` field to the ABI function elements if the network
+// is set up to use a fixed amount of gas.
+// This is done so that ethers doesn't automatically estimate gas limits on
+// every call.
+// NOTE: This is very dependant on ethers v4 implementation. It will probably
+// change on v5.
+function addGasToAbiMethodsIfNecessary(
+  networkConfig: NetworkConfig,
+  abi: any[]
+): any[] {
+  if (networkConfig.gas === "auto" || networkConfig.gas === undefined) {
+    return abi;
+  }
+
+  // ethers adds 21000 to whatever the abi `gas` field has. This may lead to
+  // OOG errors, as people may set the default gas to the same value as the
+  // block gas limit, especially on Buidler EVM.
+  // To avoid this, we substract 21000.
+  const gasLimit = bigNumberify(networkConfig.gas).sub(21000).toHexString();
+
+  const modifiedAbi: any[] = [];
+
+  for (const abiElement of abi) {
+    if (abiElement.type !== "function") {
+      modifiedAbi.push(abiElement);
+      continue;
+    }
+
+    modifiedAbi.push({
+      ...abiElement,
+      gas: gasLimit,
+    });
+  }
+
+  return modifiedAbi;
 }


### PR DESCRIPTION
This PR addresses #647, making tests run with ethers much faster. Some transactions run up to 10x faster, and received reports of entire test suits running 5x faster.

This only addresses it for ethers v4, so the issue should be left open. ethers v5 will be released tomorrow.