### PR TITLE
Improve the derivation of function selectors from the AST

### DIFF
--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
@@ -213,7 +213,7 @@ function getPublicVariableSelectorFromDeclarationAstNode(
 
   // VariableDeclaration nodes for function parameters or state variables will always
   // have their typeName fields defined.
-  let nextType = variableDeclaration.typeName!;
+  let nextType = variableDeclaration.typeName;
   while (true) {
     if (nextType.nodeType === "Mapping") {
       paramTypes.push(toCanonicalAbiType(nextType.keyType.name));
@@ -453,7 +453,7 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
     }
 
     // The rest of the function parameters always have their typeName node defined
-    const typename = param.typeName!;
+    const typename = param.typeName;
     if (typename.nodeType === "ArrayTypeName" || typename.nodeType === "FunctionTypeName") {
       paramTypes.push(typename.typeDescriptions.typeString);
       continue;

--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
@@ -457,7 +457,12 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
       continue;
     }
 
-    paramTypes.push(toCanonicalAbiType(param.typeName.name));
+    if (typename.nodeType === "FunctionTypeName") {
+      paramTypes.push(typename.typeDescriptions.typeString);
+      continue;
+    }
+
+    paramTypes.push(toCanonicalAbiType(typename.name));
   }
 
   return abi.methodID(functionDefinition.name, paramTypes);

--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
@@ -435,7 +435,7 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
 
   // The function selector is available in solc versions >=0.6.0
   if (functionDefinition.functionSelector !== undefined) {
-    return Buffer.from(functionDefinition.functionSelector, 'hex')
+    return Buffer.from(functionDefinition.functionSelector, "hex");
   }
 
   for (const param of functionDefinition.parameters.parameters) {
@@ -454,7 +454,10 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
 
     // The rest of the function parameters always have their typeName node defined
     const typename = param.typeName;
-    if (typename.nodeType === "ArrayTypeName" || typename.nodeType === "FunctionTypeName") {
+    if (
+      typename.nodeType === "ArrayTypeName" ||
+      typename.nodeType === "FunctionTypeName"
+    ) {
       paramTypes.push(typename.typeDescriptions.typeString);
       continue;
     }

--- a/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
+++ b/packages/buidler-core/src/internal/buidler-evm/stack-traces/compiler-to-model.ts
@@ -452,12 +452,9 @@ function astFunctionDefinitionToSelector(functionDefinition: any): Buffer {
       continue;
     }
 
-    if (param.typeName.nodeType === "ArrayTypeName") {
-      paramTypes.push(`${toCanonicalAbiType(param.typeName.baseType.name)}[]`);
-      continue;
-    }
-
-    if (typename.nodeType === "FunctionTypeName") {
+    // The rest of the function parameters always have their typeName node defined
+    const typename = param.typeName!;
+    if (typename.nodeType === "ArrayTypeName" || typename.nodeType === "FunctionTypeName") {
       paramTypes.push(typename.typeDescriptions.typeString);
       continue;
     }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -6,8 +6,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function doSomething(uint256[][] memory numbers) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+pragma experimental ABIEncoderV2;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function doSomething(uint256[][] memory numbers) public returns (uint256) {
+    return numbers[0][0];
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/c.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {
+    return aFunction(aParameter);
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/c.sol
@@ -4,8 +4,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_5/special-cases/function-type-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.6.0;
+
+pragma experimental ABIEncoderV2;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function doSomething(uint256[][] memory numbers) public returns (uint256) {
+    return numbers[0][0];
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -6,8 +6,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function doSomething(uint256[][] memory numbers) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/c.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.6.0;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {
+    return aFunction(aParameter);
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/c.sol
@@ -4,8 +4,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_6/special-cases/function-type-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -6,8 +6,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function doSomething(uint256[][] memory numbers) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/c.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.7.0;
+
+pragma experimental ABIEncoderV2;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function doSomething(uint256[][] memory numbers) public returns (uint256) {
+    return numbers[0][0];
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/abi-v2/nested-arrays-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/c.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.7.0;
+
+import "./../../../../../../../../console.sol";
+
+contract C {
+
+  function printSomething() public returns (string memory) {
+    return "something";
+  }
+
+  function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {
+    return aFunction(aParameter);
+  }
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/c.sol
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/c.sol
@@ -4,8 +4,8 @@ import "./../../../../../../../../console.sol";
 
 contract C {
 
-  function printSomething() public returns (string memory) {
-    return "something";
+  function printSomething() public {
+    console.log("something");
   }
 
   function proxyMessageCall(function (uint256) external returns (uint256) aFunction, uint256 aParameter) public returns (uint256) {

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/test.json
@@ -9,7 +9,9 @@
       "to": 0,
       "function": "printSomething",
       "params": [],
-      "consoleLogs": []
+      "consoleLogs": [
+        ["something"]
+      ]
     }
   ]
 }

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/test.json
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test-files/0_7/special-cases/function-type-as-public-parameter/test.json
@@ -1,0 +1,15 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C",
+      "imports": ["/../../../../../../../../console.sol"]
+    },
+    {
+      "to": 0,
+      "function": "printSomething",
+      "params": [],
+      "consoleLogs": []
+    }
+  ]
+}

--- a/packages/buidler-core/test/internal/buidler-evm/stack-traces/test.ts
+++ b/packages/buidler-core/test/internal/buidler-evm/stack-traces/test.ts
@@ -538,7 +538,7 @@ async function runDeploymentTransactionTest(
   const contract = file[tx.contract];
 
   assert.isDefined(
-    file,
+    contract,
     `Contract ${tx.contract} from transaction ${txIndex} doesn't exist`
   );
 


### PR DESCRIPTION
This improves the function selector derivation by looking at the `functionSelector` field whenever available and uses the `typeDescription.typeString` field for function and array types.

A couple of test cases were added for all supported compiler series that pass after applying these improvements:
- A contract that has a public function with a function typed parameter.
- A contract that has a public function with a nested array parameter.