### PR TITLE
Allow running tests with path to solc

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/source-maps.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/source-maps.ts
@@ -135,13 +135,15 @@ export function decodeInstructions(
     }
 
     if (sourceMap.location.file !== -1) {
-      const file = fileIdToSourceFile.get(sourceMap.location.file)!;
+      const file = fileIdToSourceFile.get(sourceMap.location.file);
 
-      location = new SourceLocation(
-        file,
-        sourceMap.location.offset,
-        sourceMap.location.length
-      );
+      if (file !== undefined) {
+        location = new SourceLocation(
+          file,
+          sourceMap.location.offset,
+          sourceMap.location.length
+        );
+      }
     }
 
     const instruction = new Instruction(

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/compilation.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/compilation.ts
@@ -68,19 +68,23 @@ function loadCompilerSources(compilerPath: string) {
   return loadedSolc;
 }
 
-async function getSolc(compilerVersion: string): Promise<any> {
+async function getSolc(compilerPath: string): Promise<any> {
+  if (path.isAbsolute(compilerPath)) {
+    return solcWrapper(loadCompilerSources(compilerPath));
+  }
+
   const compilersDir = path.join(__dirname, "compilers");
-  const compilerPath = path.join(compilersDir, compilerVersion);
+  const absoluteCompilerPath = path.join(compilersDir, compilerPath);
 
   // download if necessary
-  if (!fs.existsSync(compilerPath)) {
-    const compilerUrl = `https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/${compilerVersion}`;
+  if (!fs.existsSync(absoluteCompilerPath)) {
+    const compilerUrl = `https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/${compilerPath}`;
     await download(compilerUrl, compilersDir, {
-      filename: path.basename(compilerVersion),
+      filename: path.basename(compilerPath),
     });
   }
 
-  const solc = solcWrapper(loadCompilerSources(compilerPath));
+  const solc = solcWrapper(loadCompilerSources(absoluteCompilerPath));
 
   return solc;
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test.ts
@@ -662,6 +662,42 @@ const solidity06Compilers: CompilerOptions[] = [
 describe("Stack traces", function () {
   setCWD();
 
+  // if a path to a solc file was specified, we only run these tests and use
+  // that compiler
+  const customSolcPath = process.env.BUIDLER_TESTS_SOLC_PATH;
+  if (customSolcPath !== undefined) {
+    const customSolcVersion = process.env.BUIDLER_TESTS_SOLC_VERSION;
+
+    if (customSolcVersion === undefined) {
+      console.error(
+        "BUIDLER_TESTS_SOLC_VERSION has to be set when using BUIDLER_TESTS_SOLC_PATH"
+      );
+      process.exit(1);
+    }
+
+    describe.only(`Use compiler at ${customSolcPath} with version ${customSolcVersion}`, function () {
+      const compilerOptions = {
+        solidityVersion: customSolcVersion,
+        compilerPath: customSolcPath,
+      };
+
+      const testsDir = semver.satisfies(customSolcVersion, "^0.5.0")
+        ? "0_5"
+        : "0_6";
+      defineDirTests(
+        path.join(__dirname, "test-files", testsDir),
+        compilerOptions
+      );
+
+      defineDirTests(
+        path.join(__dirname, "test-files", "version-independent"),
+        compilerOptions
+      );
+    });
+
+    return;
+  }
+
   // solidity v0.5
   for (const compilerOptions of solidity05Compilers) {
     describe(`Use compiler ${compilerOptions.compilerPath}`, function () {


### PR DESCRIPTION
For example:

```
$ BUIDLER_TESTS_SOLC_PATH=/path/to/soljson.js BUIDLER_TESTS_SOLC_VERSION=0.6.12 npm test
```

Maybe this should be documented somewhere? Where is the best place to do it?