### PR TITLE
Make Buidler work correctly with monorepos

### DIFF
--- a/packages/buidler-core/src/internal/context.ts
+++ b/packages/buidler-core/src/internal/context.ts
@@ -45,6 +45,8 @@ export class BuidlerContext {
   public readonly loadedPlugins: string[] = [];
   public readonly configExtenders: ConfigExtender[] = [];
 
+  private _configPath?: string;
+
   public setBuidlerRuntimeEnvironment(env: BuidlerRuntimeEnvironment) {
     if (this.environment !== undefined) {
       throw new BuidlerError(ERRORS.GENERAL.CONTEXT_BRE_ALREADY_DEFINED);
@@ -61,5 +63,17 @@ export class BuidlerContext {
 
   public setPluginAsLoaded(pluginName: string) {
     this.loadedPlugins.push(pluginName);
+  }
+
+  public setConfigPath(configPath: string) {
+    this._configPath = configPath;
+  }
+
+  public getConfigPath(): string {
+    if (this._configPath === undefined) {
+      throw new BuidlerError(ERRORS.GENERAL.CONTEXT_CONFIG_PATH_NOT_SET);
+    }
+
+    return this._configPath;
   }
 }

--- a/packages/buidler-core/src/internal/core/config/config-loading.ts
+++ b/packages/buidler-core/src/internal/core/config/config-loading.ts
@@ -38,6 +38,9 @@ export function loadConfigAndTasks(
     ([key, value]) => (globalAsAny[key] = value)
   );
 
+  const ctx = BuidlerContext.getBuidlerContext();
+  ctx.setConfigPath(configPath);
+
   loadPluginFile(path.join(__dirname, "..", "tasks", "builtin-tasks"));
 
   const defaultConfig = importCsjOrEsModule("./default-config");

--- a/packages/buidler-core/src/internal/core/errors-list.ts
+++ b/packages/buidler-core/src/internal/core/errors-list.ts
@@ -146,6 +146,16 @@ This is probably a bug in one of your plugins.
 Please [report it](https://github.com/nomiclabs/buidler/issues/new) to help us improve Buidler.`,
       shouldBeReported: true,
     },
+    CONTEXT_CONFIG_PATH_NOT_SET: {
+      number: 11,
+      message:
+        "Trying to access the BuidlerContext's config path field but it wasn't set",
+      title: "BuidlerContext's config path not defined",
+      description: `The Buidler initialization process was incomplete. This is a bug.
+
+Please [report it](https://github.com/nomiclabs/buidler/issues/new) to help us improve Buidler.`,
+      shouldBeReported: true,
+    },
   },
   NETWORK: {
     CONFIG_NOT_FOUND: {

--- a/packages/buidler-core/src/internal/core/plugins.ts
+++ b/packages/buidler-core/src/internal/core/plugins.ts
@@ -76,7 +76,7 @@ export function usePlugin(
 
   let globalFlag = "";
   let globalWarning = "";
-  if (getExecutionMode() === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION) {
+  if (executionMode === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION) {
     globalFlag = " --global";
     globalWarning =
       "You are using a global installation of Buidler. Plugins and their dependencies must also be global.\n";

--- a/packages/buidler-core/src/internal/core/typescript-support.ts
+++ b/packages/buidler-core/src/internal/core/typescript-support.ts
@@ -1,17 +1,6 @@
 import chalk from "chalk";
-import * as fs from "fs";
-import * as path from "path";
 
 import { ExecutionMode, getExecutionMode } from "./execution-mode";
-
-const NODE_MODULES_DIR = "node_modules";
-
-function getBuidlerNodeModules() {
-  return __dirname.substring(
-    0,
-    __dirname.lastIndexOf(NODE_MODULES_DIR) + NODE_MODULES_DIR.length
-  );
-}
 
 let cachedIsTypescriptSupported: boolean | undefined;
 
@@ -23,10 +12,14 @@ export function isTypescriptSupported() {
     } else if (
       executionMode === ExecutionMode.EXECUTION_MODE_LOCAL_INSTALLATION
     ) {
-      const nodeModules = getBuidlerNodeModules();
-      cachedIsTypescriptSupported =
-        fs.existsSync(path.join(nodeModules, "typescript")) &&
-        fs.existsSync(path.join(nodeModules, "ts-node"));
+      try {
+        // We resolve these from Buidler's installation.
+        require.resolve("typescript");
+        require.resolve("ts-node");
+        cachedIsTypescriptSupported = true;
+      } catch {
+        cachedIsTypescriptSupported = false;
+      }
     } else {
       // We are inside this project (e.g. running tests), or Buidler is
       // linked and we can't get the Buidler project's node_modules, so we


### PR DESCRIPTION
This PR introduces two small changes that ensure that Buidler works correctly with monorepos, even is different packages are hoisted.

Fixes #570
Fixes #468