### PR TITLE
Refactor ArgumentTypes

### DIFF
--- a/packages/buidler-core/src/internal/cli/ArgumentsParser.ts
+++ b/packages/buidler-core/src/internal/cli/ArgumentsParser.ts
@@ -1,6 +1,7 @@
 import {
   BuidlerArguments,
   BuidlerParamDefinitions,
+  CLIArgumentType,
   ParamDefinition,
   ParamDefinitionsMap,
   TaskArguments,
@@ -224,7 +225,10 @@ export class ArgumentsParser {
         });
       }
 
-      parsedArguments[paramName] = definition.type.parse(paramName, value);
+      // We only parse the arguments of non-internal tasks, and those only
+      // accept CLIArgumentTypes.
+      const type = definition.type as CLIArgumentType<any>;
+      parsedArguments[paramName] = type.parse(paramName, value);
     }
 
     return index;
@@ -238,6 +242,9 @@ export class ArgumentsParser {
 
     for (let i = 0; i < positionalParamDefinitions.length; i++) {
       const definition = positionalParamDefinitions[i];
+      // We only parse the arguments of non-internal tasks, and those only
+      // accept CLIArgumentTypes.
+      const type = definition.type as CLIArgumentType<any>;
 
       const rawArg = rawPositionalParamArgs[i];
 
@@ -250,11 +257,11 @@ export class ArgumentsParser {
 
         args[definition.name] = definition.defaultValue;
       } else if (!definition.isVariadic) {
-        args[definition.name] = definition.type.parse(definition.name, rawArg);
+        args[definition.name] = type.parse(definition.name, rawArg);
       } else {
         args[definition.name] = rawPositionalParamArgs
           .slice(i)
-          .map((raw) => definition.type.parse(definition.name, raw));
+          .map((raw) => type.parse(definition.name, raw));
       }
     }
 

--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -130,6 +130,13 @@ async function main() {
         });
       }
 
