### PR TITLE
Improve error reporting

### DIFF
--- a/packages/buidler-core/src/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/src/internal/sentry/anonymizer.ts
@@ -25,6 +25,7 @@ export class Anonymizer {
       event_id: event.event_id,
       platform: event.platform,
       timestamp: event.timestamp,
+      extra: event.extra,
     };
 
     if (event.exception !== undefined && event.exception.values !== undefined) {

--- a/packages/buidler-core/src/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/src/internal/sentry/anonymizer.ts
@@ -132,7 +132,7 @@ export class Anonymizer {
 
       // we stop after finding either a buidler file or a file from the user's
       // project
-      if (frame.filename.startsWith("node_modules/@nomiclabs")) {
+      if (this._isBuidlerFile(frame.filename)) {
         return true;
       }
 
@@ -156,6 +156,16 @@ export class Anonymizer {
     return findup.sync("package.json", {
       cwd: path.dirname(filename),
     });
+  }
+
+  private _isBuidlerFile(filename: string): boolean {
+    const nomiclabsPath = path.join("node_modules", "@nomiclabs");
+    const truffleContractPath = path.join(nomiclabsPath, "truffle-contract");
+    const isBuidlerFile =
+      filename.startsWith(nomiclabsPath) &&
+      !filename.startsWith(truffleContractPath);
+
+    return isBuidlerFile;
   }
 
   private _anonymizeExceptions(exceptions: Exception[]): Exception[] {

--- a/packages/buidler-core/src/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/src/internal/sentry/anonymizer.ts
@@ -94,7 +94,13 @@ export class Anonymizer {
   public anonymizeErrorMessage(errorMessage: string): string {
     // the \\ before path.sep is necessary for this to work on windows
     const pathRegex = new RegExp(`\\S+\\${path.sep}\\S+`, "g");
-    return errorMessage.replace(pathRegex, "<user-file>");
+
+    // for files that don't have a path separator
+    const fileRegex = new RegExp("\\S+\\.(js|ts)\\S*", "g");
+
+    return errorMessage
+      .replace(pathRegex, ANONYMIZED_FILE)
+      .replace(fileRegex, ANONYMIZED_FILE);
   }
 
   protected _getFilePackageJsonPath(filename: string): string | null {

--- a/packages/buidler-core/src/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/src/internal/sentry/anonymizer.ts
@@ -98,9 +98,13 @@ export class Anonymizer {
     // for files that don't have a path separator
     const fileRegex = new RegExp("\\S+\\.(js|ts)\\S*", "g");
 
+    // hide hex strings of 20 chars or more
+    const hexRegex = /(0x)?[0-9A-Fa-f]{20,}/g;
+
     return errorMessage
       .replace(pathRegex, ANONYMIZED_FILE)
-      .replace(fileRegex, ANONYMIZED_FILE);
+      .replace(fileRegex, ANONYMIZED_FILE)
+      .replace(hexRegex, (match) => match.replace(/./g, "x"));
   }
 
   public raisedByBuidler(event: Event): boolean {

--- a/packages/buidler-core/src/internal/sentry/reporter.ts
+++ b/packages/buidler-core/src/internal/sentry/reporter.ts
@@ -5,6 +5,7 @@ import {
 } from "../core/errors";
 import { isLocalDev } from "../core/execution-mode";
 import { isRunningOnCiServer } from "../util/ci-detection";
+import { getBuidlerVersion } from "../util/packageInfo";
 
 import { getSubprocessTransport } from "./transport";
 
@@ -31,6 +32,11 @@ export class Reporter {
     const Sentry = require("@sentry/node");
     Sentry.setExtra("verbose", instance.verbose);
     Sentry.setExtra("configPath", instance.configPath);
+    Sentry.setExtra("nodeVersion", process.version);
+
+    const buidlerVersion = getBuidlerVersion();
+    Sentry.setExtra("buidlerVersion", buidlerVersion);
+
     Sentry.captureException(error);
 
     return true;

--- a/packages/buidler-core/src/internal/sentry/subprocess.ts
+++ b/packages/buidler-core/src/internal/sentry/subprocess.ts
@@ -54,7 +54,9 @@ async function main() {
     const anonymizedEvent = anonymizer.anonymize(event);
 
     if (anonymizedEvent.isRight()) {
-      Sentry.captureEvent(anonymizedEvent.value);
+      if (anonymizer.raisedByBuidler(anonymizedEvent.value)) {
+        Sentry.captureEvent(anonymizedEvent.value);
+      }
     } else {
       Sentry.captureMessage(
         `There was an error anonymizing an event: ${anonymizedEvent.value}`

--- a/packages/buidler-core/src/internal/sentry/transport.ts
+++ b/packages/buidler-core/src/internal/sentry/transport.ts
@@ -12,7 +12,10 @@ export function getSubprocessTransport(): any {
       const { verbose = false, configPath } = event.extra ?? {};
 
       // don't send user's full config path for privacy reasons
-      delete event.extra;
+      delete event.extra?.configPath;
+
+      // we don't care about the verbose setting
+      delete event.extra?.verbose;
 
       const serializedEvent = JSON.stringify(event);
 

--- a/packages/buidler-core/src/internal/util/packageInfo.ts
+++ b/packages/buidler-core/src/internal/util/packageInfo.ts
@@ -28,3 +28,18 @@ export async function getPackageJson(): Promise<PackageJson> {
   const root = await getPackageRoot();
   return fsExtra.readJSON(path.join(root, "package.json"));
 }
+
+export function getBuidlerVersion(): string | null {
+  const packageJsonPath = findClosestPackageJson(__filename);
+
+  if (packageJsonPath === null) {
+    return null;
+  }
+
+  try {
+    const packageJson = fsExtra.readJsonSync(packageJsonPath);
+    return packageJson.version;
+  } catch (e) {
+    return null;
+  }
+}

--- a/packages/buidler-core/test/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/test/internal/sentry/anonymizer.ts
@@ -243,5 +243,61 @@ describe("Anonymizer", () => {
 
       assert.equal(anonymizedErrorMessage, errorMessage);
     });
+
+    it("should hide a private key that starts with 0x", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage =
+        "My PK is 0x3ecf4eda095143894fef9fc0c2480d44c4c7e40bf340448e3039da92888b3096";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "My PK is xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+    });
+
+    it("should hide a private key that doesn't start with 0x", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage =
+        "My PK is 3ecf4eda095143894fef9fc0c2480d44c4c7e40bf340448e3039da92888b3096";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "My PK is xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+    });
+
+    it("should hide multiple private keys", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage =
+        "My PKs are 0x3ecf4eda095143894fef9fc0c2480d44c4c7e40bf340448e3039da92888b3096\nand 0x7b63fe0cc949ac8fd4161a943b7ab26156c06315c2a9030e064980e7bcc7a056";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "My PKs are xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\nand xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+    });
+
+    it("should hide addresses", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage =
+        "My addresses are 0xf658b4176b77f6d6439D249D04f166eF315d69FC and 30444113Ad783A6bd92E057a21572a70890e7768";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "My addresses are xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx and xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      );
+    });
   });
 });

--- a/packages/buidler-core/test/internal/sentry/anonymizer.ts
+++ b/packages/buidler-core/test/internal/sentry/anonymizer.ts
@@ -196,5 +196,52 @@ describe("Anonymizer", () => {
         "Something happened at file <user-file> something"
       );
     });
+
+    it("should anonymize a file that doesn't have a path separator", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage = "Something happened at file foo.json";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "Something happened at file <user-file>"
+      );
+    });
+
+    it("should anonymize multiple files that don't have a path separator", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage =
+        "Something happened at file foo.json and at file bar.ts";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(
+        anonymizedErrorMessage,
+        "Something happened at file <user-file> and at file <user-file>"
+      );
+    });
+
+    it("shouldn't anonymize stand-alone extensions", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage = "The .json extension is not supported";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(anonymizedErrorMessage, errorMessage);
+    });
+
+    it("shouldn't interpret periods as files with extensions", () => {
+      const anonymizer = new Anonymizer();
+      const errorMessage = "This is a sentence. This is another sentence.";
+      const anonymizedErrorMessage = anonymizer.anonymizeErrorMessage(
+        errorMessage
+      );
+
+      assert.equal(anonymizedErrorMessage, errorMessage);
+    });
   });
 });

--- a/packages/buidler-core/test/internal/sentry/reporter.ts
+++ b/packages/buidler-core/test/internal/sentry/reporter.ts
@@ -1,0 +1,81 @@
+import { assert } from "chai";
+
+import {
+  BuidlerError,
+  BuidlerPluginError,
+  NomicLabsBuidlerPluginError,
+} from "../../../src/internal/core/errors";
+import { ErrorDescriptor } from "../../../src/internal/core/errors-list";
+import { Reporter } from "../../../src/internal/sentry/reporter";
+
+const mockErrorDescriptor: ErrorDescriptor = {
+  number: 123,
+  message: "error message",
+  title: "Mock error",
+  description: "This is a mock error",
+  shouldBeReported: false,
+};
+
+describe("Reporter", () => {
+  describe("shouldReport", () => {
+    it("should report plain errors", () => {
+      const result = Reporter.shouldReport(new Error("some message"));
+
+      assert.isTrue(result);
+    });
+
+    it("should report BuidlerErrors that have the shouldBeReported flag", () => {
+      const error = new BuidlerError({
+        ...mockErrorDescriptor,
+        shouldBeReported: true,
+      });
+      const result = Reporter.shouldReport(error);
+
+      assert.isTrue(result);
+    });
+
+    it("should not report BuidlerErrors that don't have the shouldBeReported flag", () => {
+      const error = new BuidlerError({
+        ...mockErrorDescriptor,
+        shouldBeReported: false,
+      });
+      const result = Reporter.shouldReport(error);
+
+      assert.isFalse(result);
+    });
+
+    it("should not report BuidlerPluginErrors", () => {
+      const result = Reporter.shouldReport(
+        new BuidlerPluginError("asd", "asd")
+      );
+
+      assert.isFalse(result);
+    });
+
+    it("should report NomicLabsBuidlerPluginErrors that have the shouldBeReported flag", () => {
+      const result = Reporter.shouldReport(
+        new NomicLabsBuidlerPluginError(
+          "asd",
+          "asd",
+          new Error("some message"),
+          true
+        )
+      );
+
+      assert.isTrue(result);
+    });
+
+    it("should not report NomicLabsBuidlerPluginErrors that don't have the shouldBeReported flag", () => {
+      const result = Reporter.shouldReport(
+        new NomicLabsBuidlerPluginError(
+          "asd",
+          "asd",
+          new Error("some message"),
+          false
+        )
+      );
+
+      assert.isFalse(result);
+    });
+  });
+});


### PR DESCRIPTION
This PR improves what errors are reported

- [x] Better handling of plugin errors
- [x] Better anonymization of files in error messages
- [x] Use the stack trace to ignore errors that didn't come from buidler