### PR TITLE
Upgrade console.sol version pragma

### DIFF
--- a/packages/buidler-core/console.sol
+++ b/packages/buidler-core/console.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.4.22 <0.7.0;
+pragma solidity >= 0.4.22 <0.8.0;
 
 library console {
 	address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);


### PR DESCRIPTION
I'm not sure if we should use `<0.8.0` or `<=0.7.0`. I think it's better to use `<0.8.0` and fix it if there's some breaking change in 0.7.x, than having to upgrade the pragma for each new patch.