+      if (taskDefinition.isInternal) {
+        throw new BuidlerError(
+          ERRORS.ARGUMENTS.RUNNING_INTERNAL_TASK_FROM_CLI,
+          { name: taskDefinition.name }
+        );
+      }
+
       taskArguments = argumentsParser.parseTaskArguments(
         taskDefinition,
         unparsedCLAs

--- a/packages/buidler-core/src/internal/core/errors-list.ts
+++ b/packages/buidler-core/src/internal/core/errors-list.ts
@@ -420,7 +420,7 @@ Please, double check your task definitions.`,
       number: 213,
       title: "Invalid argument type",
       message:
-        "Task %task% is not internal but one of arguments use the type %type%, which is not parseable.",
+        "Task %task% is not internal but one of its arguments uses the type %type%, which is not parseable.",
       description: `Tasks that can be invoked from the command line require CLIArgumentType types for their arguments.
       
 What makes these types special is that they can be represented as strings, so you can write them down in the terminal.`,

--- a/packages/buidler-core/src/internal/core/errors-list.ts
+++ b/packages/buidler-core/src/internal/core/errors-list.ts
@@ -331,43 +331,6 @@ Please double check your task definitions.`,
 Please, double check your task definitions.`,
       shouldBeReported: false,
     },
-    OVERRIDE_NO_MANDATORY_PARAMS: {
-      number: 210,
-      message:
-        "Redefinition of task %taskName% failed. Unsupported operation adding mandatory (non optional) param definitions in an overridden task.",
-      title: "Attempted to add mandatory params to an overridden task",
-      description: `You can't add mandatory (non optional) param definitions in an overridden task.
-The only supported param additions for overridden tasks are flags,
-and optional params.
-
-Please, double check your task definitions.`,
-      shouldBeReported: false,
-    },
-    OVERRIDE_NO_POSITIONAL_PARAMS: {
-      number: 211,
-      message:
-        "Redefinition of task %taskName% failed. Unsupported operation adding positional param definitions in an overridden task.",
-      title: "Attempted to add positional params to an overridden task",
-      description: `You can't add positional param definitions in an overridden task.
-The only supported param additions for overridden tasks are flags,
-and optional params.
-
-Please, double check your task definitions.`,
-      shouldBeReported: false,
-    },
-    OVERRIDE_NO_VARIADIC_PARAMS: {
-      number: 212,
-      message:
-        "Redefinition of task %taskName% failed. Unsupported operation adding variadic param definitions in an overridden task.",
-      title: "Attempted to add variadic params to an overridden task",
-      description: `You can't add variadic param definitions in an overridden task.
-The only supported param additions for overridden tasks are flags,
-and optional params.
-
-Please, double check your task definitions.`,
-      shouldBeReported: false,
-    },
-
     ACTION_NOT_SET: {
       number: 205,
       message: "No action set for task %taskName%.",
@@ -415,6 +378,52 @@ Please double check your task definitions.`,
       description: `Your parameter names must use camelCase.  
 
 Please double check your task definitions.`,
+      shouldBeReported: false,
+    },
+    OVERRIDE_NO_MANDATORY_PARAMS: {
+      number: 210,
+      message:
+        "Redefinition of task %taskName% failed. Unsupported operation adding mandatory (non optional) param definitions in an overridden task.",
+      title: "Attempted to add mandatory params to an overridden task",
+      description: `You can't add mandatory (non optional) param definitions in an overridden task.
+The only supported param additions for overridden tasks are flags,
+and optional params.
+
+Please, double check your task definitions.`,
+      shouldBeReported: false,
+    },
+    OVERRIDE_NO_POSITIONAL_PARAMS: {
+      number: 211,
+      message:
+        "Redefinition of task %taskName% failed. Unsupported operation adding positional param definitions in an overridden task.",
+      title: "Attempted to add positional params to an overridden task",
+      description: `You can't add positional param definitions in an overridden task.
+The only supported param additions for overridden tasks are flags,
+and optional params.
+
+Please, double check your task definitions.`,
+      shouldBeReported: false,
+    },
+    OVERRIDE_NO_VARIADIC_PARAMS: {
+      number: 212,
+      message:
+        "Redefinition of task %taskName% failed. Unsupported operation adding variadic param definitions in an overridden task.",
+      title: "Attempted to add variadic params to an overridden task",
+      description: `You can't add variadic param definitions in an overridden task.
+The only supported param additions for overridden tasks are flags,
+and optional params.
+
+Please, double check your task definitions.`,
+      shouldBeReported: false,
+    },
+    CLI_ARGUMENT_TYPE_REQUIRED: {
+      number: 213,
+      title: "Invalid argument type",
+      message:
+        "Task %task% is not internal but one of arguments use the type %type%, which is not parseable.",
+      description: `Tasks that can be invoked from the command line require CLIArgumentType types for their arguments.
+      
+What makes these types special is that they can be represented as strings, so you can write them down in the terminal.`,
       shouldBeReported: false,
     },
   },
