### PR TITLE
Library support for buidler-etherscan

### DIFF
--- a/packages/buidler-etherscan/README.md
+++ b/packages/buidler-etherscan/README.md
@@ -69,7 +69,7 @@ struct Point {
 }
 
 contract Foo {
-  constructor (uint x, string s, Point memory point) { ... }
+  constructor (uint x, string s, Point memory point, bytes b) { ... }
 }
 ```
 
@@ -82,7 +82,9 @@ module.exports = [
   {
     x: 10,
     y: 5,
-  }
+  },
+  // bytes have to be 0x-prefixed
+  "0xabcdef",
 ];
 ```
 

--- a/packages/buidler-etherscan/README.md
+++ b/packages/buidler-etherscan/README.md
@@ -100,7 +100,6 @@ The plugin works by fetching the bytecode in the given address and using it to c
 
 ## Known limitations
 
-- Contracts with linked libraries are supported, but libraries themselves can’t be verified on their own yet.
 - Cases where more than one contract correspond to the same bytecode aren’t supported.
 - Adding, removing, moving or renaming new contracts to the buidler project or reorganizing the directory structure of contracts after deployment may alter the resulting bytecode in some solc versions. See this [Solidity issue](https://github.com/ethereum/solidity/issues/9573) for further information.
 

--- a/packages/buidler-etherscan/src/ABIEncoder.ts
+++ b/packages/buidler-etherscan/src/ABIEncoder.ts
@@ -17,9 +17,11 @@ export async function encodeArguments(
       .encodeDeploy(constructorArguments)
       .replace("0x", "");
   } catch (error) {
-    const { isABIArgumentLengthError, isABIArgumentTypeError } = await import(
-      "./ABITypes"
-    );
+    const {
+      isABIArgumentLengthError,
+      isABIArgumentTypeError,
+      isABIArgumentOverflowError,
+    } = await import("./ABITypes");
     if (isABIArgumentLengthError(error)) {
       // TODO: add a list of types and constructor arguments to the error message?
       const message = `The constructor for ${contractFilename}:${contractName} has ${error.count.types} parameters
@@ -29,6 +31,11 @@ export async function encodeArguments(
     if (isABIArgumentTypeError(error)) {
       const message = `Value ${error.value} cannot be encoded for the parameter ${error.argument}.
   Encoder error reason: ${error.reason}`;
+      throw new NomicLabsBuidlerPluginError(pluginName, message, error);
+    }
+    if (isABIArgumentOverflowError(error)) {
+      const message = `Value ${error.value} is not a safe integer and cannot be encoded.
+  Encoder error reason: ${error.fault} fault in ${error.operation}`;
       throw new NomicLabsBuidlerPluginError(pluginName, message, error);
     }
     // Should be unreachable.

--- a/packages/buidler-etherscan/src/ABIEncoder.ts
+++ b/packages/buidler-etherscan/src/ABIEncoder.ts
@@ -25,17 +25,18 @@ export async function encodeArguments(
     if (isABIArgumentLengthError(error)) {
       // TODO: add a list of types and constructor arguments to the error message?
       const message = `The constructor for ${contractFilename}:${contractName} has ${error.count.types} parameters
-  but ${error.count.values} arguments were provided instead.`;
+but ${error.count.values} arguments were provided instead.`;
       throw new NomicLabsBuidlerPluginError(pluginName, message, error);
     }
     if (isABIArgumentTypeError(error)) {
       const message = `Value ${error.value} cannot be encoded for the parameter ${error.argument}.
-  Encoder error reason: ${error.reason}`;
+Encoder error reason: ${error.reason}`;
       throw new NomicLabsBuidlerPluginError(pluginName, message, error);
     }
     if (isABIArgumentOverflowError(error)) {
       const message = `Value ${error.value} is not a safe integer and cannot be encoded.
-  Encoder error reason: ${error.fault} fault in ${error.operation}`;
+Use a string instead of a plain number.
+Encoder error reason: ${error.fault} fault in ${error.operation}`;
       throw new NomicLabsBuidlerPluginError(pluginName, message, error);
     }
     // Should be unreachable.

--- a/packages/buidler-etherscan/src/ABITypes.ts
+++ b/packages/buidler-etherscan/src/ABITypes.ts
@@ -1,5 +1,5 @@
 export interface ABIArgumentLengthError extends Error {
-  code: string;
+  code: "INVALID_ARGUMENT";
   count: {
     types: number;
     values: number;
@@ -30,7 +30,7 @@ export function isABIArgumentLengthError(
 }
 
 export interface ABIArgumentTypeError extends Error {
-  code: string;
+  code: "INVALID_ARGUMENT";
   argument: string;
   value: any;
   reason: string;
@@ -42,6 +42,26 @@ export function isABIArgumentTypeError(
   return (
     error.code === "INVALID_ARGUMENT" &&
     typeof error.argument === "string" &&
+    "value" in error &&
+    error instanceof Error
+  );
+}
+
+export interface ABIArgumentOverflowError extends Error {
+  code: "NUMERIC_FAULT";
+  fault: "overflow";
+  value: any;
+  reason: string;
+  operation: string;
+}
+
+export function isABIArgumentOverflowError(
+  error: any
+): error is ABIArgumentOverflowError {
+  return (
+    error.code === "NUMERIC_FAULT" &&
+    error.fault === "overflow" &&
+    typeof error.operation === "string" &&
     "value" in error &&
     error instanceof Error
   );

--- a/packages/buidler-etherscan/src/index.ts
+++ b/packages/buidler-etherscan/src/index.ts
@@ -89,7 +89,8 @@ module.exports = [ arg1, arg2, ... ];`
     } catch (error) {
       throw new NomicLabsBuidlerPluginError(
         pluginName,
-        "Importing the module for the constructor arguments list failed.",
+        `Importing the module for the constructor arguments list failed.
+Reason: ${error.message}`,
         error
       );
     }

--- a/packages/buidler-etherscan/src/solc/bytecode.ts
+++ b/packages/buidler-etherscan/src/solc/bytecode.ts
@@ -192,7 +192,10 @@ export async function normalizeBytecode(
   // See https://solidity.readthedocs.io/en/latest/contracts.html#call-protection-for-libraries
   const push20OpcodeHex = "73";
   const pushPlaceholder = push20OpcodeHex + "0".repeat(20 * 2);
-  if (symbols.object.startsWith(pushPlaceholder) && bytecode.startsWith(push20OpcodeHex)) {
+  if (
+    symbols.object.startsWith(pushPlaceholder) &&
+    bytecode.startsWith(push20OpcodeHex)
+  ) {
     nestedSliceReferences.push([{ start: 1, length: 20 }]);
   }
 

--- a/packages/buidler-etherscan/src/solc/bytecode.ts
+++ b/packages/buidler-etherscan/src/solc/bytecode.ts
@@ -188,6 +188,14 @@ export async function normalizeBytecode(
     }
   }
 
+  // To normalize a library object we need to take into account its call protection mechanism.
+  // See https://solidity.readthedocs.io/en/latest/contracts.html#call-protection-for-libraries
+  const push20OpcodeHex = "73";
+  const pushPlaceholder = push20OpcodeHex + "0".repeat(20 * 2);
+  if (symbols.object.startsWith(pushPlaceholder) && bytecode.startsWith(push20OpcodeHex)) {
+    nestedSliceReferences.push([{ start: 1, length: 20 }]);
+  }
+
   const sliceReferences = flattenSlices(nestedSliceReferences);
   const normalizedBytecode = zeroOutSlices(bytecode, sliceReferences);
 

--- a/packages/buidler-etherscan/test/buidler-project/buidler.config.js
+++ b/packages/buidler-etherscan/test/buidler-project/buidler.config.js
@@ -6,7 +6,7 @@ loadPluginFile(__dirname + "/../../src/index");
 
 module.exports = {
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY || "",
+    apiKey: process.env.ETHERSCAN_API_KEY,
   },
   solc: {
     version: "0.5.15",

--- a/packages/buidler-etherscan/test/buidler-project/contracts/TestLibrary.sol
+++ b/packages/buidler-etherscan/test/buidler-project/contracts/TestLibrary.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.15;
+
+library TestLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+
+    function libID() external returns (string memory) {
+        return "placeholder";
+    }
+}

--- a/packages/buidler-etherscan/test/integration/PluginTests.ts
+++ b/packages/buidler-etherscan/test/integration/PluginTests.ts
@@ -67,6 +67,21 @@ describe("Plugin integration tests", function () {
       });
     });
 
+    it("Should verify deployed library on etherscan", async function () {
+      await this.env.run(TASK_COMPILE, { force: false });
+
+      const deployedAddress = await deployContract(
+        "TestLibrary",
+        [],
+        this.env
+      );
+
+      return this.env.run("verify", {
+        address: deployedAddress,
+        constructorArguments: [],
+      });
+    });
+
     // The plugin doesn't look at deployment bytecode while inferring the contract
     it("fail when the contract can only be singled out by its deploy bytecode", async function () {
       await this.env.run(TASK_COMPILE, { force: false });

--- a/packages/buidler-etherscan/test/integration/PluginTests.ts
+++ b/packages/buidler-etherscan/test/integration/PluginTests.ts
@@ -70,11 +70,7 @@ describe("Plugin integration tests", function () {
     it("Should verify deployed library on etherscan", async function () {
       await this.env.run(TASK_COMPILE, { force: false });
 
-      const deployedAddress = await deployContract(
-        "TestLibrary",
-        [],
-        this.env
-      );
+      const deployedAddress = await deployContract("TestLibrary", [], this.env);
 
       return this.env.run("verify", {
         address: deployedAddress,

--- a/packages/buidler-etherscan/test/unit/ABIEncoder.ts
+++ b/packages/buidler-etherscan/test/unit/ABIEncoder.ts
@@ -51,6 +51,34 @@ describe("constructor argument validation tests", () => {
     );
   });
 
+  it("should fail gracefully with an unsafe integer", async () => {
+    const abi = [
+      {
+        inputs: [
+          {
+            name: "amount",
+            type: "uint256",
+          },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+      },
+    ];
+
+    const amount = 1000000000000000000;
+    assert.isFalse(Number.isSafeInteger(amount));
+    const constructorArguments: any[] = [amount];
+
+    const encodedArguments = await encodeArguments(
+      abi,
+      contractFilename,
+      contractName,
+      constructorArguments
+    ).catch((reason) => {
+      assert.instanceOf(reason, NomicLabsBuidlerPluginError);
+    });
+  });
+
   it("should throw when the argument list is too small", async () => {
     const abi = [
       {

--- a/packages/buidler-etherscan/test/unit/solc/bytecode.ts
+++ b/packages/buidler-etherscan/test/unit/solc/bytecode.ts
@@ -113,7 +113,34 @@ describe("Compiler bytecode and deployed bytecode matching", () => {
     });
   });
 
-  describe("with one library link", () => {
+  describe("with a library contract", () => {
+    it("matches bytecode with library call protection", async () => {
+      const contract: any = {
+        contractName: "TestLibrary",
+        runtimeBytecode:
+          "0x730000000000000000000000000000000000000000301460806040526004361060335760003560e01c806305b8c7c2146038575b600080fd5b818015604357600080fd5b50606d60048036036020811015605857600080fd5b81019080803590602001909291905050506083565b6040518082815260200191505060405180910390f35b600060028202905091905056fea2646970667358221220783581f95b347b5783979ebe803f2e6cccf03e34345f61ba312b69f4205cf8f864736f6c63430007000033",
+        deployedBytecode:
+          "0x737c2c195cd6d34b8f845992d380aadb2730bb9c6f301460806040526004361060335760003560e01c806305b8c7c2146038575b600080fd5b818015604357600080fd5b50606d60048036036020811015605857600080fd5b81019080803590602001909291905050506083565b6040518082815260200191505060405180910390f35b600060028202905091905056fea2646970667358221220783581f95b347b5783979ebe803f2e6cccf03e34345f61ba312b69f4205cf8f864736f6c63430007000033",
+        solcVersion: "0.7.0",
+        linkReferences: {},
+        immutableReferences: {},
+      };
+      const contractSymbols = {
+        object: contract.runtimeBytecode.slice(2),
+        linkReferences: contract.linkReferences,
+        immutableReferences: contract.immutableReferences,
+      };
+      const deployedBytecode = contract.deployedBytecode.slice(2);
+      const contractInformation = await compareBytecode(
+        deployedBytecode,
+        contractSymbols,
+        InferralType.EXACT
+      );
+      assert.isTrue(contractInformation.match);
+    });
+  });
+
+  describe("with a contract that has one library link", () => {
     // v0.4.12 is the minimum solc version that can be run with buidler out of the box.
     it("matches bytecode emitted by solc v0.4.12", async () => {
       const contract: any = {


### PR DESCRIPTION
This pull request:
- Adds support for library contracts themselves.
- Adds a nice error message for integer overflow when encoding constructor arguments.
- Improves the error messages for failures during the importation of constructor argument modules.