### PR TITLE
Add global dir module to buidler-core internals.

### DIFF
--- a/packages/buidler-core/package-lock.json
+++ b/packages/buidler-core/package-lock.json
@@ -1321,6 +1321,11 @@
         "ansi-colors": "^3.2.1"
       }
     },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -85,6 +85,7 @@
     "deepmerge": "^2.1.0",
     "download": "^7.1.0",
     "enquirer": "^2.3.0",
+    "env-paths": "^2.2.0",
     "eth-sig-util": "^2.5.2",
     "ethereum-cryptography": "^0.1.2",
     "ethereumjs-abi": "^0.6.8",

--- a/packages/buidler-core/src/builtin-tasks/compile.ts
+++ b/packages/buidler-core/src/builtin-tasks/compile.ts
@@ -18,7 +18,7 @@ import { getInputFromDependencyGraph } from "../internal/solidity/compiler/compi
 import { DependencyGraph } from "../internal/solidity/dependencyGraph";
 import { Resolver } from "../internal/solidity/resolver";
 import { glob } from "../internal/util/glob";
-import { getCompilerDir } from "../internal/util/global-dir";
+import { getCompilersDir } from "../internal/util/global-dir";
 import { pluralize } from "../internal/util/strings";
 import { ResolvedBuidlerConfig, SolcInput } from "../types";
 
@@ -115,7 +115,7 @@ export default function () {
       types.json
     )
     .setAction(async ({ input }: { input: SolcInput }, { config }) => {
-      const compilersCache = await getCompilerDir();
+      const compilersCache = await getCompilersDir();
       const compiler = new Compiler(config.solc.version, compilersCache);
 
       return compiler.compile(input);

--- a/packages/buidler-core/src/builtin-tasks/compile.ts
+++ b/packages/buidler-core/src/builtin-tasks/compile.ts
@@ -18,6 +18,7 @@ import { getInputFromDependencyGraph } from "../internal/solidity/compiler/compi
 import { DependencyGraph } from "../internal/solidity/dependencyGraph";
 import { Resolver } from "../internal/solidity/resolver";
 import { glob } from "../internal/util/glob";
+import { getCompilerDir } from "../internal/util/global-dir";
 import { pluralize } from "../internal/util/strings";
 import { ResolvedBuidlerConfig, SolcInput } from "../types";
 
@@ -114,10 +115,8 @@ export default function () {
       types.json
     )
     .setAction(async ({ input }: { input: SolcInput }, { config }) => {
-      const compiler = new Compiler(
-        config.solc.version,
-        path.join(config.paths.cache, "compilers")
-      );
+      const compilersCache = await getCompilerDir();
+      const compiler = new Compiler(config.solc.version, compilersCache);
 
       return compiler.compile(input);
     });

--- a/packages/buidler-core/src/internal/util/global-dir.ts
+++ b/packages/buidler-core/src/internal/util/global-dir.ts
@@ -68,7 +68,7 @@ export async function writeAnalyticsId(clientId: string) {
   log(`Stored clientId ${clientId}`);
 }
 
-export async function getCompilerDir() {
+export async function getCompilersDir() {
   const cache = await getCacheDir();
   const compilersCache = path.join(cache, "compilers");
   await fs.ensureDir(compilersCache);

--- a/packages/buidler-core/src/internal/util/global-dir.ts
+++ b/packages/buidler-core/src/internal/util/global-dir.ts
@@ -67,3 +67,10 @@ export async function writeAnalyticsId(clientId: string) {
   );
   log(`Stored clientId ${clientId}`);
 }
+
+export async function getCompilerDir() {
+  const cache = await getCacheDir();
+  const compilersCache = path.join(cache, "compilers");
+  await fs.ensureDir(compilersCache);
+  return compilersCache;
+}

--- a/packages/buidler-core/src/internal/util/global-dir.ts
+++ b/packages/buidler-core/src/internal/util/global-dir.ts
@@ -1,0 +1,54 @@
+import fsExtra from "fs-extra";
+
+interface DirEntry {
+  path: string;
+  live: boolean;
+}
+
+interface DirCache {
+  [name: string]: DirEntry;
+}
+
+let paths: DirCache;
+
+async function generatePaths() {
+  const { default: envPaths } = await import("env-paths");
+  const generatedPaths = envPaths("buidler");
+  paths = {
+    config: {
+      path: generatedPaths.config,
+      live: false,
+    },
+    data: {
+      path: generatedPaths.data,
+      live: false,
+    },
+    cache: {
+      path: generatedPaths.cache,
+      live: false,
+    },
+  };
+  return paths;
+}
+
+async function getDir(name: string): Promise<string> {
+  const pathsCache = paths === undefined ? await generatePaths() : paths;
+  const dir = pathsCache[name];
+  if (!dir.live) {
+    await fsExtra.ensureDir(dir.path);
+    dir.live = true;
+  }
+  return dir.path;
+}
+
+export function getConfigDir(): Promise<string> {
+  return getDir("config");
+}
+
+export function getDataDir(): Promise<string> {
+  return getDir("data");
+}
+
+export function getCacheDir(): Promise<string> {
+  return getDir("cache");
+}


### PR DESCRIPTION
This adds a global directory module that is responsible for reading and writing global (i.e. per user) settings, data and cache for internal features.