### PR TITLE
fix: Signer instead of Wallet in loadFixture

### DIFF
--- a/packages/buidler-waffle/src/deploy.ts
+++ b/packages/buidler-waffle/src/deploy.ts
@@ -7,7 +7,7 @@ export function getDeployMockContract() {
   const waffleMockContractPath = path.dirname(
     require.resolve("@ethereum-waffle/mock-contract", {
       paths: [wafflePath],
-    })
+    }),
   );
   const waffleMockContract = require(waffleMockContractPath);
   return waffleMockContract.deployMockContract;
@@ -18,14 +18,11 @@ export async function buidlerDeployContract(
   signer: Signer,
   contractJSON: any,
   args: any[] = [],
-  overrideOptions: providers.TransactionRequest = {}
+  overrideOptions: providers.TransactionRequest = {},
 ): Promise<Contract> {
   const { deployContract } = require("ethereum-waffle/dist/cjs/deployContract");
 
-  if (
-    overrideOptions.gasLimit === undefined &&
-    typeof bre.network.config.gas === "number"
-  ) {
+  if (overrideOptions.gasLimit === undefined && typeof bre.network.config.gas === "number") {
     overrideOptions.gasLimit = bre.network.config.gas;
   }
 

--- a/packages/buidler-waffle/src/fixtures.ts
+++ b/packages/buidler-waffle/src/fixtures.ts
@@ -1,38 +1,32 @@
-import { BuidlerRuntimeEnvironment } from "@nomiclabs/buidler/types";
-import type { MockProvider } from "ethereum-waffle";
-import { providers, Wallet } from "ethers";
+import { MockProvider } from "ethereum-waffle";
+import { providers, Signer } from "ethers";
 
 // This file only exists to workaround this: https://github.com/EthWorks/Waffle/issues/281
 
-type Fixture<T> = (wallets: Wallet[], provider: MockProvider) => Promise<T>;
+type Fixture<T> = (signers: Signer[], provider: providers.JsonRpcProvider) => Promise<T>;
 interface Snapshot<T> {
   fixture: Fixture<T>;
   data: T;
   id: string;
-  provider: providers.Web3Provider;
-  wallets: Wallet[];
+  provider: providers.JsonRpcProvider;
+  signers: Signer[];
 }
 
-function createFixtureLoader(
-  overrideWallets: Wallet[] | undefined,
-  provider: MockProvider
-) {
+function createFixtureLoader(signers: Signer[], provider: providers.JsonRpcProvider) {
   const snapshots: Array<Snapshot<any>> = [];
 
   return async function load<T>(fixture: Fixture<T>): Promise<T> {
-    const snapshot = snapshots.find((p) => p.fixture === fixture);
+    const snapshot = snapshots.find(p => p.fixture === fixture);
     if (snapshot !== undefined) {
       await snapshot.provider.send("evm_revert", [snapshot.id]);
       snapshot.id = await snapshot.provider.send("evm_snapshot", []);
       return snapshot.data;
     }
     {
-      const wallets = overrideWallets ?? provider.getWallets();
-
-      const data = await fixture(wallets, provider);
+      const data = await fixture(signers, provider);
       const id = await provider.send("evm_snapshot", []);
 
-      snapshots.push({ fixture, data, id, provider, wallets });
+      snapshots.push({ fixture, data, id, provider, signers });
       return data;
     }
   };
@@ -40,11 +34,8 @@ function createFixtureLoader(
 
 export function buidlerCreateFixtureLoader(
   buidlerWaffleProvider: MockProvider,
-  overrideWallets?: Wallet[],
-  overrideProvider?: MockProvider
+  overrideSigners: Signer[],
+  overrideProvider?: providers.JsonRpcProvider,
 ) {
-  return createFixtureLoader(
-    overrideWallets,
-    overrideProvider ?? buidlerWaffleProvider
-  );
+  return createFixtureLoader(overrideSigners, overrideProvider ?? buidlerWaffleProvider);
 }

--- a/packages/buidler-waffle/src/index.ts
+++ b/packages/buidler-waffle/src/index.ts
@@ -21,7 +21,7 @@ export default function () {
         deployContract: buidlerDeployContract.bind(undefined, bre),
         deployMockContract: getDeployMockContract(),
         solidity: require("./waffle-chai"),
-        createFixtureLoader: buidlerCreateFixtureLoader.bind(buidlerWaffleProvider),
+        createFixtureLoader: buidlerCreateFixtureLoader.bind(undefined, buidlerWaffleProvider),
         loadFixture: buidlerCreateFixtureLoader(buidlerWaffleProvider),
         link: getLinkFunction(),
       };

--- a/packages/buidler-waffle/src/index.ts
+++ b/packages/buidler-waffle/src/index.ts
@@ -6,28 +6,22 @@ import { getLinkFunction } from "./link";
 import { initializeWaffleMatchers } from "./matchers";
 
 export default function () {
-  extendEnvironment((bre) => {
+  extendEnvironment(bre => {
     // We can't actually implement a MockProvider because of its private
     // properties, so we cast it here 😢
     bre.waffle = lazyObject(() => {
-      const {
-        WaffleMockProviderAdapter,
-      } = require("./waffle-provider-adapter");
+      const { WaffleMockProviderAdapter } = require("./waffle-provider-adapter");
 
       const { buidlerCreateFixtureLoader } = require("./fixtures");
 
-      const buidlerWaffleProvider = new WaffleMockProviderAdapter(
-        bre.network
-      ) as any;
+      const buidlerWaffleProvider = new WaffleMockProviderAdapter(bre.network) as any;
 
       return {
         provider: buidlerWaffleProvider,
         deployContract: buidlerDeployContract.bind(undefined, bre),
         deployMockContract: getDeployMockContract(),
         solidity: require("./waffle-chai"),
-        createFixtureLoader: buidlerCreateFixtureLoader.bind(
-          buidlerWaffleProvider
-        ),
+        createFixtureLoader: buidlerCreateFixtureLoader.bind(buidlerWaffleProvider),
         loadFixture: buidlerCreateFixtureLoader(buidlerWaffleProvider),
         link: getLinkFunction(),
       };

--- a/packages/buidler-waffle/src/link.ts
+++ b/packages/buidler-waffle/src/link.ts
@@ -5,7 +5,7 @@ export function getLinkFunction() {
   const waffleCompilerPath = path.dirname(
     require.resolve("@ethereum-waffle/compiler", {
       paths: [wafflePath],
-    })
+    }),
   );
 
   const waffleCompiler = require(path.join(waffleCompilerPath, "link"));

--- a/packages/buidler-waffle/src/type-extensions.d.ts
+++ b/packages/buidler-waffle/src/type-extensions.d.ts
@@ -1,12 +1,5 @@
 import "@nomiclabs/buidler/types";
-import type {
-  createFixtureLoader,
-  link,
-  loadFixture,
-  MockContract,
-  MockProvider,
-  solidity,
-} from "ethereum-waffle";
+import type { createFixtureLoader, link, loadFixture, MockContract, MockProvider, solidity } from "ethereum-waffle";
 import type { ContractJSON } from "ethereum-waffle/dist/esm/ContractJSON";
 import type { Contract, providers, Signer } from "ethers";
 
@@ -18,7 +11,7 @@ declare module "@nomiclabs/buidler/types" {
         signer: Signer,
         contractJSON: ContractJSON,
         args?: any[],
-        overrideOptions?: providers.TransactionRequest
+        overrideOptions?: providers.TransactionRequest,
       ) => Promise<Contract>;
       solidity: typeof solidity;
       link: typeof link;

--- a/packages/buidler-waffle/src/waffle-chai.ts
+++ b/packages/buidler-waffle/src/waffle-chai.ts
@@ -9,28 +9,18 @@ export function waffleChai(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
   const waffleChaiPath = path.dirname(
     require.resolve("@ethereum-waffle/chai", {
       paths: [wafflePath],
-    })
+    }),
   );
 
   const { supportBigNumber } = require(`${waffleChaiPath}/matchers/bigNumber`);
-  const {
-    supportChangeBalance,
-  } = require(`${waffleChaiPath}/matchers/changeBalance`);
-  const {
-    supportChangeBalances,
-  } = require(`${waffleChaiPath}/matchers/changeBalances`);
+  const { supportChangeBalance } = require(`${waffleChaiPath}/matchers/changeBalance`);
+  const { supportChangeBalances } = require(`${waffleChaiPath}/matchers/changeBalances`);
   const { supportEmit } = require(`${waffleChaiPath}/matchers/emit`);
-  const {
-    supportProperAddress,
-  } = require(`${waffleChaiPath}/matchers/properAddress`);
+  const { supportProperAddress } = require(`${waffleChaiPath}/matchers/properAddress`);
   const { supportProperHex } = require(`${waffleChaiPath}/matchers/properHex`);
-  const {
-    supportProperPrivateKey,
-  } = require(`${waffleChaiPath}/matchers/properPrivateKey`);
+  const { supportProperPrivateKey } = require(`${waffleChaiPath}/matchers/properPrivateKey`);
   const { supportReverted } = require(`${waffleChaiPath}/matchers/reverted`);
-  const {
-    supportRevertedWith,
-  } = require(`${waffleChaiPath}/matchers/revertedWith`);
+  const { supportRevertedWith } = require(`${waffleChaiPath}/matchers/revertedWith`);
 
   supportBigNumber(chai.Assertion, utils);
   supportReverted(chai.Assertion);
@@ -48,17 +38,13 @@ export function waffleChai(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
 function supportCalledOnContract(Assertion: Chai.AssertionStatic) {
   const Chai = require("chai");
   Assertion.addMethod("calledOnContract", function (contract: any) {
-    throw new Chai.AssertionError(
-      "Waffle's calledOnContract is not supported by Buidler"
-    );
+    throw new Chai.AssertionError("Waffle's calledOnContract is not supported by Buidler");
   });
 }
 
 function supportCalledOnContractWith(Assertion: Chai.AssertionStatic) {
   const Chai = require("chai");
   Assertion.addMethod("calledOnContractWith", function (contract: any) {
-    throw new Chai.AssertionError(
-      "Waffle's calledOnContractWith is not supported by Buidler"
-    );
+    throw new Chai.AssertionError("Waffle's calledOnContractWith is not supported by Buidler");
   });
 }

--- a/packages/buidler-waffle/src/waffle-provider-adapter.ts
+++ b/packages/buidler-waffle/src/waffle-provider-adapter.ts
@@ -15,9 +15,7 @@ export class WaffleMockProviderAdapter extends providers.JsonRpcProvider {
 You can use \`await bre.ethers.signers()\` in other networks.`);
     }
 
-    return (this._buidlerNetwork.config as BuidlerNetworkConfig).accounts!.map(
-      (acc) => new Wallet(acc.privateKey, this)
-    );
+    return (this._buidlerNetwork.config as BuidlerNetworkConfig).accounts!.map(acc => new Wallet(acc.privateKey, this));
   }
 
   public createEmptyWallet() {

--- a/packages/buidler-waffle/test/buidler-project-custom-accounts/buidler.config.js
+++ b/packages/buidler-waffle/test/buidler-project-custom-accounts/buidler.config.js
@@ -6,13 +6,11 @@ module.exports = {
     buidlerevm: {
       accounts: [
         {
-          privateKey:
-            "0x07711bb9fb8508a36bf0307c579a8974d1a3230badb8757b6e22d203190ea800",
+          privateKey: "0x07711bb9fb8508a36bf0307c579a8974d1a3230badb8757b6e22d203190ea800",
           balance: "123",
         },
         {
-          privateKey:
-            "0x07711bb9fb8508a36bf0307c579a8974d1a3230badb8757b6e22d203190ea803",
+          privateKey: "0x07711bb9fb8508a36bf0307c579a8974d1a3230badb8757b6e22d203190ea803",
           balance: "123",
         },
       ],

--- a/packages/buidler-waffle/test/buidler-project/test/tests.js
+++ b/packages/buidler-waffle/test/buidler-project/test/tests.js
@@ -12,7 +12,7 @@ describe("Internal test suite of buidler-waffle's test project", function () {
     throw new Error("Failed on purpose");
   });
 
-  describe("Usupported methods", function () {
+  describe("Unsupported methods", function () {
     it("Should print the right error for calledOnContractWith", function () {
       try {
         expect("balanceOf").to.be.calledOnContractWith("asd", ["asd"]);

--- a/packages/buidler-waffle/test/helpers.ts
+++ b/packages/buidler-waffle/test/helpers.ts
@@ -7,10 +7,7 @@ declare module "mocha" {
   }
 }
 
-export function useEnvironment(
-  projectPath: string,
-  networkName = "buidlerevm"
-) {
+export function useEnvironment(projectPath: string, networkName = "buidlerevm") {
   beforeEach("Loading buidler environment", function () {
     process.chdir(projectPath);
     process.env.BUIDLER_NETWORK = networkName;

--- a/packages/buidler-waffle/test/index.ts
+++ b/packages/buidler-waffle/test/index.ts
@@ -14,39 +14,27 @@ describe("Waffle plugin plugin", function () {
 
           it("Should return a wallet for each of the default accounts", function () {
             const wallets = this.env.waffle.provider.getWallets();
-            const accounts = (defaultConfig.networks!
-              .buidlerevm! as BuidlerNetworkConfig).accounts!;
+            const accounts = (defaultConfig.networks!.buidlerevm! as BuidlerNetworkConfig).accounts!;
             assert.lengthOf(wallets, accounts.length);
 
             for (let i = 0; i < wallets.length; i++) {
-              assert.equal(
-                wallets[i].privateKey.toLowerCase(),
-                accounts[i].privateKey.toLowerCase()
-              );
+              assert.equal(wallets[i].privateKey.toLowerCase(), accounts[i].privateKey.toLowerCase());
             }
           });
         });
 
         describe("With customized buidlerevm accounts", function () {
-          useEnvironment(
-            path.join(__dirname, "buidler-project-custom-accounts")
-          );
+          useEnvironment(path.join(__dirname, "buidler-project-custom-accounts"));
 
           it("Should return a wallet for each of the custom accounts", function () {
             const wallets = this.env.waffle.provider.getWallets();
-            const accounts = require(path.join(
-              __dirname,
-              "buidler-project-custom-accounts",
-              "buidler.config.js"
-            )).networks.buidlerevm.accounts;
+            const accounts = require(path.join(__dirname, "buidler-project-custom-accounts", "buidler.config.js"))
+              .networks.buidlerevm.accounts;
 
             assert.lengthOf(wallets, accounts.length);
 
             for (let i = 0; i < wallets.length; i++) {
-              assert.equal(
-                wallets[i].privateKey.toLowerCase(),
-                accounts[i].privateKey.toLowerCase()
-              );
+              assert.equal(wallets[i].privateKey.toLowerCase(), accounts[i].privateKey.toLowerCase());
             }
           });
         });
@@ -56,10 +44,7 @@ describe("Waffle plugin plugin", function () {
         useEnvironment(path.join(__dirname, "buidler-project"), "localhost");
 
         it("Should throw an error", function () {
-          assert.throws(
-            () => this.env.waffle.provider.getWallets(),
-            "This method only works with Buidler EVM"
-          );
+          assert.throws(() => this.env.waffle.provider.getWallets(), "This method only works with Buidler EVM");
         });
       });
 
@@ -70,16 +55,12 @@ describe("Waffle plugin plugin", function () {
 
             it("Should return a wallet for each of the default accounts", function () {
               const wallets = this.env.waffle.provider.getWallets();
-              const accounts = (defaultConfig.networks!
-                .buidlerevm! as BuidlerNetworkConfig).accounts!;
+              const accounts = (defaultConfig.networks!.buidlerevm! as BuidlerNetworkConfig).accounts!;
 
               assert.lengthOf(wallets, accounts.length);
 
               for (let i = 0; i < wallets.length; i++) {
-                assert.equal(
-                  wallets[i].privateKey.toLowerCase(),
-                  accounts[i].privateKey.toLowerCase()
-                );
+                assert.equal(wallets[i].privateKey.toLowerCase(), accounts[i].privateKey.toLowerCase());
               }
             });
           });


### PR DESCRIPTION
Fixes #690.

I only changed the `fixtures.ts` file in the `buidler-waffle` package. Changelog:

- [x] Change the `Wallet` type to `Signer
- [x] Change the provider type from `MockProvider` fo `providers.JsonRpcProvider`
- [x] Rename the `overrideSigners` parameter to `signers` and make it non-optional; I didn't know how to call `ethers.getSigners` from within the `buidler-waffle` package, otherwise I would've kept `overrideSigners` optional