@@ -530,6 +539,15 @@ Please double check how you invoked Buidler.`,
       description: `You tried to run a task with an invalid JSON parameter. 
 
 Please double check how you invoked Buidler or run your task.`,
+      shouldBeReported: false,
+    },
+    RUNNING_INTERNAL_TASK_FROM_CLI: {
+      number: 312,
+      title: "Internal task run from the command line",
+      message: "Trying to run the %name% internal task from the CLI",
+      description: `You tried to run an internal task from the command line.
+      
+This is not supported. Please run the help task to see the available options.`,
       shouldBeReported: false,
     },
   },

--- a/packages/buidler-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/src/internal/core/params/argumentTypes.ts
@@ -1,47 +1,16 @@
 import * as fs from "fs";
 import fsExtra from "fs-extra";
 
+import { ArgumentType, CLIArgumentType } from "../../../types";
 import { BuidlerError } from "../errors";
 import { ERRORS } from "../errors-list";
-
-/**
- * Provides an interface for every valid task argument type.
- */
-export interface ArgumentType<T> {
-  /**
-   * Type's name.
-   */
-  name: string;
-
-  /**
-   * Parses strValue. This function MUST throw BDLR301 if it
-   * can parse the given value.
-   *
-   * @param argName argument's name - used for context in case of error.
-   * @param strValue argument's string value to be parsed.
-   *
-   * @throws BDLR301 if an invalid value is given.
-   * @returns the parsed value.
-   */
-  parse(argName: string, strValue: string): T;
-
-  /**
-   * Check if argument value is of type <T>. Optional method.
-   *
-   * @param argName {string} argument's name - used for context in case of error.
-   * @param argumentValue - value to be validated
-   *
-   * @throws BDLR301 if value is not of type <t>
-   */
-  validate?(argName: string, argumentValue: any): void;
-}
 
 /**
  * String type.
  *
  * Accepts any kind of string.
  */
-export const string: ArgumentType<string> = {
+export const string: CLIArgumentType<string> = {
   name: "string",
   parse: (argName, strValue) => strValue,
   /**
@@ -71,7 +40,7 @@ export const string: ArgumentType<string> = {
  * Accepts only 'true' or 'false' (case-insensitive).
  * @throws BDLR301
  */
-export const boolean: ArgumentType<boolean> = {
+export const boolean: CLIArgumentType<boolean> = {
   name: "boolean",
   parse: (argName, strValue) => {
     if (strValue.toLowerCase() === "true") {
@@ -113,7 +82,7 @@ export const boolean: ArgumentType<boolean> = {
  * Accepts either a decimal string integer or hexadecimal string integer.
  * @throws BDLR301
  */
-export const int: ArgumentType<number> = {
+export const int: CLIArgumentType<number> = {
   name: "int",
   parse: (argName, strValue) => {
     const decimalPattern = /^\d+(?:[eE]\d+)?$/;
@@ -157,7 +126,7 @@ export const int: ArgumentType<number> = {
  * Accepts either a decimal string number or hexadecimal string number.
  * @throws BDLR301
  */
-export const float: ArgumentType<number> = {
+export const float: CLIArgumentType<number> = {
   name: "float",
   parse: (argName, strValue) => {
     const decimalPattern = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE]\d+)?$/;
@@ -203,7 +172,7 @@ export const float: ArgumentType<number> = {
  * Accepts a path to a readable file..
  * @throws BDLR302
  */
-export const inputFile: ArgumentType<string> = {
+export const inputFile: CLIArgumentType<string> = {
   name: "inputFile",
   parse(argName: string, strValue: string): string {
     try {
@@ -255,7 +224,7 @@ export const inputFile: ArgumentType<string> = {
   },
 };
 
-export const json: ArgumentType<any> = {
+export const json: CLIArgumentType<any> = {
   name: "json",
   parse(argName: string, strValue: string): any {
     try {
@@ -271,6 +240,7 @@ export const json: ArgumentType<any> = {
       );
     }
   },
+
   /**
    * Check if argument value is of type "json". We consider everything except
    * undefined to be json.
@@ -289,4 +259,9 @@ export const json: ArgumentType<any> = {
       });
     }
   },
+};
+
+export const any: ArgumentType<any> = {
+  name: "any",
+  validate(argName: string, argumentValue: any) {},
 };

--- a/packages/buidler-core/src/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/src/internal/core/runtime-environment.ts
@@ -309,10 +309,6 @@ export class Environment implements BuidlerRuntimeEnvironment {
     argumentValue: any
   ) {
     const { name: paramName, type, isVariadic } = paramDefinition;
-    if (type === undefined || type.validate === undefined) {
-      // no type or no validate() method defined, just skip validation.
-      return;
-    }
 
     // in case of variadic param, argValue is an array and the type validation must pass for all values.
     // otherwise, it's a single value that is to be validated

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -1,8 +1,6 @@
 import { EventEmitter } from "events";
 import { DeepPartial, DeepReadonly, Omit } from "ts-essentials";
 
-import * as types from "./internal/core/params/argumentTypes";
-
 // Begin config types
 
 // IMPORTANT: This t.types MUST be kept in sync with the actual types.
@@ -115,6 +113,8 @@ export interface ResolvedBuidlerConfig extends BuidlerConfig {
 
 // End config types
 
+// TODO-HH: Maybe we shouldn't place this here, as it will be possible to modify
+//  the solc input with an override, and the type can easily get incompatible.
 export interface SolcInput {
   settings: {
     metadata: { useLiteralContent: boolean };
@@ -137,8 +137,41 @@ export type ConfigExtender = (
   userConfig: DeepReadonly<BuidlerConfig>
 ) => void;
 
-export interface TasksMap {
-  [name: string]: TaskDefinition;
+/**
+ * This class is used to dynamically validate task's argument types.
+ */
+export interface ArgumentType<T> {
+  /**
+   * The type's name.
+   */
+  name: string;
+
+  /**
+   * Check if argument value is of type <T>.
+   *
+   * @param argName {string} argument's name - used for context in case of error.
+   * @param argumentValue - value to be validated
+   *
+   * @throws BDLR301 if value is not of type <t>
+   */
+  validate(argName: string, argumentValue: any): void;
+}
+
+/**
+ * This is a special case of ArgumentType.
+ *
+ * These types must have a human-friendly string representation, so that they
+ * can be used as command line arguments.
+ */
+export interface CLIArgumentType<T> extends ArgumentType<T> {
+  /**
+   * Parses strValue into T. This function MUST throw BDLR301 if it
+   * can parse the given value.
+   *
+   * @param argName argument's name - used for context in case of error.
+   * @param strValue argument's string value to be parsed.
+   */
+  parse(argName: string, strValue: string): T;
 }
 
 export interface ConfigurableTaskDefinition {
@@ -150,7 +183,7 @@ export interface ConfigurableTaskDefinition {
     name: string,
     description?: string,
     defaultValue?: T,
-    type?: types.ArgumentType<T>,
+    type?: ArgumentType<T>,
     isOptional?: boolean
   ): this;
 
@@ -158,14 +191,14 @@ export interface ConfigurableTaskDefinition {
     name: string,
     description?: string,
     defaultValue?: T,
-    type?: types.ArgumentType<T>
+    type?: ArgumentType<T>
   ): this;
 
   addPositionalParam<T>(
     name: string,
     description?: string,
     defaultValue?: T,
-    type?: types.ArgumentType<T>,
+    type?: ArgumentType<T>,
     isOptional?: boolean
   ): this;
 
@@ -173,14 +206,14 @@ export interface ConfigurableTaskDefinition {
     name: string,
     description?: string,
     defaultValue?: T,
-    type?: types.ArgumentType<T>
+    type?: ArgumentType<T>
   ): this;
 
   addVariadicPositionalParam<T>(
     name: string,
     description?: string,
     defaultValue?: T[],
-    type?: types.ArgumentType<T>,
+    type?: ArgumentType<T>,
     isOptional?: boolean
   ): this;
 
@@ -188,7 +221,7 @@ export interface ConfigurableTaskDefinition {
     name: string,
     description?: string,
     defaultValue?: T[],
-    type?: types.ArgumentType<T>
+    type?: ArgumentType<T>
   ): this;
 
   addFlag(name: string, description?: string): this;
@@ -197,7 +230,7 @@ export interface ConfigurableTaskDefinition {
 export interface ParamDefinition<T> {
   name: string;
   defaultValue?: T;
-  type: types.ArgumentType<T>;
+  type: ArgumentType<T>;
   description?: string;
   isOptional: boolean;
   isFlag: boolean;
@@ -209,35 +242,14 @@ export interface OptionalParamDefinition<T> extends ParamDefinition<T> {
   isOptional: true;
 }
 
+export interface CLIOptionalParamDefinition<T>
+  extends OptionalParamDefinition<T> {
+  type: CLIArgumentType<T>;
+}
+
 export interface ParamDefinitionsMap {
   [paramName: string]: ParamDefinition<any>;
 }
-
-/**
- * Buidler arguments:
- * * network: the network to be used.
- * * showStackTraces: flag to show stack traces.
- * * version: flag to show buidler's version.
- * * help: flag to show buidler's help message.
- * * emoji:
- * * config: used to specify buidler's config file.
- */
-export interface BuidlerArguments {
-  network?: string;
-  showStackTraces: boolean;
-  version: boolean;
-  help: boolean;
-  emoji: boolean;
-  config?: string;
-  verbose: boolean;
-  maxMemory?: number;
-}
-
-export type BuidlerParamDefinitions = {
-  [param in keyof Required<BuidlerArguments>]: OptionalParamDefinition<
-    BuidlerArguments[param]
-  >;
-};
 
 export interface TaskDefinition extends ConfigurableTaskDefinition {
   readonly name: string;
@@ -268,11 +280,6 @@ export interface TaskDefinition extends ConfigurableTaskDefinition {
  */
 export type TaskArguments = any;
 
-export type RunTaskFunction = (
-  name: string,
-  taskArguments?: TaskArguments
-) => Promise<any>;
-
 export interface RunSuperFunction<ArgT extends TaskArguments> {
   (taskArguments?: ArgT): Promise<any>;
   isDefined: boolean;
@@ -283,6 +290,8 @@ export type ActionType<ArgsT extends TaskArguments> = (
   env: BuidlerRuntimeEnvironment,
   runSuper: RunSuperFunction<ArgsT>
 ) => Promise<any>;
+
+// Network types
 
 export interface EthereumProvider extends EventEmitter {
   send(method: string, params?: any[]): Promise<any>;
@@ -297,14 +306,7 @@ export interface Network {
   provider: EthereumProvider;
 }
 
-export interface BuidlerRuntimeEnvironment {
-  readonly config: ResolvedBuidlerConfig;
-  readonly buidlerArguments: BuidlerArguments;
-  readonly tasks: TasksMap;
-  readonly run: RunTaskFunction;
-  readonly network: Network;
-  readonly ethereum: EthereumProvider; // DEPRECATED: Use network.provider
-}
+// Artifact types
 
 export interface Artifact {
   contractName: string;
@@ -319,4 +321,50 @@ export interface LinkReferences {
   [libraryFileName: string]: {
     [libraryName: string]: Array<{ length: number; start: number }>;
   };
+}
+
+// Buidler Runtime Environment types
+
+/**
+ * Buidler arguments:
+ * * network: the network to be used.
+ * * showStackTraces: flag to show stack traces.
+ * * version: flag to show buidler's version.
+ * * help: flag to show buidler's help message.
+ * * emoji:
+ * * config: used to specify buidler's config file.
+ */
+export interface BuidlerArguments {
+  network?: string;
+  showStackTraces: boolean;
+  version: boolean;
+  help: boolean;
+  emoji: boolean;
+  config?: string;
+  verbose: boolean;
+  maxMemory?: number;
+}
+
+export type BuidlerParamDefinitions = {
+  [param in keyof Required<BuidlerArguments>]: CLIOptionalParamDefinition<
+    BuidlerArguments[param]
+  >;
+};
+
+export interface TasksMap {
+  [name: string]: TaskDefinition;
+}
+
+export type RunTaskFunction = (
+  name: string,
+  taskArguments?: TaskArguments
+) => Promise<any>;
+
+export interface BuidlerRuntimeEnvironment {
+  readonly config: ResolvedBuidlerConfig;
+  readonly buidlerArguments: BuidlerArguments;
+  readonly tasks: TasksMap;
+  readonly run: RunTaskFunction;
+  readonly network: Network;
+  readonly ethereum: EthereumProvider; // DEPRECATED: Use network.provider
 }

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -366,5 +366,6 @@ export interface BuidlerRuntimeEnvironment {
   readonly tasks: TasksMap;
   readonly run: RunTaskFunction;
   readonly network: Network;
+  // TODO-HH: Remove this deprectaed field
   readonly ethereum: EthereumProvider; // DEPRECATED: Use network.provider
 }

--- a/packages/buidler-core/test/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/test/internal/core/params/argumentTypes.ts
@@ -304,4 +304,19 @@ describe("argumentTypes", () => {
       assert.throws(() => types.json.validate!("json", undefined));
     });
   });
+
+  describe("any type", () => {
+    it("Should not be a CLI argument type", () => {
+      assert.isUndefined((types.any as any).parse);
+    });
+
+    it("Should accept anything", () => {
+      assert.doesNotThrow(() => types.any.validate("a", "as"));
+      assert.doesNotThrow(() => types.any.validate("a", undefined));
+      assert.doesNotThrow(() => types.any.validate("a", null));
+      assert.doesNotThrow(() => types.any.validate("a", []));
+      assert.doesNotThrow(() => types.any.validate("a", {}));
+      assert.doesNotThrow(() => types.any.validate("a", function () {}));
+    });
+  });
 });

--- a/packages/buidler-core/test/internal/core/params/argumentTypes.ts
+++ b/packages/buidler-core/test/internal/core/params/argumentTypes.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 
 import { ERRORS } from "../../../../src/internal/core/errors-list";
 import * as types from "../../../../src/internal/core/params/argumentTypes";
+import { ArgumentType } from "../../../../src/types";
 import { expectBuidlerError } from "../../../helpers/errors";
 
 function a(f: () => any) {
@@ -15,7 +16,7 @@ describe("argumentTypes", () => {
   it("should set the right name to all the argument types", () => {
     for (const typeName of Object.keys(types)) {
       const argumentTypesMap: {
-        [name: string]: types.ArgumentType<any>;
+        [name: string]: ArgumentType<any>;
       } = types;
       assert.equal(argumentTypesMap[typeName].name, typeName);
     }

--- a/packages/buidler-core/test/internal/core/tasks/task-definitions.ts
+++ b/packages/buidler-core/test/internal/core/tasks/task-definitions.ts
@@ -774,6 +774,105 @@ describe("SimpleTaskDefinition", () => {
         );
       });
     });
+
+    describe("CLI argument types", () => {
+      describe("non-internal tasks", () => {
+        let task: SimpleTaskDefinition;
+        beforeEach(() => {
+          task = new SimpleTaskDefinition("t", false);
+        });
+
+        describe("When using non-cli argument types", () => {
+          it("Should throw on addParam", () => {
+            expectBuidlerError(
+              () => task.addParam("p", "p", undefined, types.any),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+
+          it("Should  throw on addOptionalParam", () => {
+            expectBuidlerError(
+              () => task.addOptionalParam("p", "p", "asd", types.any),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+
+          it("Should  throw on addPositionalParam", () => {
+            expectBuidlerError(
+              () => task.addPositionalParam("p", "p", undefined, types.any),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+
+          it("Should  throw on addOptionalPositionalParam", () => {
+            expectBuidlerError(
+              () => task.addOptionalPositionalParam("p", "p", "asd", types.any),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+
+          it("Should  throw on addVariadicPositionalParam", () => {
+            expectBuidlerError(
+              () =>
+                task.addVariadicPositionalParam("p", "p", undefined, types.any),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+
+          it("Should  throw on addVariadicPositionalParam", () => {
+            expectBuidlerError(
+              () =>
+                task.addOptionalVariadicPositionalParam(
+                  "p",
+                  "p",
+                  "asd",
+                  types.any
+                ),
+              ERRORS.TASK_DEFINITIONS.CLI_ARGUMENT_TYPE_REQUIRED
+            );
+          });
+        });
+      });
+
+      describe("internal tasks", () => {
+        describe("When using non-cli argument types", () => {
+          let task: SimpleTaskDefinition;
+          beforeEach(() => {
+            task = new SimpleTaskDefinition("t", true);
+          });
+
+          it("Should not throw on addParam", () => {
+            task.addParam("p", "p", undefined, types.any);
+            assert.isDefined(task.paramDefinitions.p);
+          });
+
+          it("Should not throw on addOptionalParam", () => {
+            task.addOptionalParam("p", "p", "asd", types.any);
+            assert.isDefined(task.paramDefinitions.p);
+          });
+
+          it("Should not throw on addPositionalParam", () => {
+            task.addPositionalParam("p", "p", undefined, types.any);
+            assert.lengthOf(task.positionalParamDefinitions, 1);
+          });
+
+          it("Should not throw on addOptionalPositionalParam", () => {
+            task.addOptionalPositionalParam("p", "p", "asd", types.any);
+            assert.lengthOf(task.positionalParamDefinitions, 1);
+          });
+
+          it("Should not throw on addVariadicPositionalParam", () => {
+            task.addVariadicPositionalParam("p", "p", undefined, types.any);
+            assert.lengthOf(task.positionalParamDefinitions, 1);
+          });
+
+          it("Should not throw on addVariadicPositionalParam", () => {
+            task.addOptionalVariadicPositionalParam("p", "p", "asd", types.any);
+            assert.lengthOf(task.positionalParamDefinitions, 1);
+          });
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This PR refactors how `ArgumentType` are handled.

It introduces the following breaking changes:
* There are now two types for `ArgumentType`s
  * `ArgumentType`, which validates args at runtime
  * `CLIArgumentType` which can also parse strings into the arg type.
* It forbids non-internal tasks from using non-cli `ArgumentType`s
* It moves the `ArgumentType`'s types to `types.ts` (🤪), as they are part of the public api
* It introduces the `any` argument type