### PR TITLE
Buidler EVM HD accounts support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,8 +26,6 @@ jobs:
             node_modules
             packages/*/node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/*/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-10-
       - name: Install node-gyp-cache
         run: |
           npm install -g node-gyp-cache
@@ -54,8 +52,6 @@ jobs:
             node_modules
             packages/*/node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/*/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-10-
       - name: Install node-gyp-cache
         run: |
           npm install -g node-gyp-cache
@@ -96,8 +92,6 @@ jobs:
             node_modules
             packages/*/node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/*/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-10-
       - name: Install node-gyp-cache
         run: |
           npm install -g node-gyp-cache
@@ -130,8 +124,6 @@ jobs:
             node_modules
             packages/*/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/*/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-
       - name: Install node-gyp-cache
         run: |
           npm install -g node-gyp-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,125 +5,124 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/generator": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.1.tgz",
-      "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1",
+        "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-      "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-      "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-      "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-      "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-      "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-      "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/generator": "^7.10.1",
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
     },
     "@babel/types": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
-      "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -878,9 +877,9 @@
       }
     },
     "@lerna/publish": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.22.0.tgz",
-      "integrity": "sha512-8LBeTLBN8NIrCrLGykRu+PKrfrCC16sGCVY0/bzq9TDioR7g6+cY0ZAw653Qt/0Kr7rg3J7XxVNdzj3fvevlwA==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.22.1.tgz",
+      "integrity": "sha512-PG9CM9HUYDreb1FbJwFg90TCBQooGjj+n/pb3gw/eH5mEDq0p8wKdLFe0qkiqUkm/Ub5C8DbVFertIo0Vd0zcw==",
       "dev": true,
       "requires": {
         "@evocateur/libnpmaccess": "^3.1.2",
@@ -904,7 +903,7 @@
         "@lerna/run-lifecycle": "3.16.2",
         "@lerna/run-topologically": "3.18.5",
         "@lerna/validation-error": "3.13.0",
-        "@lerna/version": "3.22.0",
+        "@lerna/version": "3.22.1",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^8.1.0",
         "npm-package-arg": "^6.1.0",
@@ -1051,9 +1050,9 @@
       }
     },
     "@lerna/version": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.22.0.tgz",
-      "integrity": "sha512-6uhL6RL7/FeW6u1INEgyKjd5dwO8+IsbLfkfC682QuoVLS7VG6OOB+JmTpCvnuyYWI6fqGh1bRk9ww8kPsj+EA==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.22.1.tgz",
+      "integrity": "sha512-PSGt/K1hVqreAFoi3zjD0VEDupQ2WZVlVIwesrE5GbrL2BjXowjCsTDPqblahDUPy0hp6h7E2kG855yLTp62+g==",
       "dev": true,
       "requires": {
         "@lerna/check-working-tree": "3.16.5",
@@ -1111,48 +1110,36 @@
       "dev": true
     },
     "@octokit/auth-token": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.1.tgz",
-      "integrity": "sha512-NB81O5h39KfHYGtgfWr2booRxp2bWOJoqbWwbyUg2hw6h35ArWYlAST5B3XwAkbdcx13yt84hFXyFP5X0QToWA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^4.0.1"
+        "@octokit/types": "^5.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.2.tgz",
-      "integrity": "sha512-xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^4.0.1",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^5.0.0"
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
         "universal-user-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-          "dev": true,
-          "requires": {
-            "os-name": "^3.1.0"
-          }
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
         }
       }
     },
@@ -1210,55 +1197,43 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.4.tgz",
-      "integrity": "sha512-vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^4.0.1",
+        "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "node-fetch": "^2.3.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "@octokit/request-error": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
-          "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+          "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
           "dev": true,
           "requires": {
-            "@octokit/types": "^4.0.1",
+            "@octokit/types": "^5.0.1",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
           }
         },
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
         "universal-user-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-          "dev": true,
-          "requires": {
-            "os-name": "^3.1.0"
-          }
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
         }
       }
     },
@@ -1285,9 +1260,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.43.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
-      "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+      "version": "16.43.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+      "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.0",
@@ -1309,27 +1284,20 @@
       }
     },
     "@octokit/types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.2.tgz",
-      "integrity": "sha512-+4X6qfhT/fk/5FD66395NrFLxCzD6FsGlpPwfwvnukdyfYbhiZB/FJltiT1XM5Q63rGGBSf9FPaNV3WpNHm54A==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
       }
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -1353,9 +1321,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
-      "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA==",
+      "version": "10.17.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+      "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1420,9 +1388,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1641,9 +1609,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
     "balanced-match": {
@@ -1723,9 +1691,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "bluebird": {
@@ -2212,23 +2180,29 @@
       "dev": true
     },
     "compare-func": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "dot-prop": "^5.1.0"
       },
       "dependencies": {
         "dot-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "^2.0.0"
           }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
         }
       }
     },
@@ -2273,12 +2247,12 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-      "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+      "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "q": "^1.5.1"
       }
     },
@@ -2304,11 +2278,12 @@
       },
       "dependencies": {
         "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
           "dev": true,
           "requires": {
+            "inherits": "^2.0.4",
             "readable-stream": "2 || 3"
           }
         }
@@ -2321,12 +2296,12 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.6",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
@@ -2339,11 +2314,12 @@
       },
       "dependencies": {
         "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
           "dev": true,
           "requires": {
+            "inherits": "^2.0.4",
             "readable-stream": "2 || 3"
           }
         }
@@ -2375,11 +2351,12 @@
       },
       "dependencies": {
         "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
           "dev": true,
           "requires": {
+            "inherits": "^2.0.4",
             "readable-stream": "2 || 3"
           }
         }
@@ -2853,18 +2830,18 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
     "duplexify": {
@@ -2896,12 +2873,12 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
       }
     },
     "end-of-stream": {
@@ -2920,9 +2897,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
-      "integrity": "sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+      "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
       "dev": true
     },
     "err-code": {
@@ -2941,22 +2918,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -3120,6 +3097,17 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extglob": {
@@ -3194,9 +3182,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
@@ -3483,26 +3471,25 @@
       "dev": true
     },
     "ganache-cli": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.9.1.tgz",
-      "integrity": "sha512-VPBumkNUZzXDRQwVOby5YyQpd5t1clkr06xMgB28lZdEIn5ht1GMwUskOTFOAxdkQ4J12IWP0gdeacVRGowqbA==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.10.2.tgz",
+      "integrity": "sha512-wCuQjy7k040J8hii1KQ/dYHv8qjdHIcP3fw331AWPqQjeqNquf5HVVQNJOYXINTDofMDkCMQv3ru4ze/A+WyPQ==",
       "dev": true,
       "requires": {
         "ethereumjs-util": "6.1.0",
+        "scrypt": "6.0.3",
         "source-map-support": "0.5.12",
         "yargs": "13.2.4"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -3510,8 +3497,7 @@
         },
         "bindings": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
@@ -3519,29 +3505,25 @@
         },
         "bip66": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-          "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "bundled": true,
           "dev": true
         },
         "brorand": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+          "bundled": true,
           "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-          "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
@@ -3554,26 +3536,22 @@
         },
         "buffer-from": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "bundled": true,
           "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+          "bundled": true,
           "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "bundled": true,
           "dev": true
         },
         "cipher-base": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -3582,8 +3560,7 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^3.1.0",
@@ -3593,8 +3570,7 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -3602,14 +3578,12 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "bundled": true,
           "dev": true
         },
         "create-hash": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
@@ -3621,8 +3595,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
@@ -3635,8 +3608,7 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -3648,14 +3620,12 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "drbg.js": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-          "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
@@ -3664,9 +3634,8 @@
           }
         },
         "elliptic": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-          "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+          "version": "6.5.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
@@ -3680,14 +3649,12 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "bundled": true,
           "dev": true
         },
         "end-of-stream": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "version": "1.4.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -3695,8 +3662,7 @@
         },
         "ethereumjs-util": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
@@ -3710,8 +3676,7 @@
         },
         "ethjs-util": {
           "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
@@ -3720,8 +3685,7 @@
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
@@ -3730,8 +3694,7 @@
         },
         "execa": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
@@ -3745,14 +3708,12 @@
         },
         "file-uri-to-path": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+          "bundled": true,
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -3760,33 +3721,30 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "hash-base": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
           }
         },
         "hash.js": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3795,8 +3753,7 @@
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
@@ -3806,44 +3763,37 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "bundled": true,
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "bundled": true,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "bundled": true,
           "dev": true
         },
         "is-hex-prefixed": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "keccak": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bindings": "^1.2.1",
@@ -3854,8 +3804,7 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -3863,8 +3812,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -3873,8 +3821,7 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -3882,8 +3829,7 @@
         },
         "md5.js": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -3893,8 +3839,7 @@
         },
         "mem": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -3904,38 +3849,32 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "bundled": true,
           "dev": true
         },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+          "bundled": true,
           "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+          "bundled": true,
           "dev": true
         },
         "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "version": "2.14.1",
+          "bundled": true,
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+          "bundled": true,
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -3943,8 +3882,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -3952,8 +3890,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -3963,26 +3900,22 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+          "bundled": true,
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "version": "2.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3990,8 +3923,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -3999,48 +3931,51 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
         },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "bundled": true,
           "dev": true
         },
         "ripemd160": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -4048,25 +3983,21 @@
           }
         },
         "rlp": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
-          "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+          "version": "2.2.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.1",
-            "safe-buffer": "^5.1.1"
+            "bn.js": "^4.11.1"
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "bundled": true,
           "dev": true
         },
         "secp256k1": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+          "version": "3.8.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -4074,27 +4005,24 @@
             "bn.js": "^4.11.8",
             "create-hash": "^1.2.0",
             "drbg.js": "^1.0.1",
-            "elliptic": "^6.4.1",
+            "elliptic": "^6.5.2",
             "nan": "^2.14.0",
             "safe-buffer": "^5.1.2"
           }
         },
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "5.7.1",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -4103,8 +4031,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -4112,26 +4039,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "bundled": true,
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.12",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -4140,8 +4063,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -4149,10 +4071,17 @@
             "strip-ansi": "^5.1.0"
           }
         },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -4160,23 +4089,25 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-          "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
         },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -4184,14 +4115,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -4201,20 +4130,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "13.2.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -4231,9 +4157,8 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "version": "13.1.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -4703,9 +4628,9 @@
       }
     },
     "git-up": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+      "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -4713,9 +4638,9 @@
       }
     },
     "git-url-parse": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.2.0.tgz",
+      "integrity": "sha512-KPoHZg8v+plarZvto4ruIzzJLFQoRx+sUs5DQSr07By9IBKguVd+e6jwrFR6/TP6xrCJlNV1tPqLO1aREc7O2g==",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -4821,12 +4746,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -4969,12 +4894,12 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "iferr": {
@@ -5164,9 +5089,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "inversify": {
@@ -5223,9 +5148,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-ci": {
@@ -5324,6 +5249,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5366,18 +5297,18 @@
       }
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-ssh": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
@@ -5531,12 +5462,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "make-dir": {
@@ -5621,6 +5552,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -5673,9 +5610,9 @@
       "dev": true
     },
     "lerna": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.0.tgz",
-      "integrity": "sha512-xWlHdAStcqK/IjKvjsSMHPZjPkBV1lS60PmsIeObU8rLljTepc4Sg/hncw4HWfQxPIewHAUTqhrxPIsqf9L2Eg==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
+      "integrity": "sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==",
       "dev": true,
       "requires": {
         "@lerna/add": "3.21.0",
@@ -5691,9 +5628,9 @@
         "@lerna/init": "3.21.0",
         "@lerna/link": "3.21.0",
         "@lerna/list": "3.21.0",
-        "@lerna/publish": "3.22.0",
+        "@lerna/publish": "3.22.1",
         "@lerna/run": "3.21.0",
-        "@lerna/version": "3.22.0",
+        "@lerna/version": "3.22.1",
         "import-local": "^2.0.0",
         "npmlog": "^4.1.2"
       }
@@ -5728,9 +5665,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -5829,9 +5766,9 @@
       }
     },
     "macos-release": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "dev": true
     },
     "make-dir": {
@@ -5898,18 +5835,16 @@
       }
     },
     "meow": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+      "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
-        "arrify": "^2.0.1",
-        "camelcase": "^6.0.0",
         "camelcase-keys": "^6.2.2",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
+        "minimist-options": "4.1.0",
         "normalize-package-data": "^2.5.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
@@ -5918,18 +5853,6 @@
         "yargs-parser": "^18.1.3"
       },
       "dependencies": {
-        "arrify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-          "dev": true
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5959,14 +5882,14 @@
           }
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -6029,14 +5952,6 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
           }
         }
       }
@@ -6059,9 +5974,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -6107,9 +6022,9 @@
       "dev": true
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimatch": {
@@ -6297,6 +6212,18 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -6422,6 +6349,13 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6442,9 +6376,9 @@
       }
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -6478,9 +6412,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-fetch-npm": {
@@ -6844,9 +6778,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -6865,15 +6799,37 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -7066,9 +7022,9 @@
       }
     },
     "parse-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+      "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -7076,9 +7032,9 @@
       }
     },
     "parse-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -7238,9 +7194,9 @@
       "dev": true
     },
     "protocols": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
       "dev": true
     },
     "protoduck": {
@@ -7340,14 +7296,13 @@
       }
     },
     "read-package-json": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-      "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "json-parse-better-errors": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.0",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
       }
@@ -7683,9 +7638,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -7711,6 +7666,16 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "scrypt": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
+      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.0.8"
+      }
     },
     "semver": {
       "version": "6.3.0",
@@ -8063,9 +8028,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "split": {
@@ -8183,28 +8148,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -8364,9 +8307,9 @@
       "dev": true
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
@@ -8486,9 +8429,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
-      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -8624,14 +8567,11 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-      "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
+      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "optional": true
     },
     "uid-number": {
       "version": "0.0.6",
@@ -8737,9 +8677,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -8859,9 +8799,9 @@
       }
     },
     "windows-release": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
-      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+      "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3484,12 +3484,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -3497,7 +3499,8 @@
         },
         "bindings": {
           "version": "1.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
           "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
@@ -3505,7 +3508,8 @@
         },
         "bip66": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+          "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -3513,17 +3517,20 @@
         },
         "bn.js": {
           "version": "4.11.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         },
         "brorand": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
           "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+          "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
@@ -3536,22 +3543,26 @@
         },
         "buffer-from": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
           "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
           "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cipher-base": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -3560,7 +3571,8 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
             "string-width": "^3.1.0",
@@ -3570,7 +3582,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -3578,12 +3591,14 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "create-hash": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
@@ -3595,7 +3610,8 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
@@ -3608,7 +3624,8 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -3620,12 +3637,14 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "drbg.js": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+          "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
           "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
@@ -3635,7 +3654,8 @@
         },
         "elliptic": {
           "version": "6.5.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
@@ -3649,12 +3669,14 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -3662,7 +3684,8 @@
         },
         "ethereumjs-util": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
@@ -3676,7 +3699,8 @@
         },
         "ethjs-util": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
@@ -3685,7 +3709,8 @@
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
@@ -3694,7 +3719,8 @@
         },
         "execa": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
@@ -3708,12 +3734,14 @@
         },
         "file-uri-to-path": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -3721,12 +3749,14 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -3734,7 +3764,8 @@
         },
         "hash-base": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.4",
@@ -3744,7 +3775,8 @@
         },
         "hash.js": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3753,7 +3785,8 @@
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
@@ -3763,37 +3796,44 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-hex-prefixed": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "keccak": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
           "dev": true,
           "requires": {
             "bindings": "^1.2.1",
@@ -3804,7 +3844,8 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -3812,7 +3853,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -3821,7 +3863,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -3829,7 +3872,8 @@
         },
         "md5.js": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -3839,7 +3883,8 @@
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -3849,32 +3894,38 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
           "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
           "dev": true
         },
         "nan": {
           "version": "2.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -3882,7 +3933,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -3890,7 +3942,8 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -3900,22 +3953,26 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3923,7 +3980,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -3931,22 +3989,26 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -3955,7 +4017,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3965,17 +4028,20 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "ripemd160": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -3984,7 +4050,8 @@
         },
         "rlp": {
           "version": "2.2.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.1"
@@ -3992,12 +4059,14 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "secp256k1": {
           "version": "3.8.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
           "dev": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -4012,17 +4081,20 @@
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -4031,7 +4103,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -4039,22 +4112,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -4063,7 +4140,8 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -4073,7 +4151,8 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -4081,7 +4160,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -4089,12 +4169,14 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+          "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
@@ -4102,12 +4184,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -4115,12 +4199,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -4130,17 +4216,20 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
           "version": "13.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -4158,7 +4247,8 @@
         },
         "yargs-parser": {
           "version": "13.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/packages/buidler-core/package-lock.json
+++ b/packages/buidler-core/package-lock.json
@@ -1,61 +1,61 @@
 {
 	"name": "@nomiclabs/buidler",
-	"version": "1.99.0",
+	"version": "1.4.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@ethersproject/abi": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.3.tgz",
-			"integrity": "sha512-fSSs4sgaf5R1955QSpYXW2YkrYBgyOSyENyyMEyJwxTsKJKQPaReTQXafyeRc8ZLi3/2uzeqakH09r0S1hlFng==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+			"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
-				"@ethersproject/hash": "^5.0.3",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/abstract-provider": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.3.tgz",
-			"integrity": "sha512-0dVq0IcJd6/qTjT+bhJw6ooJuCJDNWTL8SKRFBnqr4OgDW7p1AXX2l7lQd7vX9RpbnDzurSM+fTBKCVWjdm3Vw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+			"integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/networks": "^5.0.3",
 				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.3",
-				"@ethersproject/web": "^5.0.4"
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6"
 			}
 		},
 		"@ethersproject/abstract-signer": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.3.tgz",
-			"integrity": "sha512-uhHXqmcJcxWYD+hcvsp/pu8iSgqQzgSXHJtFGUYBBkWGpCp5kF95nSRlFnyVu9uAqZxwynBtOrPZBd1ACGBQBQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz",
+			"integrity": "sha512-nwSZKtCTKhJADlW42c+a//lWxQlnA7jYLTnabJ3YCfgGU6ic9jnT9nRDlAyT1U3kCMeqPL7fTcKbdWCVrM0xsw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
-			"integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+			"integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
@@ -83,9 +83,9 @@
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
-			"integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+			"integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/bytes": "^5.0.4",
@@ -103,90 +103,82 @@
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
-			"integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+			"integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.6"
+				"@ethersproject/bignumber": "^5.0.7"
 			}
 		},
 		"@ethersproject/contracts": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.3.tgz",
-			"integrity": "sha512-60H7UJx6qsp3JP5q3jFjzVNGUygRfz+XzfRwx/VeCKjHBUpFxPEIO2S30SMjYKPqw6JsgxbOjxFFZgOfQiNesw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+			"integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.3",
-				"@ethersproject/abstract-provider": "^5.0.3",
-				"@ethersproject/abstract-signer": "^5.0.3",
-				"@ethersproject/address": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
+				"@ethersproject/constants": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.3.tgz",
-			"integrity": "sha512-KSnJyL0G9lxbOK0UPrUcaYTc/RidrX8c+kn7xnEpTmSGxqlndw4BzvQcRgYt31bOIwuFtwlWvOo6AN2tJgdQtA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+			"integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/strings": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/hdnode": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.3.tgz",
-			"integrity": "sha512-+VQj0gRxfwRPHH7J32fTU8Ouk9CBFBIqvl937I0swO5PghNXBy/1U+o8gZMOitLIId1P3Wr6QcaDHkusi7OQXw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+			"integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.3",
+				"@ethersproject/abstract-signer": "^5.0.4",
 				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/pbkdf2": "^5.0.3",
 				"@ethersproject/properties": "^5.0.3",
 				"@ethersproject/sha2": "^5.0.3",
 				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/strings": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.3",
-				"@ethersproject/wordlists": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/json-wallets": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.5.tgz",
-			"integrity": "sha512-g2kdOY5l+TDE5rIE9BLK+S7fiQMIIsM+KTxxVu4H2COROFwCSMeEb5uMCkccXc3iDX1sOBF653h8kTXCaFY03Q==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+			"integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.3",
-				"@ethersproject/address": "^5.0.3",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.3",
+				"@ethersproject/hdnode": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/pbkdf2": "^5.0.3",
 				"@ethersproject/properties": "^5.0.3",
 				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
 				"aes-js": "3.0.0",
 				"scrypt-js": "3.0.1"
-			},
-			"dependencies": {
-				"scrypt-js": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/keccak256": {
@@ -242,26 +234,29 @@
 			}
 		},
 		"@ethersproject/providers": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.6.tgz",
-			"integrity": "sha512-hY1mFtZvbzqckPxwyR989ujr+cEzsQQdx+DDkNI6E5wF8GiTETAUMl3SmxPzcPebSD++ZI4vKtYdcabsJF0yaA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.9.tgz",
+			"integrity": "sha512-UtGrlJxekFNV7lriPOxQbnYminyiwTgjHMPX83pG7N/W/t+PekQK8V9rdlvMr2bRyGgafHml0ZZMaTV4FxiBYg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.3",
-				"@ethersproject/abstract-signer": "^5.0.3",
-				"@ethersproject/address": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
-				"@ethersproject/hash": "^5.0.3",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/networks": "^5.0.3",
 				"@ethersproject/properties": "^5.0.3",
 				"@ethersproject/random": "^5.0.3",
 				"@ethersproject/rlp": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.3",
-				"@ethersproject/web": "^5.0.4",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6",
+				"bech32": "1.1.4",
 				"ws": "7.2.3"
 			},
 			"dependencies": {
@@ -326,59 +321,42 @@
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
 				"elliptic": "6.5.3"
-			},
-			"dependencies": {
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
 			}
 		},
 		"@ethersproject/solidity": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.3.tgz",
-			"integrity": "sha512-a6ni4OIj1e+JrvDiuLVqygYmAh53Ljk5iErkjzPgFBY8dz9xQfDxhpASjOZY0lzCf+N125yeK9N7Vm3HI7OLzQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+			"integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/sha2": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
-			"integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+			"integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
+				"@ethersproject/constants": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/transactions": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.3.tgz",
-			"integrity": "sha512-cqsAAFUQV6iWqfgLL7KCPNfd3pXJPDdYtE6QuBEAIpc7cgbJ7TIDCF/dN+1otfERHJIbjGSNrhh4axKRnSFswg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+			"integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
+				"@ethersproject/constants": "^5.0.4",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
@@ -387,79 +365,79 @@
 			}
 		},
 		"@ethersproject/units": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.3.tgz",
-			"integrity": "sha512-PyQ066mFczUy0CSJJrc/VK+1ATh1bsI8EkzAVT7GQ0IPJlNDcXnGNtlH5EQGHzuXA3GDQNV23poB0Cy/WDb2zg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+			"integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.6",
-				"@ethersproject/constants": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/constants": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/wallet": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.3.tgz",
-			"integrity": "sha512-Nouwfh1HlpxaeRRi4+UDVsfrd9fitBHUvw35bTMSwJLFsZTb9xPd0LGWdX4llwVlAP/CXb6qDc0zwYy6uLp7Lw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+			"integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.3",
-				"@ethersproject/abstract-signer": "^5.0.3",
-				"@ethersproject/address": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.3",
-				"@ethersproject/hdnode": "^5.0.3",
-				"@ethersproject/json-wallets": "^5.0.5",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
 				"@ethersproject/random": "^5.0.3",
 				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.3",
-				"@ethersproject/wordlists": "^5.0.3"
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/web": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.4.tgz",
-			"integrity": "sha512-1ZSbFGJo61huhDW5M8hqjP8zoCK6zZlu3jYAJrFKVNgBjEm1UYMY5fsoogYHWkLgCgBIf+M6yKzYdtAs4tol4Q==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.7.tgz",
+			"integrity": "sha512-BM8FdGrzdcULYaOIyMXDKvxv+qOwGne8FKpPxUrifZIWAWPrq/y+oBOZlzadIKsP3wvYbAcMN2CgOLO1E3yIfw==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/base64": "^5.0.3",
 				"@ethersproject/bytes": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/wordlists": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.3.tgz",
-			"integrity": "sha512-Asro9CcBJqxtMnmKrsg79GMmH02p0JmdOwhEdRHRbr51UMRqAfV5RjiidYk21aMsTflv4VY3HgFs6q6FtRJs+w==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+			"integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.3",
+				"@ethersproject/hash": "^5.0.4",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3"
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@nomiclabs/ethereumjs-vm": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.1.1.tgz",
-			"integrity": "sha512-zQJBssmK7PyHonzng3VuFUvXQ6uugQeGAA7XvFVoMmEcY9KdWCqEQYh+XQ1jLZ8H9EISYB1BHF9HY6aFnflgcw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+			"integrity": "sha512-+XwqoO941bILTO4KDLIUJ37U42ySxw6it7jyoi0tKv0/VUcOrWKF1TCQWMv6dBDRlxpPQd273n9o5SVlYYLRWQ==",
 			"requires": {
 				"async": "^2.1.2",
 				"async-eventemitter": "^0.2.2",
 				"core-js-pure": "^3.0.1",
 				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.1",
-				"ethereumjs-blockchain": "^4.0.2",
-				"ethereumjs-common": "^1.3.2",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "~6.1.0",
+				"ethereumjs-block": "^2.2.2",
+				"ethereumjs-blockchain": "^4.0.3",
+				"ethereumjs-common": "^1.5.0",
+				"ethereumjs-tx": "^2.1.2",
+				"ethereumjs-util": "^6.2.0",
 				"fake-merkle-patricia-tree": "^1.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"merkle-patricia-tree": "^2.3.2",
@@ -468,35 +446,10 @@
 				"util.promisify": "^1.0.0"
 			},
 			"dependencies": {
-				"ethereumjs-util": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-					"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "0.1.6",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
 				},
 				"merkle-patricia-tree": {
 					"version": "2.3.2",
@@ -519,17 +472,17 @@
 							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						}
 					}
@@ -572,89 +525,77 @@
 				}
 			}
 		},
-		"@sentry/apm": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.18.1.tgz",
-			"integrity": "sha512-UcfEgECz7/X9l/3OoUwVCIpSb0RqyUAd/yRCRGF5Lh7kaqaYi1HbatkYUTDEnhOhaEXYtXUvRXPmRD1zMukqsw==",
-			"requires": {
-				"@sentry/browser": "5.18.1",
-				"@sentry/hub": "5.18.1",
-				"@sentry/minimal": "5.18.1",
-				"@sentry/types": "5.18.1",
-				"@sentry/utils": "5.18.1",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/browser": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.18.1.tgz",
-			"integrity": "sha512-U1w0d5kRMsfzMYwWn4+awDKfBEI5lxhHa0bMChSpj5z/dWiz/e0mikZ9gCoF+ZNqkXJ92l/3r9gRz+SIsn5ZoA==",
-			"requires": {
-				"@sentry/core": "5.18.1",
-				"@sentry/types": "5.18.1",
-				"@sentry/utils": "5.18.1",
-				"tslib": "^1.9.3"
-			}
-		},
 		"@sentry/core": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.18.1.tgz",
-			"integrity": "sha512-nC2aK6gwVIBVysmtdFHxYJyuChIHtkv7TnvmwgA5788L/HWo7E3R+Rd8Tf2npvp/aP+kmNITNbc5CIIqwGPaqQ==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.24.2.tgz",
+			"integrity": "sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==",
 			"requires": {
-				"@sentry/hub": "5.18.1",
-				"@sentry/minimal": "5.18.1",
-				"@sentry/types": "5.18.1",
-				"@sentry/utils": "5.18.1",
+				"@sentry/hub": "5.24.2",
+				"@sentry/minimal": "5.24.2",
+				"@sentry/types": "5.24.2",
+				"@sentry/utils": "5.24.2",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/hub": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.18.1.tgz",
-			"integrity": "sha512-dFnaj1fQRT74EhoF8MXJ23K3svt11zEF6CS3cdMrkSzfRbAHjyza7KT2AJHUeF6gtH2BZzqsSw+FnfAke0HGIg==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.24.2.tgz",
+			"integrity": "sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==",
 			"requires": {
-				"@sentry/types": "5.18.1",
-				"@sentry/utils": "5.18.1",
+				"@sentry/types": "5.24.2",
+				"@sentry/utils": "5.24.2",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/minimal": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.18.1.tgz",
-			"integrity": "sha512-St2bjcZ5FFiH+bYkWoEPlEb0w38YSvftnjJTvZyk05SCdsF7HkGfoBeFmztwBf1VLQPYt3ojny14L6KDAvOTpw==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.24.2.tgz",
+			"integrity": "sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==",
 			"requires": {
-				"@sentry/hub": "5.18.1",
-				"@sentry/types": "5.18.1",
+				"@sentry/hub": "5.24.2",
+				"@sentry/types": "5.24.2",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/node": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.18.1.tgz",
-			"integrity": "sha512-faIKb/1i0MYKkWL6crtnIuw1WTwvnQZFaOX4zjZeqZ+z7Q72YfnLWMTaJMe8Q38P/obWf75YRffIJrezkT9lXw==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.24.2.tgz",
+			"integrity": "sha512-ddfU2tLTvhnY+NqzLIA/gxMt/uxq7R204Nb2J5qqE0WAgbh0dtylNAzfKZTizLdbZfRnpeISmd+CBILh3tavog==",
 			"requires": {
-				"@sentry/apm": "5.18.1",
-				"@sentry/core": "5.18.1",
-				"@sentry/hub": "5.18.1",
-				"@sentry/types": "5.18.1",
-				"@sentry/utils": "5.18.1",
-				"cookie": "^0.3.1",
-				"https-proxy-agent": "^4.0.0",
+				"@sentry/core": "5.24.2",
+				"@sentry/hub": "5.24.2",
+				"@sentry/tracing": "5.24.2",
+				"@sentry/types": "5.24.2",
+				"@sentry/utils": "5.24.2",
+				"cookie": "^0.4.1",
+				"https-proxy-agent": "^5.0.0",
 				"lru_map": "^0.3.3",
 				"tslib": "^1.9.3"
 			}
 		},
+		"@sentry/tracing": {
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.24.2.tgz",
+			"integrity": "sha512-1uDgvGGVF8lb3hRXbhNnns+8DBUKjhRKOFR5Z3RExjrDFYTDbHmoNtV73Q12Ra+Iht9HTZnIBOqYD3oSZIbJ0w==",
+			"requires": {
+				"@sentry/hub": "5.24.2",
+				"@sentry/minimal": "5.24.2",
+				"@sentry/types": "5.24.2",
+				"@sentry/utils": "5.24.2",
+				"tslib": "^1.9.3"
+			}
+		},
 		"@sentry/types": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.18.1.tgz",
-			"integrity": "sha512-y5YTkRFC4Y7r4GHrvin6aZLBpQIGdMZRq78f/s7IIEZrmWYbVKsK4dyJht6pOsUdEaxeYpsu3okIA0bqmthSJA=="
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.24.2.tgz",
+			"integrity": "sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ=="
 		},
 		"@sentry/utils": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.18.1.tgz",
-			"integrity": "sha512-P4lt6NauCBWASaP6R5kfOmc24imbD32G5FeWqK7vHftIphOJ0X7OZfh93DJPs3e5RIvW3YCywUsa7MpTH5/ClA==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.24.2.tgz",
+			"integrity": "sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==",
 			"requires": {
-				"@sentry/types": "5.18.1",
+				"@sentry/types": "5.24.2",
 				"tslib": "^1.9.3"
 			}
 		},
@@ -664,9 +605,9 @@
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
 		"@sinonjs/commons": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-			"integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -692,9 +633,9 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-			"integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+			"integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.6.0",
@@ -722,9 +663,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/chai-as-promised": {
@@ -768,12 +709,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/find-up": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@types/find-up/-/find-up-2.1.1.tgz",
@@ -790,12 +725,11 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -810,9 +744,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.150",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-			"integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
+			"version": "4.14.161",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+			"integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
 			"dev": true
 		},
 		"@types/lru-cache": {
@@ -827,9 +761,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -842,17 +776,17 @@
 			}
 		},
 		"@types/pbkdf2": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.0.0.tgz",
-			"integrity": "sha512-6J6MHaAlBJC/eVMy9jOwj9oHaprfutukfW/Dyt0NEnpQ/6HN6YQrpvLwzWdWDeWZIdenjGHlbYDzyEODO5Z+2Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/qs": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==",
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+			"integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -873,9 +807,9 @@
 			}
 		},
 		"@types/semver": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
-			"integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.2.tgz",
+			"integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==",
 			"dev": true
 		},
 		"@types/sinon": {
@@ -891,9 +825,9 @@
 			"dev": true
 		},
 		"@types/ws": {
-			"version": "7.2.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
-			"integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
+			"version": "7.2.6",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
+			"integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -929,14 +863,17 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+			"requires": {
+				"debug": "4"
+			}
 		},
 		"ansi-colors": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
 		},
 		"ansi-escapes": {
 			"version": "4.3.1",
@@ -1037,31 +974,21 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+			"dev": true
+		},
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -1116,9 +1043,9 @@
 			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -1158,15 +1085,6 @@
 				"evp_bytestokey": "^1.0.3",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"browserify-sha3": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-			"integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-			"requires": {
-				"js-sha3": "^0.6.1",
-				"safe-buffer": "^5.1.1"
 			}
 		},
 		"bs58": {
@@ -1320,9 +1238,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-			"integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
@@ -1419,12 +1337,9 @@
 			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
 		},
 		"commander": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-			"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-			"requires": {
-				"graceful-readlink": ">= 1.0.0"
-			}
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1456,9 +1371,9 @@
 			}
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
 		},
 		"core-js-pure": {
 			"version": "3.6.5",
@@ -1502,11 +1417,11 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -1706,25 +1621,15 @@
 				"pify": "^3.0.0"
 			}
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -1761,9 +1666,12 @@
 					}
 				},
 				"level-codec": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-					"integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+					"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+					"requires": {
+						"buffer": "^5.6.0"
+					}
 				},
 				"level-errors": {
 					"version": "2.0.1",
@@ -1789,11 +1697,11 @@
 			}
 		},
 		"enquirer": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz",
-			"integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
 			"requires": {
-				"ansi-colors": "^3.2.1"
+				"ansi-colors": "^4.1.1"
 			}
 		},
 		"env-paths": {
@@ -1810,21 +1718,21 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			},
 			"dependencies": {
 				"object-keys": {
@@ -1877,80 +1785,78 @@
 					},
 					"dependencies": {
 						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+							"version": "4.5.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+							"integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
 							"requires": {
 								"bn.js": "^4.8.0",
 								"create-hash": "^1.1.2",
-								"keccakjs": "^0.2.0",
-								"rlp": "^2.0.0",
-								"secp256k1": "^3.0.1"
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
+								"rlp": "^2.0.0"
 							}
 						}
 					}
 				},
 				"ethereumjs-util": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-					"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 					"requires": {
 						"bn.js": "^4.11.0",
 						"create-hash": "^1.1.2",
+						"elliptic": "^6.5.2",
+						"ethereum-cryptography": "^0.1.3",
 						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
 						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
+						"safe-buffer": "^5.1.1"
 					}
 				}
 			}
 		},
 		"ethashjs": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
-			"integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+			"integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
 			"requires": {
-				"async": "^1.4.2",
-				"buffer-xor": "^1.0.3",
-				"ethereumjs-util": "^4.0.1",
+				"async": "^2.1.2",
+				"buffer-xor": "^2.0.1",
+				"ethereumjs-util": "^7.0.2",
 				"miller-rabin": "^4.0.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"bn.js": {
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+				},
+				"buffer-xor": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+					"integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+					"requires": {
+						"safe-buffer": "^5.1.1"
+					}
 				},
 				"ethereumjs-util": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.5.tgz",
+					"integrity": "sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==",
 					"requires": {
-						"bn.js": "^4.8.0",
+						"@types/bn.js": "^4.11.3",
+						"bn.js": "^5.1.2",
 						"create-hash": "^1.1.2",
-						"keccakjs": "^0.2.0",
-						"rlp": "^2.0.0",
-						"secp256k1": "^3.0.1"
+						"ethereum-cryptography": "^0.1.3",
+						"ethjs-util": "0.1.6",
+						"rlp": "^2.2.4"
 					}
 				}
 			}
 		},
 		"ethereum-cryptography": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.2.tgz",
-			"integrity": "sha512-VsGgeYGalsAjaDqvGYMDZnal1dMWVfsnRtUdMfqBjRK1p4dpJM4837DG7OKdgrP7hcAtz2jWfMC+bWj9O2xokQ==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
 			"requires": {
 				"@types/pbkdf2": "^3.0.0",
 				"@types/secp256k1": "^4.0.1",
@@ -1967,27 +1873,6 @@
 				"scrypt-js": "^3.0.0",
 				"secp256k1": "^4.0.1",
 				"setimmediate": "^1.0.5"
-			},
-			"dependencies": {
-				"keccak": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.0.tgz",
-					"integrity": "sha512-/4h4FIfFEpTEuySXi/nVFM5rqSKPnnhI7cL4K3MFSwoI3VyM7AhPSq3SsysARtnEBEeIKMBUWD8cTh9nHE8AkA==",
-					"requires": {
-						"node-addon-api": "^2.0.0",
-						"node-gyp-build": "^4.2.0"
-					}
-				},
-				"secp256k1": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
-					"integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
-					"requires": {
-						"elliptic": "^6.5.2",
-						"node-addon-api": "^2.0.0",
-						"node-gyp-build": "^4.2.0"
-					}
-				}
 			}
 		},
 		"ethereumjs-abi": {
@@ -2022,34 +1907,23 @@
 			},
 			"dependencies": {
 				"ethereumjs-util": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-					"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 					"requires": {
 						"bn.js": "^4.11.0",
 						"create-hash": "^1.1.2",
+						"elliptic": "^6.5.2",
+						"ethereum-cryptography": "^0.1.3",
 						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
 						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
 				},
 				"merkle-patricia-tree": {
 					"version": "2.3.2",
@@ -2112,53 +1986,26 @@
 			}
 		},
 		"ethereumjs-blockchain": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
-			"integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+			"integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
 			"requires": {
 				"async": "^2.6.1",
 				"ethashjs": "~0.0.7",
 				"ethereumjs-block": "~2.2.2",
 				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "~6.1.0",
+				"ethereumjs-util": "^6.1.0",
 				"flow-stoplight": "^1.0.0",
 				"level-mem": "^3.0.1",
 				"lru-cache": "^5.1.1",
 				"rlp": "^2.2.2",
 				"semaphore": "^1.1.0"
-			},
-			"dependencies": {
-				"ethereumjs-util": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-					"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "0.1.6",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
-				}
 			}
 		},
 		"ethereumjs-common": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-			"integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
 		},
 		"ethereumjs-tx": {
 			"version": "2.1.2",
@@ -2170,55 +2017,55 @@
 			}
 		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethers": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.9.tgz",
-			"integrity": "sha512-jv2ULxAKRlJv0zrhpUvYcwwITFghoJOEhOqSJhLBT3TnZyF/lmAS3tC8nejIlwxzOJw7LCyde8U+BwTzZdFDrQ==",
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz",
+			"integrity": "sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.3",
-				"@ethersproject/abstract-provider": "^5.0.3",
-				"@ethersproject/abstract-signer": "^5.0.3",
-				"@ethersproject/address": "^5.0.3",
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
 				"@ethersproject/base64": "^5.0.3",
 				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.6",
+				"@ethersproject/bignumber": "^5.0.7",
 				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.3",
-				"@ethersproject/contracts": "^5.0.3",
-				"@ethersproject/hash": "^5.0.3",
-				"@ethersproject/hdnode": "^5.0.3",
-				"@ethersproject/json-wallets": "^5.0.5",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/contracts": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
 				"@ethersproject/keccak256": "^5.0.3",
 				"@ethersproject/logger": "^5.0.5",
 				"@ethersproject/networks": "^5.0.3",
 				"@ethersproject/pbkdf2": "^5.0.3",
 				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/providers": "^5.0.6",
+				"@ethersproject/providers": "^5.0.8",
 				"@ethersproject/random": "^5.0.3",
 				"@ethersproject/rlp": "^5.0.3",
 				"@ethersproject/sha2": "^5.0.3",
 				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/solidity": "^5.0.3",
-				"@ethersproject/strings": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.3",
-				"@ethersproject/units": "^5.0.3",
-				"@ethersproject/wallet": "^5.0.3",
-				"@ethersproject/web": "^5.0.4",
-				"@ethersproject/wordlists": "^5.0.3"
+				"@ethersproject/solidity": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/units": "^5.0.4",
+				"@ethersproject/wallet": "^5.0.4",
+				"@ethersproject/web": "^5.0.6",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"ethjs-util": {
@@ -2281,11 +2128,6 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
 			"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"filename-reserved-regex": {
 			"version": "2.0.0",
@@ -2508,11 +2350,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -2607,11 +2444,11 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"requires": {
-				"agent-base": "5",
+				"agent-base": "6",
 				"debug": "4"
 			}
 		},
@@ -2629,9 +2466,9 @@
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"immediate": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-			"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
 		},
 		"immutable": {
 			"version": "4.0.0-rc.12",
@@ -2688,9 +2525,9 @@
 			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
 		},
 		"is-date-object": {
 			"version": "1.0.2",
@@ -2734,6 +2571,11 @@
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
 		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2758,11 +2600,11 @@
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-retry-allowed": {
@@ -2803,9 +2645,9 @@
 			}
 		},
 		"js-sha3": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-			"integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -2830,29 +2672,18 @@
 			}
 		},
 		"just-extend": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+			"integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
 			"dev": true
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
-			}
-		},
-		"keccakjs": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-			"integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-			"requires": {
-				"browserify-sha3": "^0.0.4",
-				"sha3": "^1.2.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"keyv": {
@@ -2934,6 +2765,11 @@
 					"requires": {
 						"xtend": "~4.0.0"
 					}
+				},
+				"immediate": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 				},
 				"memdown": {
 					"version": "3.0.0",
@@ -3117,9 +2953,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -3229,34 +3065,23 @@
 			},
 			"dependencies": {
 				"ethereumjs-util": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-					"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 					"requires": {
 						"bn.js": "^4.11.0",
 						"create-hash": "^1.1.2",
+						"elliptic": "^6.5.2",
+						"ethereum-cryptography": "^0.1.3",
 						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
 						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
 				},
 				"level-ws": {
 					"version": "1.0.0",
@@ -3321,9 +3146,9 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
 		},
 		"mime-types": {
 			"version": "2.1.27",
@@ -3332,6 +3157,14 @@
 			"dev": true,
 			"requires": {
 				"mime-db": "1.44.0"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.44.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+					"dev": true
+				}
 			}
 		},
 		"mimic-response": {
@@ -3371,9 +3204,9 @@
 			}
 		},
 		"mocha": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-			"integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
 			"requires": {
 				"ansi-colors": "3.2.3",
 				"browser-stdout": "1.3.1",
@@ -3464,6 +3297,22 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				},
+				"object-keys": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+				},
+				"object.assign": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+					"requires": {
+						"define-properties": "^1.1.2",
+						"function-bind": "^1.1.1",
+						"has-symbols": "^1.0.0",
+						"object-keys": "^1.0.11"
+					}
+				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -3508,15 +3357,10 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"nise": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-			"integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+			"integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.0",
@@ -3527,9 +3371,9 @@
 			}
 		},
 		"node-addon-api": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
-			"integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
 		},
 		"node-environment-flags": {
 			"version": "1.0.6",
@@ -3553,9 +3397,9 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-gyp-build": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
-			"integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -3597,9 +3441,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
 		},
 		"object-keys": {
 			"version": "0.4.0",
@@ -3607,16 +3451,35 @@
 			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.0",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
 			},
 			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.0",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
 				"object-keys": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -3740,9 +3603,9 @@
 			"dev": true
 		},
 		"pbkdf2": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -3909,9 +3772,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-			"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -3922,9 +3785,9 @@
 			"integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
 		},
 		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -3932,31 +3795,26 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"scrypt-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.0.tgz",
-			"integrity": "sha512-7CC7aufwukEvqdmllR0ny0QaSg0+S22xKXrXz3ZahaV6J+fgD2YAtrjtImuoDWog17/Ty9Q4HBmnXEXJ3JkfQA=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"seek-bzip": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
 			"requires": {
-				"commander": "~2.8.1"
+				"commander": "^2.8.1"
 			}
 		},
 		"semaphore": {
@@ -3993,33 +3851,18 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"sha3": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
-			"integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
-			"requires": {
-				"nan": "2.13.2"
-			},
-			"dependencies": {
-				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-				}
-			}
-		},
 		"sinon": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-			"integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+			"integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.2",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@sinonjs/formatio": "^5.0.1",
-				"@sinonjs/samsam": "^5.0.3",
+				"@sinonjs/samsam": "^5.1.0",
 				"diff": "^4.0.2",
-				"nise": "^4.0.1",
+				"nise": "^4.0.4",
 				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
@@ -4036,9 +3879,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4082,11 +3925,6 @@
 						"path-is-absolute": "^1.0.0",
 						"rimraf": "^2.2.8"
 					}
-				},
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 				},
 				"jsonfile": {
 					"version": "2.4.0",
@@ -4155,16 +3993,6 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
 			}
 		},
 		"string.prototype.trimend": {
@@ -4174,26 +4002,6 @@
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimstart": "^1.0.0"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimend": "^1.0.0"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -4214,10 +4022,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-			"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			}
 		},
 		"strip-dirs": {
 			"version": "2.1.0",
@@ -4348,6 +4158,12 @@
 						"has-color": "~0.1.0",
 						"strip-ansi": "~0.1.0"
 					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
 				}
 			}
 		},
@@ -4440,9 +4256,9 @@
 			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
 		},
 		"unbzip2-stream": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
-			"integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 			"requires": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
@@ -4554,9 +4370,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-			"integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
 		},
 		"xtend": {
 			"version": "2.1.2",

--- a/packages/buidler-core/package.json
+++ b/packages/buidler-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler",
-  "version": "1.99.1-rc.0",
+  "version": "1.4.7",
   "author": "Nomic Labs LLC",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://buidler.dev",

--- a/packages/buidler-core/src/builtin-tasks/node.ts
+++ b/packages/buidler-core/src/builtin-tasks/node.ts
@@ -17,6 +17,7 @@ import {
   BuidlerNetworkConfig,
   EthereumProvider,
   ResolvedBuidlerConfig,
+  ResolvedBuidlerNetworkConfig,
 } from "../types";
 
 import { TASK_NODE } from "./task-names";
@@ -30,7 +31,7 @@ function _createBuidlerEVMProvider(
   log("Creating BuidlerEVM Provider");
 
   const networkName = BUIDLEREVM_NETWORK_NAME;
-  const networkConfig = config.networks[networkName] as BuidlerNetworkConfig;
+  const networkConfig = config.networks[BUIDLEREVM_NETWORK_NAME];
 
   return lazyObject(() => {
     log(`Creating buidlerevm provider for JSON-RPC sever`);
@@ -42,7 +43,7 @@ function _createBuidlerEVMProvider(
   });
 }
 
-function logBuidlerEvmAccounts(networkConfig: BuidlerNetworkConfig) {
+function logBuidlerEvmAccounts(networkConfig: ResolvedBuidlerNetworkConfig) {
   if (networkConfig.accounts === undefined) {
     return;
   }
@@ -129,9 +130,7 @@ export default function () {
             Reporter.reportError(error);
           }
 
-          const networkConfig = config.networks[
-            BUIDLEREVM_NETWORK_NAME
-          ] as BuidlerNetworkConfig;
+          const networkConfig = config.networks[BUIDLEREVM_NETWORK_NAME];
           logBuidlerEvmAccounts(networkConfig);
 
           await server.waitUntilClosed();

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -80,6 +80,21 @@ const BuidlerNetworkAccount = t.type({
   balance: t.string,
 });
 
+const HDAccountsConfig = t.type({
+  mnemonic: t.string,
+  initialIndex: optional(t.number),
+  count: optional(t.number),
+  path: optional(t.string),
+});
+
+const BuidlerNetworkHDAccountsConfig = t.type({
+  mnemonic: t.string,
+  initialIndex: optional(t.number),
+  count: optional(t.number),
+  path: optional(t.string),
+  accountsBalance: optional(t.string),
+});
+
 const BuidlerNetworkConfig = t.type({
   hardfork: optional(t.string),
   chainId: optional(t.number),
@@ -87,20 +102,15 @@ const BuidlerNetworkConfig = t.type({
   gas: optional(t.union([t.literal("auto"), t.number])),
   gasPrice: optional(t.union([t.literal("auto"), t.number])),
   gasMultiplier: optional(t.number),
-  accounts: optional(t.array(BuidlerNetworkAccount)),
+  accounts: optional(
+    t.union([t.array(BuidlerNetworkAccount), BuidlerNetworkHDAccountsConfig])
+  ),
   blockGasLimit: optional(t.number),
   throwOnTransactionFailures: optional(t.boolean),
   throwOnCallFailures: optional(t.boolean),
   loggingEnabled: optional(t.boolean),
   allowUnlimitedContractSize: optional(t.boolean),
   initialDate: optional(t.string),
-});
-
-const HDAccountsConfig = t.type({
-  mnemonic: t.string,
-  initialIndex: optional(t.number),
-  count: optional(t.number),
-  path: optional(t.string),
 });
 
 const OtherAccountsConfig = t.type({

--- a/packages/buidler-core/src/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/src/internal/core/config/config-validation.ts
@@ -308,38 +308,49 @@ export function getValidationErrors(config: any): string[] {
         );
       }
 
-      if (buidlerNetwork.accounts !== undefined) {
-        if (Array.isArray(buidlerNetwork.accounts)) {
-          for (const account of buidlerNetwork.accounts) {
-            if (typeof account.privateKey !== "string") {
-              errors.push(
-                getErrorMessage(
-                  `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts[].privateKey`,
-                  account.privateKey,
-                  "string"
-                )
-              );
-            }
-
-            if (typeof account.balance !== "string") {
-              errors.push(
-                getErrorMessage(
-                  `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts[].balance`,
-                  account.balance,
-                  "string"
-                )
-              );
-            }
+      if (Array.isArray(buidlerNetwork.accounts)) {
+        for (const account of buidlerNetwork.accounts) {
+          if (typeof account.privateKey !== "string") {
+            errors.push(
+              getErrorMessage(
+                `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts[].privateKey`,
+                account.privateKey,
+                "string"
+              )
+            );
           }
-        } else {
+
+          if (typeof account.balance !== "string") {
+            errors.push(
+              getErrorMessage(
+                `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts[].balance`,
+                account.balance,
+                "string"
+              )
+            );
+          }
+        }
+      } else if (typeof buidlerNetwork.accounts === "object") {
+        const hdConfigResult = BuidlerNetworkHDAccountsConfig.decode(
+          buidlerNetwork.accounts
+        );
+        if (hdConfigResult.isLeft()) {
           errors.push(
             getErrorMessage(
               `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts`,
               buidlerNetwork.accounts,
-              "[{privateKey: string, balance: string}] | undefined"
+              "[{privateKey: string, balance: string}] | BuidlerNetworkHDAccountsConfig | undefined"
             )
           );
         }
+      } else if (buidlerNetwork.accounts !== undefined) {
+        errors.push(
+          getErrorMessage(
+            `BuidlerConfig.networks.${BUIDLEREVM_NETWORK_NAME}.accounts`,
+            buidlerNetwork.accounts,
+            "[{privateKey: string, balance: string}] | BuidlerNetworkHDAccountsConfig | undefined"
+          )
+        );
       }
     }
 

--- a/packages/buidler-core/src/internal/core/config/default-config.ts
+++ b/packages/buidler-core/src/internal/core/config/default-config.ts
@@ -3,6 +3,9 @@ import { BUIDLEREVM_NETWORK_NAME } from "../../constants";
 
 export const DEFAULT_SOLC_VERSION = "0.5.15";
 export const BUIDLEREVM_DEFAULT_GAS_PRICE = 8e9;
+const BUIDLER_EVM_MNEMONIC =
+  "test test test test test test test test test test test junk";
+export const DEFAULT_BUIDLER_NETWORK_BALANCE = "10000000000000000000000";
 
 const DEFAULT_BUIDLER_NETWORK_CONFIG: BuidlerNetworkConfig = {
   hardfork: "istanbul",
@@ -13,130 +16,11 @@ const DEFAULT_BUIDLER_NETWORK_CONFIG: BuidlerNetworkConfig = {
   throwOnTransactionFailures: true,
   throwOnCallFailures: true,
   allowUnlimitedContractSize: false,
-  accounts: [
-    // 20 accounts with 10k ETH each
-    // Addresses:
-    //   0xc783df8a850f42e7f7e57013759c285caa701eb6
-    //   0xead9c93b79ae7c1591b1fb5323bd777e86e150d4
-    //   0xe5904695748fe4a84b40b3fc79de2277660bd1d3
-    //   0x92561f28ec438ee9831d00d1d59fbdc981b762b2
-    //   0x2ffd013aaa7b5a7da93336c2251075202b33fb2b
-    //   0x9fc9c2dfba3b6cf204c37a5f690619772b926e39
-    //   0xfbc51a9582d031f2ceaad3959256596c5d3a5468
-    //   0x84fae3d3cba24a97817b2a18c2421d462dbbce9f
-    //   0xfa3bdc8709226da0da13a4d904c8b66f16c3c8ba
-    //   0x6c365935ca8710200c7595f0a72eb6023a7706cd
-    //   0xd7de703d9bbc4602242d0f3149e5ffcd30eb3adf
-    //   0x532792b73c0c6e7565912e7039c59986f7e1dd1f
-    //   0xea960515f8b4c237730f028cbacf0a28e7f45de0
-    //   0x3d91185a02774c70287f6c74dd26d13dfb58ff16
-    //   0x5585738127d12542a8fd6c71c19d2e4cecdab08a
-    //   0x0e0b5a3f244686cf9e7811754379b9114d42f78b
-    //   0x704cf59b16fd50efd575342b46ce9c5e07076a4a
-    //   0x0a057a7172d0466aef80976d7e8c80647dfd35e3
-    //   0x68dfc526037e9030c8f813d014919cc89e7d4d74
-    //   0x26c43a1d431a4e5ee86cd55ed7ef9edf3641e901
-    {
-      privateKey:
-        "0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0xd49743deccbccc5dc7baa8e69e5be03298da8688a15dd202e20f15d5e0e9a9fb",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x23c601ae397441f3ef6f1075dcb0031ff17fb079837beadaf3c84d96c6f3e569",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0xee9d129c1997549ee09c0757af5939b2483d80ad649a0eda68e8b0357ad11131",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x87630b2d1de0fbd5044eb6891b3d9d98c34c8d310c852f98550ba774480e47cc",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x275cc4a2bfd4f612625204a20a2280ab53a6da2d14860c47a9f5affe58ad86d4",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x7f307c41137d1ed409f0a7b028f6c7596f12734b1d289b58099b99d60a96efff",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x2a8aede924268f84156a00761de73998dac7bf703408754b776ff3f873bcec60",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x8b24fd94f1ce869d81a34b95351e7f97b2cd88a891d5c00abc33d0ec9501902e",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b29085",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b29086",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b29087",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b29088",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b29089",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908a",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908b",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908c",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908d",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908e",
-      balance: "10000000000000000000000",
-    },
-    {
-      privateKey:
-        "0x28d1bfbbafe9d1d4f5a11c3c16ab6bf9084de48d99fbac4058bdfa3c80b2908f",
-      balance: "10000000000000000000000",
-    },
-  ],
+  accounts: {
+    mnemonic: BUIDLER_EVM_MNEMONIC,
+    count: 20,
+    accountsBalance: DEFAULT_BUIDLER_NETWORK_BALANCE,
+  },
 };
 
 const defaultConfig: BuidlerConfig = {

--- a/packages/buidler-core/src/internal/core/providers/accounts.ts
+++ b/packages/buidler-core/src/internal/core/providers/accounts.ts
@@ -1,11 +1,11 @@
 import { Transaction as TransactionT } from "ethereumjs-tx";
 
 import { EIP1193Provider, RequestArguments } from "../../../types";
-import { deriveKeyFromMnemonicAndPath } from "../../util/keys-derivation";
 import { BuidlerError } from "../errors";
 import { ERRORS } from "../errors-list";
 
 import { ProviderWrapperWithChainId } from "./chainId";
+import { derivePrivateKeys } from "./util";
 import { ProviderWrapper } from "./wrapper";
 
 // This library's types are wrong, they don't type check
@@ -207,31 +207,12 @@ export class HDWalletProvider extends LocalAccountsProvider {
     initialIndex: number = 0,
     count: number = 10
   ) {
-    if (hdpath.match(HD_PATH_REGEX) === null) {
-      throw new BuidlerError(ERRORS.NETWORK.INVALID_HD_PATH, { path: hdpath });
-    }
-
-    if (!hdpath.endsWith("/")) {
-      hdpath += "/";
-    }
-
-    const privateKeys: Buffer[] = [];
-
-    for (let i = initialIndex; i < initialIndex + count; i++) {
-      const privateKey = deriveKeyFromMnemonicAndPath(
-        mnemonic,
-        hdpath + i.toString()
-      );
-
-      if (privateKey === undefined) {
-        throw new BuidlerError(ERRORS.NETWORK.CANT_DERIVE_KEY, {
-          mnemonic,
-          path: hdpath,
-        });
-      }
-
-      privateKeys.push(privateKey);
-    }
+    const privateKeys = derivePrivateKeys(
+      mnemonic,
+      hdpath,
+      initialIndex,
+      count
+    );
 
     const { bufferToHex } = require("ethereumjs-util");
     const privateKeysAsHex = privateKeys.map((pk) => bufferToHex(pk));

--- a/packages/buidler-core/src/internal/core/providers/util.ts
+++ b/packages/buidler-core/src/internal/core/providers/util.ts
@@ -1,0 +1,65 @@
+import {
+  BuidlerNetworkAccount,
+  BuidlerNetworkHDAccountsConfig,
+} from "../../../types";
+import { deriveKeyFromMnemonicAndPath } from "../../util/keys-derivation";
+import { DEFAULT_BUIDLER_NETWORK_BALANCE } from "../config/default-config";
+import { BuidlerError } from "../errors";
+import { ERRORS } from "../errors-list";
+
+const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
+
+export function derivePrivateKeys(
+  mnemonic: string,
+  hdpath: string = "m/44'/60'/0'/0/",
+  initialIndex: number = 0,
+  count: number = 10
+): Buffer[] {
+  if (hdpath.match(HD_PATH_REGEX) === null) {
+    throw new BuidlerError(ERRORS.NETWORK.INVALID_HD_PATH, { path: hdpath });
+  }
+
+  if (!hdpath.endsWith("/")) {
+    hdpath += "/";
+  }
+
+  const privateKeys: Buffer[] = [];
+
+  for (let i = initialIndex; i < initialIndex + count; i++) {
+    const privateKey = deriveKeyFromMnemonicAndPath(
+      mnemonic,
+      hdpath + i.toString()
+    );
+
+    if (privateKey === undefined) {
+      throw new BuidlerError(ERRORS.NETWORK.CANT_DERIVE_KEY, {
+        mnemonic,
+        path: hdpath,
+      });
+    }
+
+    privateKeys.push(privateKey);
+  }
+
+  return privateKeys;
+}
+
+export function normalizeBuidlerEVMAccountsConfig(
+  accountsConfig: BuidlerNetworkAccount[] | BuidlerNetworkHDAccountsConfig
+): BuidlerNetworkAccount[] {
+  if (Array.isArray(accountsConfig)) {
+    return accountsConfig;
+  }
+
+  const { bufferToHex } = require("ethereumjs-util");
+
+  return derivePrivateKeys(
+    accountsConfig.mnemonic,
+    accountsConfig.path,
+    accountsConfig.initialIndex,
+    accountsConfig.count
+  ).map((pk) => ({
+    privateKey: bufferToHex(pk),
+    balance: accountsConfig.accountsBalance ?? DEFAULT_BUIDLER_NETWORK_BALANCE,
+  }));
+}

--- a/packages/buidler-core/src/types.ts
+++ b/packages/buidler-core/src/types.ts
@@ -21,7 +21,7 @@ export interface BuidlerNetworkAccount {
 }
 
 export interface BuidlerNetworkConfig extends CommonNetworkConfig {
-  accounts?: BuidlerNetworkAccount[];
+  accounts?: BuidlerNetworkAccount[] | BuidlerNetworkHDAccountsConfig;
   blockGasLimit?: number;
   hardfork?: string;
   throwOnTransactionFailures?: boolean;
@@ -36,11 +36,19 @@ export interface BuidlerNetworkConfig extends CommonNetworkConfig {
   };
 }
 
+export interface ResolvedBuidlerNetworkConfig extends BuidlerNetworkConfig {
+  accounts: BuidlerNetworkAccount[];
+}
+
 export interface HDAccountsConfig {
   mnemonic: string;
   initialIndex?: number;
   count?: number;
   path?: string;
+}
+
+export interface BuidlerNetworkHDAccountsConfig extends HDAccountsConfig {
+  accountsBalance?: string;
 }
 
 export interface OtherAccountsConfig {
@@ -60,10 +68,24 @@ export interface HttpNetworkConfig extends CommonNetworkConfig {
   accounts?: NetworkConfigAccounts;
 }
 
+export interface ResolvedHttpNetworkConfig extends HttpNetworkConfig {
+  url: string;
+}
+
 export type NetworkConfig = BuidlerNetworkConfig | HttpNetworkConfig;
 
+export type ResolvedNetworkConfig =
+  | ResolvedBuidlerNetworkConfig
+  | ResolvedHttpNetworkConfig;
+
 export interface Networks {
+  buidlerevm: BuidlerNetworkConfig;
   [networkName: string]: NetworkConfig;
+}
+
+export interface ResolvedNetworks {
+  buidlerevm: ResolvedBuidlerNetworkConfig;
+  [networkName: string]: ResolvedNetworkConfig;
 }
 
 /**
@@ -117,7 +139,7 @@ export interface BuidlerConfig {
 export interface ResolvedBuidlerConfig extends BuidlerConfig {
   defaultNetwork: string;
   paths: ProjectPaths;
-  networks: Networks;
+  networks: ResolvedNetworks;
   analytics: AnalyticsConfig;
   solidity: MultiSolcConfig;
 }
@@ -382,7 +404,7 @@ export type IEthereumProvider = EthereumProvider;
 
 export interface Network {
   name: string;
-  config: NetworkConfig;
+  config: ResolvedNetworkConfig;
   provider: EthereumProvider;
 }
 

--- a/packages/buidler-core/test/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/test/internal/core/config/config-validation.ts
@@ -498,6 +498,81 @@ describe("Config validation", function () {
             ERRORS.GENERAL.INVALID_CONFIG
           );
         });
+
+        describe("BuidlerNetworkHDAccounstConfig", function () {
+          it("Should fail with invalid types", function () {
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [BUIDLEREVM_NETWORK_NAME]: {
+                      accounts: {
+                        mnemonic: 123,
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [BUIDLEREVM_NETWORK_NAME]: {
+                      accounts: {
+                        initialIndex: "asd",
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [BUIDLEREVM_NETWORK_NAME]: {
+                      accounts: {
+                        count: "asd",
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [BUIDLEREVM_NETWORK_NAME]: {
+                      accounts: {
+                        path: 123,
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+
+            expectBuidlerError(
+              () =>
+                validateConfig({
+                  networks: {
+                    [BUIDLEREVM_NETWORK_NAME]: {
+                      accounts: {
+                        mnemonic: "asd",
+                        accountsBalance: {},
+                      },
+                    },
+                  },
+                }),
+              ERRORS.GENERAL.INVALID_CONFIG
+            );
+          });
+        });
       });
 
       describe("HTTP network config", function () {

--- a/packages/buidler-core/test/internal/core/config/config-validation.ts
+++ b/packages/buidler-core/test/internal/core/config/config-validation.ts
@@ -6,6 +6,7 @@ import {
   validateConfig,
 } from "../../../../src/internal/core/config/config-validation";
 import { ERRORS } from "../../../../src/internal/core/errors-list";
+import { BuidlerNetworkHDAccountsConfig } from "../../../../src/types";
 import { expectBuidlerError } from "../../../helpers/errors";
 
 describe("Config validation", function () {
@@ -500,6 +501,36 @@ describe("Config validation", function () {
         });
 
         describe("BuidlerNetworkHDAccounstConfig", function () {
+          it("Should accept a valid HD config", function () {
+            let hdConfig: BuidlerNetworkHDAccountsConfig = {
+              mnemonic: "asd",
+            };
+
+            validateConfig({
+              networks: {
+                [BUIDLEREVM_NETWORK_NAME]: {
+                  accounts: hdConfig,
+                },
+              },
+            });
+
+            hdConfig = {
+              mnemonic: "asd",
+              accountsBalance: "123",
+              count: 123,
+              initialIndex: 1,
+              path: "m/1/2",
+            };
+
+            validateConfig({
+              networks: {
+                [BUIDLEREVM_NETWORK_NAME]: {
+                  accounts: hdConfig,
+                },
+              },
+            });
+          });
+
           it("Should fail with invalid types", function () {
             expectBuidlerError(
               () =>

--- a/packages/buidler-core/test/internal/core/runtime-environment.ts
+++ b/packages/buidler-core/test/internal/core/runtime-environment.ts
@@ -28,6 +28,9 @@ describe("Environment", () => {
       local: {
         url: "http://localhost:8545",
       },
+      buidlerevm: {
+        accounts: [],
+      },
       default: {
         url: "http://localhost:8545",
       },

--- a/packages/buidler-docker/package-lock.json
+++ b/packages/buidler-docker/package-lock.json
@@ -5,15 +5,15 @@
 	"requires": true,
 	"dependencies": {
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/dockerode": {
-			"version": "2.5.29",
-			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.29.tgz",
-			"integrity": "sha512-ioDiW8FvAUApGduFUNER7bU3gv1EBqInMutY9TYcxdfnE7QP6AzF7rIvfkIjQkEvWMfksaGSPfTXsZ3H1mPJBg==",
+			"version": "2.5.34",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.34.tgz",
+			"integrity": "sha512-LcbLGcvcBwBAvjH9UrUI+4qotY+A5WCer5r43DR5XHv2ZIEByNXFdPLo1XxR+v/BjkGjlggW8qUiXuVEhqfkpA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -29,9 +29,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"@types/node-fetch": {
@@ -60,9 +60,9 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"

--- a/packages/buidler-ethers/package-lock.json
+++ b/packages/buidler-ethers/package-lock.json
@@ -5,304 +5,281 @@
 	"requires": true,
 	"dependencies": {
 		"@ethersproject/abi": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.1.tgz",
-			"integrity": "sha512-9fqSa3jEYV4nN8tijW+jz4UnT/Ma9/b8y4+nHlsvuWqr32E2kYsT9SCIVpk/51iM6NOud7xsA6UxCox9zBeHKg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+			"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/abstract-provider": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.1.tgz",
-			"integrity": "sha512-/KOw65ayviYPtKLqFE1qozeIJJlfI1wE/tNA+iKUPUai6bU6vg2tbfLFGarRTCQe3HoWV1t7xSsD/z9T9xg74g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+			"integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6"
 			}
 		},
 		"@ethersproject/abstract-signer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.1.tgz",
-			"integrity": "sha512-Rp8DP+cLcSNFkd1YhwPSBcgEWLRipNakitwIwHngAmhbo4zdiWgALD/OLqdQ7SKF75CufF1W4BCuXcQgiWaRow==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz",
+			"integrity": "sha512-nwSZKtCTKhJADlW42c+a//lWxQlnA7jYLTnabJ3YCfgGU6ic9jnT9nRDlAyT1U3kCMeqPL7fTcKbdWCVrM0xsw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
-			"integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+			"integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/rlp": "^5.0.3",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/base64": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.1.tgz",
-			"integrity": "sha512-WZDa+TYl6BQfUm9EQIDDfJFL0GiuYXNZPIWoiZx3uds7P1XMsvcW3k71AyjYUxIkU5AKW7awwPbzCbBeP1uXsA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
+			"integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4"
 			}
 		},
 		"@ethersproject/basex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.1.tgz",
-			"integrity": "sha512-ssL2+p/A5bZgkZkiWy0iQDVz2mVJxZfzpf7dpw8t0sKF9VpoM3ZiMthRapH/QBhd4Rr6TNbr619pFLAGmMi9Ug==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
+			"integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.1.tgz",
-			"integrity": "sha512-srGDO7ksT0avdDw5pBtj6F81psv5xiJMInwSSatfIKplitubFb6yVwoHGObGRd0Pp3TvrkIDfJkuskoSMj4OHQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+			"integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
-			"integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+			"integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
-			"integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+			"integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7"
 			}
 		},
 		"@ethersproject/contracts": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.1.tgz",
-			"integrity": "sha512-1uPajmkvw3Oy/dxs5TKUsGaXzQ3s5qiXKSVpw9ZrhGG6fMRO3gNyUA+uSWk9IXK0ulj5P95F7vW8HmYOkzep/Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+			"integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
-			"integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+			"integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/hdnode": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.1.tgz",
-			"integrity": "sha512-L2OZP4SKKxNtHUdwfK8cND09kHRH62ncxXW33WAJU9shKo8Sbz31HVqSdov84bMAGm8QfEKZbfbAJV/7DM6DjQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+			"integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/basex": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/json-wallets": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.1.tgz",
-			"integrity": "sha512-QjqQCh1a0a6wRVHdnqVccCLWX0vAgxnvGZeGqpOk2NbyNE8HTzV7GpOE+4LU+iCc8oonfy1gYd4hpsf+iEUWGg==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+			"integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
 				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1",
-				"uuid": "2.0.1"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-					"dev": true
-				}
+				"scrypt-js": "3.0.1"
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
-			"integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+			"integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
 				"js-sha3": "0.5.7"
-			},
-			"dependencies": {
-				"js-sha3": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
-			"integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+			"integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
 			"dev": true
 		},
 		"@ethersproject/networks": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.1.tgz",
-			"integrity": "sha512-Pe34JCTC6Apm/DkK3z97xotvEyu9YHKIFlDIu5hGV6yFDb4/sUfY2SHKYSGdUrV0418ZZVrwYDveJtBFMmYu2Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
+			"integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/pbkdf2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.1.tgz",
-			"integrity": "sha512-4wc8Aov0iJmiomu6Dv1JNGOlhm3L7omITjLmChz/vgeDnW4Unv4J/nGybCeWKgY4hnjyQMVXkdkQ15BCRbkaYg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
+			"integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/sha2": "^5.0.3"
 			}
 		},
 		"@ethersproject/properties": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
-			"integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+			"integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/providers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.2.tgz",
-			"integrity": "sha512-28ABJmHB9ii/73F3P9CXLBvlRkitiOGHCrUZqjQ6FELuAtKEROqA/yDklT9o/r/BpGcGTeeWpWfvdfgDHjshiw==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.9.tgz",
+			"integrity": "sha512-UtGrlJxekFNV7lriPOxQbnYminyiwTgjHMPX83pG7N/W/t+PekQK8V9rdlvMr2bRyGgafHml0ZZMaTV4FxiBYg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6",
+				"bech32": "1.1.4",
 				"ws": "7.2.3"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/random": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.1.tgz",
-			"integrity": "sha512-nYzNhcp5Th4dCocV3yceZmh80bRmSQxqNRgND7Y/YgEgYJSSnknScpfRHACG//kgbsY8zui8ajXJeEnzS7yFbQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
+			"integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
-			"integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+			"integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/sha2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.1.tgz",
-			"integrity": "sha512-5wNdULNDMJKwyzqrTH66e2TZPZTSqqluS7RNtuuuQSTP+yIALoID7ewLjDoj31g4kZyq/pqQbackKJLOXejTKw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
+			"integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"hash.js": "1.1.3"
 			},
 			"dependencies": {
@@ -319,138 +296,122 @@
 			}
 		},
 		"@ethersproject/signing-key": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.1.tgz",
-			"integrity": "sha512-Z3yMPFFf4KkWltndDNi/tpese7qZh6ZWKbGu3DHd8xOX0PJqbScdAs6gCfFeMatO06qyX307Y52soc/Ayf8ZSg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+			"integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"elliptic": "6.5.2"
-			},
-			"dependencies": {
-				"elliptic": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"elliptic": "6.5.3"
 			}
 		},
 		"@ethersproject/solidity": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.1.tgz",
-			"integrity": "sha512-3L+xI1LaJmd2zBJxnK9Y4cd1vb2aJLFvL6fxvjWpzcMiFiZ4dbPwj3kharv5f5mAlbGwAs6NiPJaFWvbOpm96Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+			"integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
-			"integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+			"integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/transactions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
-			"integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+			"integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4"
 			}
 		},
 		"@ethersproject/units": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.1.tgz",
-			"integrity": "sha512-7J7Jmm4hMZ+yFiqEd7D5oeVK/V74GDwQlT0Om1yxXLYX6UPcV5ChHkUz/xpHPT9JXQlQ+2D69HBf1dzvdflrmQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+			"integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/wallet": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.1.tgz",
-			"integrity": "sha512-1/QPpFngJtUGtdVOLSoIN3vf+zEWyEVxQ0lhRCwGkiBqL2SoVoDHB7/nCfcv7wwlZkdnegFfo/8DxeyYjTZN7w==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+			"integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/web": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.1.tgz",
-			"integrity": "sha512-lWPg8BR6KoyiIKYRIM6j+XO9bT9vGM1JnxFj2HmhIvOrOjba7ZRd8ANBOsDVGfw5igLUdfqAUOf9WpSsH//TzA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.7.tgz",
+			"integrity": "sha512-BM8FdGrzdcULYaOIyMXDKvxv+qOwGne8FKpPxUrifZIWAWPrq/y+oBOZlzadIKsP3wvYbAcMN2CgOLO1E3yIfw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/wordlists": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.1.tgz",
-			"integrity": "sha512-R7boLmpewucz5v4jD7cWwI0BGHR/DstiZtjdhUOft6XdMqM1OGb1UTL0GBQeS4vDXzCLuJEHddjJ69beGVN/4Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+			"integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/fs-extra": {
@@ -463,9 +424,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"aes-js": {
@@ -478,6 +439,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
 			"dev": true
 		},
 		"bn.js": {
@@ -521,41 +488,57 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"ethers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.2.tgz",
-			"integrity": "sha512-hAWTPQXvjFlrtnPLCnOOJJuqiqmJv820egPHpOwcWTIQxXRrcfZyse2692eaqsXMeYLNM2CRfYgEomBiBGvgjw==",
+		"elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/contracts": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/providers": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/solidity": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/units": "^5.0.0",
-				"@ethersproject/wallet": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"ethers": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz",
+			"integrity": "sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==",
+			"dev": true,
+			"requires": {
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/contracts": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/providers": "^5.0.8",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/solidity": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/units": "^5.0.4",
+				"@ethersproject/wallet": "^5.0.4",
+				"@ethersproject/web": "^5.0.6",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"get-func-name": {
@@ -591,6 +574,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"js-sha3": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+			"dev": true
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -619,6 +608,12 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
+		},
+		"ws": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
 			"dev": true
 		}
 	}

--- a/packages/buidler-etherscan/package-lock.json
+++ b/packages/buidler-etherscan/package-lock.json
@@ -5,276 +5,271 @@
 	"requires": true,
 	"dependencies": {
 		"@ethersproject/abi": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.2.tgz",
-			"integrity": "sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+			"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/abstract-provider": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz",
-			"integrity": "sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+			"integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6"
 			}
 		},
 		"@ethersproject/abstract-signer": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz",
-			"integrity": "sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz",
+			"integrity": "sha512-nwSZKtCTKhJADlW42c+a//lWxQlnA7jYLTnabJ3YCfgGU6ic9jnT9nRDlAyT1U3kCMeqPL7fTcKbdWCVrM0xsw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
-			"integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+			"integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/rlp": "^5.0.3",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/base64": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.2.tgz",
-			"integrity": "sha512-0FE5RH5cUDddOiQEDpWtyHjkSW4D5/rdJzA3KTZo8Fk5ab/Y8vdzqbamsXPyPsXU3gS+zCE5Qq4EKVOWlWLLTA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
+			"integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4"
 			}
 		},
 		"@ethersproject/basex": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.2.tgz",
-			"integrity": "sha512-p4m2CeQqI9vma3XipRbP2iDf6zTsbroE0MEXBAYXidsoJQSvePKrC6MVRKfTzfcHej1b9wfmjVBzqhqn3FRhIA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
+			"integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
-			"integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+			"integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
-			"integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+			"integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
-			"integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+			"integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7"
 			}
 		},
 		"@ethersproject/contracts": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.2.tgz",
-			"integrity": "sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+			"integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
-			"integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+			"integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/hdnode": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.2.tgz",
-			"integrity": "sha512-QAUI5tfseTFqv00Vnbwzofqse81wN9TaL+x5GufTHIHJXgVdguxU+l39E3VYDCmO+eVAA6RCn5dJgeyra+PU2g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+			"integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/basex": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/json-wallets": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.4.tgz",
-			"integrity": "sha512-jqtb+X3rJXWG/w+Qyr7vq1V+fdc5jiLlyc6akwI3SQIHTfcuuyF+eZRd9u2/455urNwV3nuCsnrgxs2NrtHHIw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+			"integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
 				"aes-js": "3.0.0",
 				"scrypt-js": "3.0.1"
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
-			"integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+			"integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
 				"js-sha3": "0.5.7"
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
-			"integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+			"integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
 		},
 		"@ethersproject/networks": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.2.tgz",
-			"integrity": "sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
+			"integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/pbkdf2": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.2.tgz",
-			"integrity": "sha512-OJFxdX/VtGI5M04lAzXKEOb76XBzjCOzGyko3/bMWat3ePAw7RveBOLyhm79SBs2fh21MSYgdG6JScEMHoSImw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
+			"integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/sha2": "^5.0.3"
 			}
 		},
 		"@ethersproject/properties": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
-			"integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+			"integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/providers": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.5.tgz",
-			"integrity": "sha512-ZR3yFg/m8qDl7317yXOHE7tKeGfoyZIZ/imhVC4JqAH+SX1rb6bdZcSjhJfet7rLmnJSsnYLTgIiVIT85aVLgg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.9.tgz",
+			"integrity": "sha512-UtGrlJxekFNV7lriPOxQbnYminyiwTgjHMPX83pG7N/W/t+PekQK8V9rdlvMr2bRyGgafHml0ZZMaTV4FxiBYg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6",
+				"bech32": "1.1.4",
 				"ws": "7.2.3"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/random": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.2.tgz",
-			"integrity": "sha512-kLeS+6bwz37WR2zbe69gudyoGVoUzljQO0LhifnATsZ7rW0JZ9Zgt0h5aXY7tqFDo9TvdqeCwUFdp1t3T5Fkhg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
+			"integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
-			"integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+			"integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/sha2": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.2.tgz",
-			"integrity": "sha512-VFl4qSStjQZaygpqoAHswaCY59qBm1Sm0rf8iv0tmgVsRf0pBg2nJaNf9NXXvcuJ9AYPyXl57dN8kozdC4z5Cg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
+			"integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"hash.js": "1.1.3"
 			},
 			"dependencies": {
@@ -291,132 +286,115 @@
 			}
 		},
 		"@ethersproject/signing-key": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
-			"integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+			"integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
 				"elliptic": "6.5.3"
-			},
-			"dependencies": {
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
 			}
 		},
 		"@ethersproject/solidity": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.2.tgz",
-			"integrity": "sha512-RygurUe1hPW1LDYAPXy4471AklGWNnxgFWc3YUE6H11gzkit26jr6AyZH4Yyjw38eBBL6j0AOfQzMWm+NhxZ9g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+			"integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
-			"integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+			"integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/transactions": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
-			"integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+			"integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4"
 			}
 		},
 		"@ethersproject/units": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.2.tgz",
-			"integrity": "sha512-PSuzycBA1zmRysTtKtp+XYZ3HIJfbmfRdZchOUxdyeGo5siUi9H6mYQcxdJHv82oKp/FniMj8qS8qtLQThhOEg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+			"integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/wallet": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.2.tgz",
-			"integrity": "sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+			"integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/web": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.3.tgz",
-			"integrity": "sha512-9WoIWNxbFOk+8TiWqQMQbYJUIFeC1Z7zNr7oCHpVyhxF0EY54ZVXlP/Y7VJ7KzK++A/iMGOuTIGeL5sMqa2QMg==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.7.tgz",
+			"integrity": "sha512-BM8FdGrzdcULYaOIyMXDKvxv+qOwGne8FKpPxUrifZIWAWPrq/y+oBOZlzadIKsP3wvYbAcMN2CgOLO1E3yIfw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/wordlists": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.2.tgz",
-			"integrity": "sha512-6vKDQcjjpnfdSCr0+jNxpFH3ieKxUPkm29tQX2US7a3zT/sJU/BGlKBR7D8oOpwdE0hpkHhJyMlypRBK+A2avA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+			"integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@types/bn.js": {
@@ -428,18 +406,18 @@
 			}
 		},
 		"@types/cbor": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-5.0.0.tgz",
-			"integrity": "sha512-9HFbkKNnQUn8bseuoggKdgynqAuM31Bf5IPMlPFh7SOKApjMFG1M+yoIrVbXOo/ohzovKkFW14zsDGlnuBofqA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/cbor/-/cbor-5.0.1.tgz",
+			"integrity": "sha512-zVqJy2KzusZPLOgyGJDnOIbu3DxIGGqxYbEwtEEe4Z+la8jwIhOyb+GMrlHafs5tvKruwf8f8qOYP6zTvse/pw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/ethereumjs-abi": {
@@ -461,9 +439,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -475,10 +453,26 @@
 				"form-data": "^3.0.0"
 			}
 		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/semver": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
-			"integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.2.tgz",
+			"integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==",
 			"dev": true
 		},
 		"aes-js": {
@@ -505,26 +499,29 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+			"dev": true
+		},
 		"bignumber.js": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn.js": {
 			"version": "4.11.9",
@@ -559,18 +556,36 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"cbor": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.2.tgz",
-			"integrity": "sha512-6JiKVURxxO92FntzTJq54QdN/8fBaBwD7+nNyGIAi1HL9mBgU3YK6ULV8k7WTuT/EwfRsjy3MuqDKlkQMCmfXg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
+			"integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
 			"requires": {
 				"bignumber.js": "^9.0.0",
-				"nofilter": "^1.0.3"
+				"nofilter": "^1.0.4"
 			}
 		},
 		"chai": {
@@ -617,6 +632,12 @@
 			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
 			"dev": true
 		},
+		"commander": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+			"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -649,12 +670,12 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"deep-eql": {
@@ -695,20 +716,10 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -720,22 +731,22 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -749,6 +760,28 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"ethereumjs-abi": {
 			"version": "0.6.8",
 			"resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
@@ -759,55 +792,55 @@
 			}
 		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethers": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.8.tgz",
-			"integrity": "sha512-of/rPgJ7E3yyBADUv5A7Gtkd7EB8ta/T9NS5CCG9tj9cifnXcI3KIdYQ7d8AS+9vm38pR1g6S5I+Q/mRnlQZlg==",
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz",
+			"integrity": "sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/basex": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/contracts": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/providers": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/solidity": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/units": "^5.0.0",
-				"@ethersproject/wallet": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/contracts": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/providers": "^5.0.8",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/solidity": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/units": "^5.0.4",
+				"@ethersproject/wallet": "^5.0.4",
+				"@ethersproject/web": "^5.0.6",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"ethjs-util": {
@@ -828,11 +861,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-		},
 		"form-data": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -842,6 +870,19 @@
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
+			}
+		},
+		"fs-extra": {
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^2.1.0",
+				"klaw": "^1.0.0",
+				"path-is-absolute": "^1.0.0",
+				"rimraf": "^2.2.8"
 			}
 		},
 		"fs.realpath": {
@@ -948,9 +989,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
 			"dev": true
 		},
 		"is-date-object": {
@@ -964,13 +1005,19 @@
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
 			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+			"dev": true
+		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-symbol": {
@@ -993,15 +1040,22 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"dev": true,
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"keccak": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+			"requires": {
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"klaw": {
@@ -1014,9 +1068,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
 		"md5.js": {
@@ -1090,11 +1144,6 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"nock": {
 			"version": "10.0.6",
 			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
@@ -1120,20 +1169,30 @@
 				}
 			}
 		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
 		"node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+		},
 		"nofilter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.3.tgz",
-			"integrity": "sha512-FlUlqwRK6reQCaFLAhMcF+6VkVG2caYjKQY3YsRDTl4/SEch595Qb3oLjJRDr8dkHAAOVj2pOx3VknfnSgkE5g=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-is": {
@@ -1153,15 +1212,37 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.0",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.0",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"once": {
@@ -1191,6 +1272,18 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
 		"propagate": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
@@ -1198,10 +1291,18 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+			"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
 			"dev": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"readable-stream": {
 			"version": "3.6.0",
@@ -1248,9 +1349,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -1263,28 +1364,27 @@
 		"scrypt-js": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-			"dev": true
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -1311,39 +1411,11 @@
 				"tmp": "0.0.33"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-					"dev": true
-				},
-				"fs-extra": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0",
-						"klaw": "^1.0.0",
-						"path-is-absolute": "^1.0.0",
-						"rimraf": "^2.2.8"
-					}
-				},
 				"js-sha3": {
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
 					"dev": true
-				},
-				"jsonfile": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
 				},
 				"semver": {
 					"version": "5.7.1",
@@ -1361,28 +1433,6 @@
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimstart": "^1.0.0"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimend": "^1.0.0"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -1435,6 +1485,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"ws": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
 			"dev": true
 		}
 	}

--- a/packages/buidler-etherscan/test/unit/solc/metadata.ts
+++ b/packages/buidler-etherscan/test/unit/solc/metadata.ts
@@ -37,7 +37,7 @@ describe("Metadata decoder tests", () => {
   ];
 
   for (const mockPayload of mockPayloads) {
-    const mockMetadata = encode(mockPayload);
+    const mockMetadata = Buffer.from(encode(mockPayload));
     const length = Buffer.alloc(2);
     length.writeUInt16BE(mockMetadata.length, 0);
 
@@ -62,8 +62,9 @@ describe("Metadata decoder tests", () => {
   );
 
   for (const mockSolcMetadataMapping of mockSolcMetadataMappings) {
-    const mockMetadata = encode(mockSolcMetadataMapping);
+    const mockMetadata = Buffer.from(encode(mockSolcMetadataMapping));
     const length = Buffer.alloc(2);
+
     length.writeUInt16BE(mockMetadata.length, 0);
 
     const metadataBuffer = Buffer.concat([

--- a/packages/buidler-ganache/package-lock.json
+++ b/packages/buidler-ganache/package-lock.json
@@ -4,239 +4,10 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@nomiclabs/buidler": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.4.5.tgz",
-			"integrity": "sha512-jaaVvG7OsrObhEBnLtQ/8L3J92+Jgioaw2+296dDO4Uc+MO/kprORbnpbE/WKvPL1geKQ4uj6VdCpM7qNCwL3g==",
-			"dev": true,
-			"requires": {
-				"@nomiclabs/ethereumjs-vm": "^4.1.1",
-				"@sentry/node": "^5.18.1",
-				"@solidity-parser/parser": "^0.5.2",
-				"@types/bn.js": "^4.11.5",
-				"@types/lru-cache": "^5.1.0",
-				"abort-controller": "^3.0.0",
-				"ansi-escapes": "^4.3.0",
-				"chalk": "^2.4.2",
-				"chokidar": "^3.4.0",
-				"ci-info": "^2.0.0",
-				"debug": "^4.1.1",
-				"deepmerge": "^2.1.0",
-				"download": "^7.1.0",
-				"enquirer": "^2.3.0",
-				"eth-sig-util": "^2.5.2",
-				"ethereum-cryptography": "^0.1.2",
-				"ethereumjs-abi": "^0.6.8",
-				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.0",
-				"ethereumjs-common": "^1.3.2",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "^6.1.0",
-				"find-up": "^2.1.0",
-				"fp-ts": "1.19.3",
-				"fs-extra": "^7.0.1",
-				"glob": "^7.1.3",
-				"io-ts": "1.10.4",
-				"is-installed-globally": "^0.2.0",
-				"lodash": "^4.17.11",
-				"merkle-patricia-tree": "^3.0.0",
-				"mocha": "^7.1.2",
-				"node-fetch": "^2.6.0",
-				"qs": "^6.7.0",
-				"raw-body": "^2.4.1",
-				"semver": "^6.3.0",
-				"slash": "^3.0.0",
-				"solc": "0.6.8",
-				"source-map-support": "^0.5.13",
-				"ts-essentials": "^2.0.7",
-				"tsort": "0.0.1",
-				"uuid": "^3.3.2",
-				"ws": "^7.2.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				}
-			}
-		},
-		"@nomiclabs/ethereumjs-vm": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
-			"integrity": "sha512-+XwqoO941bILTO4KDLIUJ37U42ySxw6it7jyoi0tKv0/VUcOrWKF1TCQWMv6dBDRlxpPQd273n9o5SVlYYLRWQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.1.2",
-				"async-eventemitter": "^0.2.2",
-				"core-js-pure": "^3.0.1",
-				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.2",
-				"ethereumjs-blockchain": "^4.0.3",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-tx": "^2.1.2",
-				"ethereumjs-util": "^6.2.0",
-				"fake-merkle-patricia-tree": "^1.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"merkle-patricia-tree": "^2.3.2",
-				"rustbn.js": "~0.2.0",
-				"safe-buffer": "^5.1.1",
-				"util.promisify": "^1.0.0"
-			},
-			"dependencies": {
-				"merkle-patricia-tree": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-					"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-					"dev": true,
-					"requires": {
-						"async": "^1.4.2",
-						"ethereumjs-util": "^5.0.0",
-						"level-ws": "0.0.0",
-						"levelup": "^1.2.1",
-						"memdown": "^1.0.0",
-						"readable-stream": "^2.0.0",
-						"rlp": "^2.0.0",
-						"semaphore": ">=1.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-							"dev": true
-						},
-						"ethereumjs-util": {
-							"version": "5.2.1",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-							"dev": true,
-							"requires": {
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"elliptic": "^6.5.2",
-								"ethereum-cryptography": "^0.1.3",
-								"ethjs-util": "^0.1.3",
-								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1"
-							}
-						}
-					}
-				}
-			}
-		},
-		"@sentry/core": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.22.3.tgz",
-			"integrity": "sha512-eGL5uUarw3o4i9QUb9JoFHnhriPpWCaqeaIBB06HUpdcvhrjoowcKZj1+WPec5lFg5XusE35vez7z/FPzmJUDw==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/minimal": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/hub": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.22.3.tgz",
-			"integrity": "sha512-INo47m6N5HFEs/7GMP9cqxOIt7rmRxdERunA3H2L37owjcr77MwHVeeJ9yawRS6FMtbWXplgWTyTIWIYOuqVbw==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/minimal": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.22.3.tgz",
-			"integrity": "sha512-HoINpYnVYCpNjn2XIPIlqH5o4BAITpTljXjtAftOx6Hzj+Opjg8tR8PWliyKDvkXPpc4kXK9D6TpEDw8MO0wZA==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/node": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.22.3.tgz",
-			"integrity": "sha512-TCCKO7hJKiQi1nGmJcQfvbbqv98P08LULh7pb/NaO5pV20t1FtICfGx8UMpORRDehbcAiYq/f7rPOF6X/Xl5iw==",
-			"dev": true,
-			"requires": {
-				"@sentry/core": "5.22.3",
-				"@sentry/hub": "5.22.3",
-				"@sentry/tracing": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"cookie": "^0.4.1",
-				"https-proxy-agent": "^5.0.0",
-				"lru_map": "^0.3.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/tracing": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.22.3.tgz",
-			"integrity": "sha512-Zp59kMCk5v56ZAyErqjv/QvGOWOQ5fRltzeVQVp8unIDTk6gEFXfhwPsYHOokJe1mfkmrgPDV6xAkYgtL3KCDQ==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/minimal": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/types": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.22.3.tgz",
-			"integrity": "sha512-cv+VWK0YFgCVDvD1/HrrBWOWYG3MLuCUJRBTkV/Opdy7nkdNjhCAJQrEyMM9zX0sac8FKWKOHT0sykNh8KgmYw==",
-			"dev": true
-		},
-		"@sentry/utils": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.22.3.tgz",
-			"integrity": "sha512-AHNryXMBvIkIE+GQxTlmhBXD0Ksh+5w1SwM5qi6AttH+1qjWLvV6WB4+4pvVvEoS8t5F+WaVUZPQLmCCWp6zKw==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sindresorhus/is": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-			"dev": true
-		},
-		"@solidity-parser/parser": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
-			"integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==",
-			"dev": true
-		},
-		"@types/bn.js": {
-			"version": "4.11.6",
-			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/debug": {
@@ -254,119 +25,11 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/lru-cache": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-			"integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
-			"dev": true
-		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
-		},
-		"@types/pbkdf2": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^5.0.0"
-			}
-		},
-		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-			"dev": true,
-			"requires": {
-				"xtend": "~4.0.0"
-			}
-		},
-		"agent-base": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
-			"dev": true,
-			"requires": {
-				"debug": "4"
-			}
-		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
-		},
-		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.11.0"
-			}
-		},
-		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
-		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			}
-		},
-		"archive-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
-			"integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
-			"dev": true,
-			"requires": {
-				"file-type": "^4.2.0"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-					"integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
-					"dev": true
-				}
-			}
 		},
 		"arg": {
 			"version": "4.1.3",
@@ -374,248 +37,17 @@
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true
 		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"async-eventemitter": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-			"dev": true,
-			"requires": {
-				"async": "^2.4.0"
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
-		},
-		"base-x": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
-		"binary-extensions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-			"dev": true
-		},
-		"bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"blakejs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
-			"dev": true
-		},
-		"bn.js": {
-			"version": "4.11.9",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
-			"requires": {
-				"fill-range": "^7.0.1"
-			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
-		"browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"dev": true,
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"dev": true,
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"buffer": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
-			}
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
-		},
-		"buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-			"dev": true
-		},
-		"cacheable-request": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"dev": true,
-			"requires": {
-				"clone-response": "1.0.2",
-				"get-stream": "3.0.0",
-				"http-cache-semantics": "3.8.1",
-				"keyv": "3.0.0",
-				"lowercase-keys": "1.0.0",
-				"normalize-url": "2.0.1",
-				"responselike": "1.0.2"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"lowercase-keys": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-					"dev": true
-				}
-			}
-		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"caw": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
-			"dev": true,
-			"requires": {
-				"get-proxy": "^2.0.0",
-				"isurl": "^1.0.0-alpha5",
-				"tunnel-agent": "^0.6.0",
-				"url-to-options": "^1.0.1"
-			}
 		},
 		"chai": {
 			"version": "4.2.0",
@@ -631,314 +63,24 @@
 				"type-detect": "^4.0.5"
 			}
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
-		"checkpoint-store": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
-			"integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
-			"dev": true,
-			"requires": {
-				"functional-red-black-tree": "^1.0.1"
-			}
-		},
-		"chokidar": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-			"dev": true,
-			"requires": {
-				"anymatch": "~3.1.1",
-				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
-				"glob-parent": "~5.1.0",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
-			}
-		},
-		"ci-info": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true
-		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"command-exists": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-			"dev": true
-		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
-		},
-		"config-chain": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.4",
-				"proto-list": "~1.2.1"
-			}
-		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.2"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
-			}
-		},
-		"cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true
-		},
-		"core-js-pure": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-			"dev": true
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
-		},
-		"decompress": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-			"requires": {
-				"decompress-tar": "^4.0.0",
-				"decompress-tarbz2": "^4.0.0",
-				"decompress-targz": "^4.0.0",
-				"decompress-unzip": "^4.0.1",
-				"graceful-fs": "^4.1.10",
-				"make-dir": "^1.0.0",
-				"pify": "^2.3.0",
-				"strip-dirs": "^2.0.0"
-			}
-		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
-		"decompress-tar": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-			"requires": {
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0",
-				"tar-stream": "^1.5.2"
-			}
-		},
-		"decompress-tarbz2": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-			"requires": {
-				"decompress-tar": "^4.1.0",
-				"file-type": "^6.1.0",
-				"is-stream": "^1.1.0",
-				"seek-bzip": "^1.0.5",
-				"unbzip2-stream": "^1.0.9"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
-				}
-			}
-		},
-		"decompress-targz": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-			"requires": {
-				"decompress-tar": "^4.1.1",
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0"
-			}
-		},
-		"decompress-unzip": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-			"requires": {
-				"file-type": "^3.8.0",
-				"get-stream": "^2.2.0",
-				"pify": "^2.3.0",
-				"yauzl": "^2.4.2"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-				}
+				"ms": "2.1.2"
 			}
 		},
 		"deep-eql": {
@@ -950,618 +92,11 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"deepmerge": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
-			"dev": true
-		},
-		"deferred-leveldown": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~2.6.0"
-			}
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
 		"diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
-		},
-		"download": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
-			"integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
-			"dev": true,
-			"requires": {
-				"archive-type": "^4.0.0",
-				"caw": "^2.0.1",
-				"content-disposition": "^0.5.2",
-				"decompress": "^4.2.0",
-				"ext-name": "^5.0.0",
-				"file-type": "^8.1.0",
-				"filenamify": "^2.0.0",
-				"get-stream": "^3.0.0",
-				"got": "^8.3.1",
-				"make-dir": "^1.2.0",
-				"p-event": "^2.1.0",
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-					"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
-					"dev": true
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
-		},
-		"elliptic": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
-			}
-		},
-		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
-		"encoding-down": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-			"integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "^5.0.0",
-				"inherits": "^2.0.3",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"xtend": "^4.0.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"level-codec": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-					"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.6.0"
-					}
-				},
-				"level-errors": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
-					"requires": {
-						"errno": "~0.1.1"
-					}
-				}
-			}
-		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
-		"enquirer": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "^4.1.1"
-			}
-		},
-		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
-			"requires": {
-				"prr": "~1.0.1"
-			}
-		},
-		"es-abstract": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-			"dev": true,
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.2.0",
-				"is-regex": "^1.1.0",
-				"object-inspect": "^1.7.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimend": "^1.0.1",
-				"string.prototype.trimstart": "^1.0.1"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"eth-sig-util": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.3.tgz",
-			"integrity": "sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"elliptic": "^6.4.0",
-				"ethereumjs-abi": "0.6.5",
-				"ethereumjs-util": "^5.1.1",
-				"tweetnacl": "^1.0.0",
-				"tweetnacl-util": "^0.15.0"
-			},
-			"dependencies": {
-				"ethereumjs-abi": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-					"integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.10.0",
-						"ethereumjs-util": "^4.3.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "4.5.1",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-							"integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
-							"dev": true,
-							"requires": {
-								"bn.js": "^4.8.0",
-								"create-hash": "^1.1.2",
-								"elliptic": "^6.5.2",
-								"ethereum-cryptography": "^0.1.3",
-								"rlp": "^2.0.0"
-							}
-						}
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				}
-			}
-		},
-		"ethashjs": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
-			"integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
-			"dev": true,
-			"requires": {
-				"async": "^2.1.2",
-				"buffer-xor": "^2.0.1",
-				"ethereumjs-util": "^7.0.2",
-				"miller-rabin": "^4.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-					"dev": true
-				},
-				"buffer-xor": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-					"integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"ethereumjs-util": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
-					"integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
-					"dev": true,
-					"requires": {
-						"@types/bn.js": "^4.11.3",
-						"bn.js": "^5.1.2",
-						"create-hash": "^1.1.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "0.1.6",
-						"rlp": "^2.2.4"
-					}
-				}
-			}
-		},
-		"ethereum-cryptography": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-			"dev": true,
-			"requires": {
-				"@types/pbkdf2": "^3.0.0",
-				"@types/secp256k1": "^4.0.1",
-				"blakejs": "^1.1.0",
-				"browserify-aes": "^1.2.0",
-				"bs58check": "^2.1.2",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"hash.js": "^1.1.7",
-				"keccak": "^3.0.0",
-				"pbkdf2": "^3.0.17",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.1.2",
-				"scrypt-js": "^3.0.0",
-				"secp256k1": "^4.0.1",
-				"setimmediate": "^1.0.5"
-			}
-		},
-		"ethereumjs-abi": {
-			"version": "0.6.8",
-			"resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-			"integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.8",
-				"ethereumjs-util": "^6.0.0"
-			}
-		},
-		"ethereumjs-account": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
-			"integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-util": "^6.0.0",
-				"rlp": "^2.2.1",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"ethereumjs-block": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-			"integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-			"dev": true,
-			"requires": {
-				"async": "^2.0.1",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "^5.0.0",
-				"merkle-patricia-tree": "^2.1.2"
-			},
-			"dependencies": {
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"merkle-patricia-tree": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-					"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-					"dev": true,
-					"requires": {
-						"async": "^1.4.2",
-						"ethereumjs-util": "^5.0.0",
-						"level-ws": "0.0.0",
-						"levelup": "^1.2.1",
-						"memdown": "^1.0.0",
-						"readable-stream": "^2.0.0",
-						"rlp": "^2.0.0",
-						"semaphore": ">=1.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"ethereumjs-blockchain": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
-			"integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"ethashjs": "~0.0.7",
-				"ethereumjs-block": "~2.2.2",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.1.0",
-				"flow-stoplight": "^1.0.0",
-				"level-mem": "^3.0.1",
-				"lru-cache": "^5.1.1",
-				"rlp": "^2.2.2",
-				"semaphore": "^1.1.0"
-			}
-		},
-		"ethereumjs-common": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
-			"dev": true
-		},
-		"ethereumjs-tx": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-			"integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.0.0"
-			}
-		},
-		"ethereumjs-util": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-			"dev": true,
-			"requires": {
-				"@types/bn.js": "^4.11.3",
-				"bn.js": "^4.11.0",
-				"create-hash": "^1.1.2",
-				"elliptic": "^6.5.2",
-				"ethereum-cryptography": "^0.1.3",
-				"ethjs-util": "0.1.6",
-				"rlp": "^2.2.3"
-			}
-		},
-		"ethjs-util": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-			"dev": true,
-			"requires": {
-				"is-hex-prefixed": "1.0.0",
-				"strip-hex-prefix": "1.0.0"
-			}
-		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true
-		},
-		"evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"ext-list": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
-			"dev": true,
-			"requires": {
-				"mime-db": "^1.28.0"
-			}
-		},
-		"ext-name": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
-			"dev": true,
-			"requires": {
-				"ext-list": "^2.0.0",
-				"sort-keys-length": "^1.0.0"
-			}
-		},
-		"fake-merkle-patricia-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
-			"integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
-			"dev": true,
-			"requires": {
-				"checkpoint-store": "^1.1.0"
-			}
-		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"requires": {
-				"pend": "~1.2.0"
-			}
-		},
-		"file-type": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-		},
-		"filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-			"dev": true
-		},
-		"filenamify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
-			"dev": true,
-			"requires": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.0",
-				"trim-repeated": "^1.0.0"
-			}
-		},
-		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
-		},
-		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
-			"requires": {
-				"locate-path": "^2.0.0"
-			}
-		},
-		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "~2.0.3"
-			}
-		},
-		"flow-stoplight": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
-			"integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=",
-			"dev": true
-		},
-		"fp-ts": {
-			"version": "1.19.3",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
-			"integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
-			"dev": true
-		},
-		"from2": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
-			}
-		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-extra": {
 			"version": "4.0.3",
@@ -1574,35 +109,10 @@
 				"universalify": "^0.1.0"
 			}
 		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"dev": true,
-			"optional": true
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
-		},
 		"ganache-core": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.10.2.tgz",
-			"integrity": "sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==",
+			"version": "2.11.3",
+			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.3.tgz",
+			"integrity": "sha512-SsFJUnyiZI+jW3I43XluXi3TvJC3Ke6vZkvN6NjbWpXvi6dOrmafkyq9Rq07+Qrri6BLGKWoZcG8HfH6ietuqg==",
 			"requires": {
 				"abstract-leveldown": "3.0.0",
 				"async": "2.6.2",
@@ -1618,12 +128,13 @@
 				"ethereumjs-common": "1.5.0",
 				"ethereumjs-tx": "2.1.2",
 				"ethereumjs-util": "6.2.0",
-				"ethereumjs-vm": "4.1.3",
+				"ethereumjs-vm": "4.2.0",
 				"ethereumjs-wallet": "0.6.3",
 				"heap": "0.2.6",
 				"level-sublevel": "6.6.4",
 				"levelup": "3.1.1",
 				"lodash": "4.17.14",
+				"lru-cache": "5.1.1",
 				"merkle-patricia-tree": "2.3.2",
 				"seedrandom": "3.0.1",
 				"source-map-support": "0.5.12",
@@ -1634,30 +145,31 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
-						"@babel/highlight": "^7.8.3"
+						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/core": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-					"integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+					"version": "7.11.1",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+					"integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.3",
-						"@babel/helpers": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/traverse": "^7.8.3",
-						"@babel/types": "^7.8.3",
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.11.0",
+						"@babel/helper-module-transforms": "^7.11.0",
+						"@babel/helpers": "^7.10.4",
+						"@babel/parser": "^7.11.1",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.11.0",
+						"@babel/types": "^7.11.0",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.13",
+						"json5": "^2.1.2",
+						"lodash": "^4.17.19",
 						"resolve": "^1.3.2",
 						"semver": "^5.4.1",
 						"source-map": "^0.5.0"
@@ -1672,17 +184,17 @@
 							}
 						},
 						"json5": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-							"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+							"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 							"requires": {
-								"minimist": "^1.2.0"
+								"minimist": "^1.2.5"
 							}
 						},
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"semver": {
 							"version": "5.7.1",
@@ -1697,13 +209,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-					"integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+					"integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
 					"requires": {
-						"@babel/types": "^7.8.3",
+						"@babel/types": "^7.11.0",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					},
 					"dependencies": {
@@ -1720,48 +231,118 @@
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
 					"requires": {
-						"@babel/types": "^7.8.3"
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+					"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-simple-access": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.11.0",
+						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+						}
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+					"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+					"requires": {
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 					"requires": {
-						"@babel/types": "^7.8.3"
+						"@babel/types": "^7.11.0"
 					}
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
 				"@babel/helpers": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-					"integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+					"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
 					"requires": {
-						"@babel/template": "^7.8.3",
-						"@babel/traverse": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					},
 					"dependencies": {
@@ -1799,49 +380,34 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-					"integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
-				},
-				"@babel/runtime": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-					"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					},
-					"dependencies": {
-						"regenerator-runtime": {
-							"version": "0.13.3",
-							"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-							"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-						}
-					}
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
 				},
 				"@babel/template": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-					"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-					"integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+					"integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.3",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/types": "^7.8.3",
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.11.0",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.11.0",
+						"@babel/types": "^7.11.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
+						"lodash": "^4.17.19"
 					},
 					"dependencies": {
 						"debug": {
@@ -1856,19 +422,29 @@
 							"version": "11.12.0",
 							"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 							"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+						},
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+					"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					},
 					"dependencies": {
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+						},
 						"to-fast-properties": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1877,12 +453,13 @@
 					}
 				},
 				"@istanbuljs/load-nyc-config": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-					"integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+					"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 					"requires": {
 						"camelcase": "^5.3.1",
 						"find-up": "^4.1.0",
+						"get-package-type": "^0.1.0",
 						"js-yaml": "^3.13.1",
 						"resolve-from": "^5.0.0"
 					},
@@ -1910,9 +487,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -1989,15 +566,36 @@
 					"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 					"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 				},
+				"@types/json-schema": {
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+					"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+				},
 				"@types/node": {
-					"version": "13.5.2",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
-					"integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
+					"version": "14.0.27",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+					"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
 				},
 				"@types/parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+				},
+				"@types/pbkdf2": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+					"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/secp256k1": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+					"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+					"requires": {
+						"@types/node": "*"
+					}
 				},
 				"@types/web3": {
 					"version": "1.2.2",
@@ -2052,11 +650,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 						}
 					}
 				},
@@ -2246,14 +839,14 @@
 					}
 				},
 				"acorn": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
 				},
 				"acorn-jsx": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-					"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 				},
 				"aes-js": {
 					"version": "3.1.2",
@@ -2278,9 +871,9 @@
 					}
 				},
 				"ajv": {
-					"version": "6.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-					"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+					"version": "6.12.3",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+					"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -2294,9 +887,9 @@
 					"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 				},
 				"ajv-keywords": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-					"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 				},
 				"ansi-colors": {
 					"version": "1.1.0",
@@ -2307,11 +900,18 @@
 					}
 				},
 				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "^0.11.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.11.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+							"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+						}
 					}
 				},
 				"ansi-gray": {
@@ -2354,6 +954,16 @@
 					"requires": {
 						"micromatch": "^3.1.4",
 						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
 					}
 				},
 				"append-buffer": {
@@ -2622,9 +1232,9 @@
 					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 				},
 				"aws4": {
-					"version": "1.9.1",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-					"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+					"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
@@ -3173,11 +1783,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"source-map": {
@@ -3352,10 +1962,9 @@
 					}
 				},
 				"base-x": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-					"integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
-					"optional": true,
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+					"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -3430,7 +2039,55 @@
 					"requires": {
 						"readable-stream": "^2.3.5",
 						"safe-buffer": "^5.1.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
+						}
 					}
+				},
+				"blakejs": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+					"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 				},
 				"bluebird": {
 					"version": "3.7.2",
@@ -3438,9 +2095,9 @@
 					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+					"version": "4.11.9",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 				},
 				"body-parser": {
 					"version": "1.19.0",
@@ -3572,27 +2229,27 @@
 						"randombytes": "^2.0.1"
 					}
 				},
-				"browserify-sha3": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-					"integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-					"requires": {
-						"js-sha3": "^0.6.1",
-						"safe-buffer": "^5.1.1"
-					}
-				},
 				"browserify-sign": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-					"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+					"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
 					"requires": {
-						"bn.js": "^4.1.1",
-						"browserify-rsa": "^4.0.0",
-						"create-hash": "^1.1.0",
-						"create-hmac": "^1.1.2",
-						"elliptic": "^6.0.0",
-						"inherits": "^2.0.1",
-						"parse-asn1": "^5.0.0"
+						"bn.js": "^5.1.1",
+						"browserify-rsa": "^4.0.1",
+						"create-hash": "^1.2.0",
+						"create-hmac": "^1.1.7",
+						"elliptic": "^6.5.3",
+						"inherits": "^2.0.4",
+						"parse-asn1": "^5.1.5",
+						"readable-stream": "^3.6.0",
+						"safe-buffer": "^5.2.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+							"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+						}
 					}
 				},
 				"browserify-zlib": {
@@ -3616,7 +2273,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-					"optional": true,
 					"requires": {
 						"base-x": "^3.0.2"
 					}
@@ -3625,7 +2281,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
 					"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-					"optional": true,
 					"requires": {
 						"bs58": "^4.0.0",
 						"create-hash": "^1.1.0",
@@ -3633,9 +2288,9 @@
 					}
 				},
 				"buffer": {
-					"version": "5.4.3",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-					"integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -3745,35 +2400,20 @@
 								"minipass": "^3.0.0"
 							}
 						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"requires": {
-								"yallist": "^3.0.2"
-							},
-							"dependencies": {
-								"yallist": {
-									"version": "3.1.1",
-									"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-									"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-								}
-							}
-						},
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"p-map": {
@@ -3852,6 +2492,14 @@
 							"requires": {
 								"xtend": "~4.0.0"
 							}
+						},
+						"lru-cache": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+							"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+							"requires": {
+								"pseudomap": "^1.0.1"
+							}
 						}
 					}
 				},
@@ -3867,9 +2515,9 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -3892,9 +2540,9 @@
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001023",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
-					"integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA=="
+					"version": "1.0.30001111",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
+					"integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg=="
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -3943,19 +2591,12 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-						}
 					}
 				},
 				"chownr": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-					"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 				},
 				"chrome-trace-event": {
 					"version": "1.0.2",
@@ -4030,9 +2671,9 @@
 					}
 				},
 				"cli-width": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+					"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -4075,30 +2716,46 @@
 						"inherits": "^2.0.1",
 						"process-nextick-args": "^2.0.0",
 						"readable-stream": "^2.3.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-				},
-				"coinstring": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
-					"integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
-					"optional": true,
-					"requires": {
-						"bs58": "^2.0.1",
-						"create-hash": "^1.1.1"
-					},
-					"dependencies": {
-						"bs58": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-							"integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
-							"optional": true
-						}
-					}
 				},
 				"collection-map": {
 					"version": "1.0.0",
@@ -4146,17 +2803,14 @@
 					}
 				},
 				"command-exists": {
-					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-					"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+					"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
 				},
 				"commander": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				},
 				"commondir": {
 					"version": "1.0.1",
@@ -4182,6 +2836,40 @@
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.2.2",
 						"typedarray": "^0.0.6"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"console-browserify": {
@@ -4263,11 +2951,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -4292,9 +2980,9 @@
 					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"core-js-pure": {
-					"version": "3.6.4",
-					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-					"integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+					"version": "3.6.5",
+					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+					"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4323,9 +3011,9 @@
 					},
 					"dependencies": {
 						"parse-json": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-							"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+							"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
 							"requires": {
 								"@babel/code-frame": "^7.0.0",
 								"error-ex": "^1.3.1",
@@ -4341,31 +3029,24 @@
 					}
 				},
 				"coveralls": {
-					"version": "3.0.9",
-					"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-					"integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+					"integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
 					"requires": {
 						"js-yaml": "^3.13.1",
 						"lcov-parse": "^1.0.0",
 						"log-driver": "^1.2.7",
-						"minimist": "^1.2.0",
-						"request": "^2.88.0"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-						}
+						"minimist": "^1.2.5",
+						"request": "^2.88.2"
 					}
 				},
 				"create-ecdh": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-					"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+					"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 					"requires": {
 						"bn.js": "^4.1.0",
-						"elliptic": "^6.0.0"
+						"elliptic": "^6.5.3"
 					}
 				},
 				"create-hash": {
@@ -4411,9 +3092,9 @@
 					}
 				},
 				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 					"requires": {
 						"path-key": "^3.1.0",
 						"shebang-command": "^2.0.0",
@@ -4492,6 +3173,28 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"decompress": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+					"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+					"requires": {
+						"decompress-tar": "^4.0.0",
+						"decompress-tarbz2": "^4.0.0",
+						"decompress-targz": "^4.0.0",
+						"decompress-unzip": "^4.0.1",
+						"graceful-fs": "^4.1.10",
+						"make-dir": "^1.0.0",
+						"pify": "^2.3.0",
+						"strip-dirs": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
 				},
 				"decompress-response": {
 					"version": "3.3.0",
@@ -4778,9 +3481,9 @@
 					}
 				},
 				"dom-walk": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-					"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 				},
 				"domain-browser": {
 					"version": "1.2.0",
@@ -4819,6 +3522,40 @@
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"each-props": {
@@ -4845,9 +3582,9 @@
 					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.341",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
-					"integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g=="
+					"version": "1.3.521",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.521.tgz",
+					"integrity": "sha512-7/Cf5jUuAfLRY8SjfRES/6+9BDvmHAB2YQotCAaXK0IEacpjoSlyosPoC4s7lfb7vIOBubXvsssu8+8qaRGjcg=="
 				},
 				"elegant-spinner": {
 					"version": "1.0.1",
@@ -4855,9 +3592,9 @@
 					"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 				},
 				"elliptic": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+					"version": "6.5.3",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 					"requires": {
 						"bn.js": "^4.4.0",
 						"brorand": "^1.0.1",
@@ -4874,9 +3611,9 @@
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
 				"emojis-list": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
 				},
 				"encodeurl": {
 					"version": "1.0.2",
@@ -4884,11 +3621,21 @@
 					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 				},
 				"encoding": {
-					"version": "0.1.12",
-					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"version": "0.1.13",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+					"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 					"requires": {
-						"iconv-lite": "~0.4.13"
+						"iconv-lite": "^0.6.2"
+					},
+					"dependencies": {
+						"iconv-lite": {
+							"version": "0.6.2",
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+							"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3.0.0"
+							}
+						}
 					}
 				},
 				"encoding-down": {
@@ -4922,15 +3669,20 @@
 					}
 				},
 				"enhanced-resolve": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-					"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+					"integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"memory-fs": "^0.5.0",
 						"tapable": "^1.0.0"
 					},
 					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
 						"memory-fs": {
 							"version": "0.5.0",
 							"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -4938,6 +3690,33 @@
 							"requires": {
 								"errno": "^0.1.3",
 								"readable-stream": "^2.0.1"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
@@ -4959,21 +3738,21 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"version": "1.17.6",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+					"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
+						"is-callable": "^1.2.0",
+						"is-regex": "^1.1.0",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
 					},
 					"dependencies": {
 						"object-keys": {
@@ -5143,27 +3922,27 @@
 							}
 						},
 						"glob-parent": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-							"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 							"requires": {
 								"is-glob": "^4.0.1"
 							}
 						},
 						"globals": {
-							"version": "12.3.0",
-							"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-							"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+							"version": "12.4.0",
+							"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+							"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 							"requires": {
 								"type-fest": "^0.8.1"
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"path-key": {
@@ -5213,9 +3992,9 @@
 					"integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA=="
 				},
 				"eslint-import-resolver-node": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-					"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+					"version": "0.3.4",
+					"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+					"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
 					"requires": {
 						"debug": "^2.6.9",
 						"resolve": "^1.13.1"
@@ -5237,9 +4016,9 @@
 					}
 				},
 				"eslint-module-utils": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-					"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+					"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 					"requires": {
 						"debug": "^2.6.9",
 						"pkg-dir": "^2.0.0"
@@ -5261,26 +4040,26 @@
 					}
 				},
 				"eslint-plugin-es": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-					"integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+					"integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
 					"requires": {
 						"eslint-utils": "^2.0.0",
 						"regexpp": "^3.0.0"
 					},
 					"dependencies": {
 						"eslint-utils": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-							"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+							"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 							"requires": {
 								"eslint-visitor-keys": "^1.1.0"
 							}
 						},
 						"regexpp": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-							"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+							"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
 						}
 					}
 				},
@@ -5402,17 +4181,17 @@
 					},
 					"dependencies": {
 						"eslint-utils": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-							"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+							"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 							"requires": {
 								"eslint-visitor-keys": "^1.1.0"
 							}
 						},
 						"ignore": {
-							"version": "5.1.4",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-							"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+							"version": "5.1.8",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+							"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
 						},
 						"semver": {
 							"version": "6.3.0",
@@ -5432,9 +4211,9 @@
 					"integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ=="
 				},
 				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
@@ -5449,17 +4228,17 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
 				},
 				"espree": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-					"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 					"requires": {
-						"acorn": "^7.1.0",
-						"acorn-jsx": "^5.1.0",
+						"acorn": "^7.1.1",
+						"acorn-jsx": "^5.2.0",
 						"eslint-visitor-keys": "^1.1.0"
 					}
 				},
@@ -5469,11 +4248,18 @@
 					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"esquery": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-					"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+					"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 					"requires": {
-						"estraverse": "^4.0.0"
+						"estraverse": "^5.1.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+						}
 					}
 				},
 				"esrecurse": {
@@ -5523,17 +4309,17 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"pify": {
@@ -5634,17 +4420,17 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -5678,28 +4464,17 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -5714,36 +4489,20 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
-									}
-								},
-								"keccak": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-									"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-									"requires": {
-										"bindings": "^1.5.0",
-										"inherits": "^2.0.4",
-										"nan": "^2.14.0",
-										"safe-buffer": "^5.2.0"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 						}
 					}
 				},
@@ -5792,31 +4551,31 @@
 							},
 							"dependencies": {
 								"ethereumjs-util": {
-									"version": "4.5.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-									"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+									"version": "4.5.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+									"integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
 									"requires": {
 										"bn.js": "^4.8.0",
 										"create-hash": "^1.1.2",
-										"keccakjs": "^0.2.0",
-										"rlp": "^2.0.0",
-										"secp256k1": "^3.0.1"
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
+										"rlp": "^2.0.0"
 									}
 								}
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						}
 					}
@@ -5882,17 +4641,17 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -5926,28 +4685,17 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -5962,88 +4710,96 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
-									}
-								},
-								"keccak": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-									"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-									"requires": {
-										"bindings": "^1.5.0",
-										"inherits": "^2.0.4",
-										"nan": "^2.14.0",
-										"safe-buffer": "^5.2.0"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 						}
 					}
 				},
 				"ethashjs": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
-					"integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+					"integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
 					"requires": {
-						"async": "^1.4.2",
-						"buffer-xor": "^1.0.3",
-						"ethereumjs-util": "^4.0.1",
+						"async": "^2.1.2",
+						"buffer-xor": "^2.0.1",
+						"ethereumjs-util": "^7.0.2",
 						"miller-rabin": "^4.0.0"
 					},
 					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+						"bn.js": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+							"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+						},
+						"buffer-xor": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+							"integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+							"requires": {
+								"safe-buffer": "^5.1.1"
+							}
 						},
 						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+							"version": "7.0.4",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
+							"integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
 							"requires": {
-								"bn.js": "^4.8.0",
+								"@types/bn.js": "^4.11.3",
+								"bn.js": "^5.1.2",
 								"create-hash": "^1.1.2",
-								"keccakjs": "^0.2.0",
-								"rlp": "^2.0.0",
-								"secp256k1": "^3.0.1"
+								"ethereum-cryptography": "^0.1.3",
+								"ethjs-util": "0.1.6",
+								"rlp": "^2.2.4"
 							}
 						}
 					}
 				},
 				"ethereum-bloom-filters": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
-					"integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+					"integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
 					"requires": {
 						"js-sha3": "^0.8.0"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.8.0",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-							"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-						}
 					}
 				},
 				"ethereum-common": {
 					"version": "0.0.18",
 					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 					"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+				},
+				"ethereum-cryptography": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+					"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+					"requires": {
+						"@types/pbkdf2": "^3.0.0",
+						"@types/secp256k1": "^4.0.1",
+						"blakejs": "^1.1.0",
+						"browserify-aes": "^1.2.0",
+						"bs58check": "^2.1.2",
+						"create-hash": "^1.2.0",
+						"create-hmac": "^1.1.7",
+						"hash.js": "^1.1.7",
+						"keccak": "^3.0.0",
+						"pbkdf2": "^3.0.17",
+						"randombytes": "^2.1.0",
+						"safe-buffer": "^5.1.2",
+						"scrypt-js": "^3.0.0",
+						"secp256k1": "^4.0.1",
+						"setimmediate": "^1.0.5"
+					}
 				},
 				"ethereumjs-abi": {
 					"version": "0.6.7",
@@ -6077,60 +4833,36 @@
 					},
 					"dependencies": {
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						}
 					}
 				},
 				"ethereumjs-blockchain": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
-					"integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+					"integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
 					"requires": {
 						"async": "^2.6.1",
 						"ethashjs": "~0.0.7",
 						"ethereumjs-block": "~2.2.2",
 						"ethereumjs-common": "^1.5.0",
-						"ethereumjs-util": "~6.1.0",
+						"ethereumjs-util": "^6.1.0",
 						"flow-stoplight": "^1.0.0",
 						"level-mem": "^3.0.1",
 						"lru-cache": "^5.1.1",
 						"rlp": "^2.2.2",
 						"semaphore": "^1.1.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-							"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-							"requires": {
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"ethjs-util": "0.1.6",
-								"keccak": "^1.0.2",
-								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
-							}
-						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"requires": {
-								"yallist": "^3.0.2"
-							}
-						}
 					}
 				},
 				"ethereumjs-common": {
@@ -6172,17 +4904,27 @@
 								"safe-buffer": "^5.2.0"
 							}
 						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+						"secp256k1": {
+							"version": "3.8.0",
+							"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+							"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+							"requires": {
+								"bindings": "^1.5.0",
+								"bip66": "^1.1.5",
+								"bn.js": "^4.11.8",
+								"create-hash": "^1.2.0",
+								"drbg.js": "^1.0.1",
+								"elliptic": "^6.5.2",
+								"nan": "^2.14.0",
+								"safe-buffer": "^5.1.2"
+							}
 						}
 					}
 				},
 				"ethereumjs-vm": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.3.tgz",
-					"integrity": "sha512-RTrD0y7My4O6Qr1P2ZIsMfD6RzL6kU/RhBZ0a5XrPzAeR61crBS7or66ohDrvxDI/rDBxMi+6SnsELih6fzalw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+					"integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
 					"requires": {
 						"async": "^2.1.2",
 						"async-eventemitter": "^0.2.2",
@@ -6199,38 +4941,6 @@
 						"rustbn.js": "~0.2.0",
 						"safe-buffer": "^5.1.1",
 						"util.promisify": "^1.0.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "6.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-							"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-							"requires": {
-								"@types/bn.js": "^4.11.3",
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"ethjs-util": "0.1.6",
-								"keccak": "^2.0.0",
-								"rlp": "^2.2.3",
-								"secp256k1": "^3.0.1"
-							}
-						},
-						"keccak": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-							"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-							"requires": {
-								"bindings": "^1.5.0",
-								"inherits": "^2.0.4",
-								"nan": "^2.14.0",
-								"safe-buffer": "^5.2.0"
-							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-						}
 					}
 				},
 				"ethereumjs-wallet": {
@@ -6270,6 +4980,20 @@
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
 							"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+						},
+						"elliptic": {
+							"version": "6.5.2",
+							"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+							"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+							"requires": {
+								"bn.js": "^4.4.0",
+								"brorand": "^1.0.1",
+								"hash.js": "^1.0.0",
+								"hmac-drbg": "^1.0.0",
+								"inherits": "^2.0.1",
+								"minimalistic-assert": "^1.0.0",
+								"minimalistic-crypto-utils": "^1.0.0"
+							}
 						},
 						"hash.js": {
 							"version": "1.1.3",
@@ -6333,9 +5057,9 @@
 					"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 				},
 				"events": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-					"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+					"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
 				},
 				"evp_bytestokey": {
 					"version": "1.0.3",
@@ -6636,9 +5360,9 @@
 					}
 				},
 				"fast-deep-equal": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.1.0",
@@ -6678,14 +5402,14 @@
 					}
 				},
 				"figgy-pudding": {
-					"version": "3.5.1",
-					"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+					"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
 				},
 				"figures": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+					"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
 					}
@@ -6764,12 +5488,12 @@
 					}
 				},
 				"find-cache-dir": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.0",
+						"make-dir": "^3.0.2",
 						"pkg-dir": "^4.1.0"
 					},
 					"dependencies": {
@@ -6791,17 +5515,17 @@
 							}
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -6912,9 +5636,9 @@
 					}
 				},
 				"flatted": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-					"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+					"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
 				},
 				"flow-stoplight": {
 					"version": "1.0.0",
@@ -6928,6 +5652,40 @@
 					"requires": {
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.3.6"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"for-each": {
@@ -7000,12 +5758,46 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"fromentries": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-					"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+					"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw=="
 				},
 				"fs-constants": {
 					"version": "1.0.0",
@@ -7048,385 +5840,17 @@
 						"iferr": "^0.1.5",
 						"imurmurhash": "^0.1.4",
 						"readable-stream": "1 || 2"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"fsevents": {
-					"version": "1.2.11",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-					"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1",
-						"node-pre-gyp": "*"
 					},
 					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.5",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.1.3",
-							"bundled": true,
-							"optional": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "3.2.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						},
-						"deep-extend": {
-							"version": "0.6.0",
-							"bundled": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.7",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.6.0"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.4",
-							"bundled": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.3.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.9.0"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.4.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"debug": "^3.2.6",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.14.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.1",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.2.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4.4.2"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.1.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"npm-normalize-package-bin": "^1.0.1"
-							}
-						},
-						"npm-normalize-package-bin": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.4.7",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.8",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.6.0",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"optional": true
-								}
-							}
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 						},
 						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"optional": true,
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -7437,112 +5861,34 @@
 								"util-deprecate": "~1.0.1"
 							}
 						},
-						"rimraf": {
-							"version": "2.7.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.7.1",
-							"bundled": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
-							"optional": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
 							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"tar": {
-							"version": "4.4.13",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.8.6",
-								"minizlib": "^1.2.1",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.3"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2 || 2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.1.1",
-							"bundled": true,
-							"optional": true
 						}
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
 					}
 				},
 				"function-bind": {
@@ -7574,6 +5920,11 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
 					"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+				},
+				"get-package-type": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+					"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
 				},
 				"get-stream": {
 					"version": "4.1.0",
@@ -7643,18 +5994,53 @@
 						"remove-trailing-separator": "^1.0.1",
 						"to-absolute-glob": "^2.0.0",
 						"unique-stream": "^2.0.2"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"glob-watcher": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
-					"integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
+					"integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
 					"requires": {
 						"anymatch": "^2.0.0",
 						"async-done": "^1.2.0",
 						"chokidar": "^2.0.0",
 						"is-negated-glob": "^1.0.0",
 						"just-debounce": "^1.0.0",
+						"normalize-path": "^3.0.0",
 						"object.defaults": "^1.1.0"
 					}
 				},
@@ -7721,14 +6107,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-				},
-				"graceful-readlink": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-					"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 				},
 				"growl": {
 					"version": "1.10.5",
@@ -7747,9 +6128,9 @@
 					},
 					"dependencies": {
 						"gulp-cli": {
-							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-							"integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+							"integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
 							"requires": {
 								"ansi-colors": "^1.0.1",
 								"archy": "^1.0.0",
@@ -7759,7 +6140,7 @@
 								"copy-props": "^2.0.1",
 								"fancy-log": "^1.3.2",
 								"gulplog": "^1.0.0",
-								"interpret": "^1.1.0",
+								"interpret": "^1.4.0",
 								"isobject": "^3.0.1",
 								"liftoff": "^3.1.0",
 								"matchdep": "^2.0.0",
@@ -7767,7 +6148,7 @@
 								"pretty-hrtime": "^1.0.0",
 								"replace-homedir": "^1.0.0",
 								"semver-greatest-satisfied-range": "^1.1.0",
-								"v8flags": "^3.0.1",
+								"v8flags": "^3.2.0",
 								"yargs": "^7.1.0"
 							}
 						}
@@ -7787,11 +6168,11 @@
 					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 				},
 				"har-validator": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-					"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+					"version": "5.1.5",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+					"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 					"requires": {
-						"ajv": "^6.5.5",
+						"ajv": "^6.12.3",
 						"har-schema": "^2.0.0"
 					}
 				},
@@ -7864,12 +6245,13 @@
 					}
 				},
 				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+					"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
 					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.6.0",
+						"safe-buffer": "^5.2.0"
 					}
 				},
 				"hash.js": {
@@ -7882,9 +6264,9 @@
 					}
 				},
 				"hasha": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-					"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+					"integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
 					"requires": {
 						"is-stream": "^2.0.0",
 						"type-fest": "^0.8.0"
@@ -7898,14 +6280,32 @@
 					}
 				},
 				"hdkey": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
-					"integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
+					"integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
 					"optional": true,
 					"requires": {
-						"coinstring": "^2.0.0",
+						"bs58check": "^2.1.2",
 						"safe-buffer": "^5.1.1",
 						"secp256k1": "^3.0.1"
+					},
+					"dependencies": {
+						"secp256k1": {
+							"version": "3.8.0",
+							"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+							"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+							"optional": true,
+							"requires": {
+								"bindings": "^1.5.0",
+								"bip66": "^1.1.5",
+								"bn.js": "^4.11.8",
+								"create-hash": "^1.2.0",
+								"drbg.js": "^1.0.1",
+								"elliptic": "^6.5.2",
+								"nan": "^2.14.0",
+								"safe-buffer": "^5.1.2"
+							}
+						}
 					}
 				},
 				"he": {
@@ -7946,19 +6346,19 @@
 					}
 				},
 				"hosted-git-info": {
-					"version": "2.8.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-					"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+					"version": "2.8.8",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 				},
 				"html-escaper": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-					"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+					"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
 				},
 				"http-cache-semantics": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-					"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 				},
 				"http-errors": {
 					"version": "1.7.2",
@@ -8078,9 +6478,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -8165,9 +6565,9 @@
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 				},
 				"immediate": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+					"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
 				},
 				"import-fresh": {
 					"version": "3.2.1",
@@ -8205,9 +6605,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -8275,22 +6675,22 @@
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 				},
 				"inquirer": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-					"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+					"version": "7.3.3",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+					"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
 					"requires": {
 						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
+						"chalk": "^4.1.0",
 						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
+						"cli-width": "^3.0.0",
 						"external-editor": "^3.0.3",
 						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
+						"lodash": "^4.17.19",
 						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
+						"run-async": "^2.4.0",
+						"rxjs": "^6.6.0",
 						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
+						"strip-ansi": "^6.0.0",
 						"through": "^2.3.6"
 					},
 					"dependencies": {
@@ -8300,22 +6700,40 @@
 							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 						},
 						"ansi-styles": {
-							"version": "3.2.1",
-							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"version": "4.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+							"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 							"requires": {
-								"color-convert": "^1.9.0"
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
 							}
 						},
 						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
 							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+						},
+						"has-flag": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 						},
 						"is-fullwidth-code-point": {
 							"version": "3.0.0",
@@ -8323,9 +6741,9 @@
 							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 						},
 						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"string-width": {
 							"version": "4.2.0",
@@ -8335,47 +6753,30 @@
 								"emoji-regex": "^8.0.0",
 								"is-fullwidth-code-point": "^3.0.0",
 								"strip-ansi": "^6.0.0"
-							},
-							"dependencies": {
-								"strip-ansi": {
-									"version": "6.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-									"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-									"requires": {
-										"ansi-regex": "^5.0.0"
-									}
-								}
 							}
 						},
 						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 							"requires": {
-								"ansi-regex": "^4.1.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "4.1.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-									"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-								}
+								"ansi-regex": "^5.0.0"
 							}
 						},
 						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"version": "7.1.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+							"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 							"requires": {
-								"has-flag": "^3.0.0"
+								"has-flag": "^4.0.0"
 							}
 						}
 					}
 				},
 				"interpret": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+					"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
 				},
 				"invariant": {
 					"version": "2.2.4",
@@ -8391,9 +6792,9 @@
 					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 				},
 				"ipaddr.js": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-					"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+					"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 				},
 				"is-absolute": {
 					"version": "1.0.0",
@@ -8446,9 +6847,9 @@
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+					"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
@@ -8501,12 +6902,9 @@
 					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-finite": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+					"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
 				},
 				"is-fn": {
 					"version": "1.0.0",
@@ -8522,9 +6920,9 @@
 					}
 				},
 				"is-function": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-					"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
 				},
 				"is-glob": {
 					"version": "4.0.1",
@@ -8599,16 +6997,16 @@
 					}
 				},
 				"is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-					"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+					"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
 				},
 				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 					"requires": {
-						"has": "^1.0.3"
+						"has-symbols": "^1.0.1"
 					}
 				},
 				"is-regexp": {
@@ -8714,14 +7112,11 @@
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
-					"integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 					"requires": {
 						"@babel/core": "^7.7.5",
-						"@babel/parser": "^7.7.5",
-						"@babel/template": "^7.7.4",
-						"@babel/traverse": "^7.7.4",
 						"@istanbuljs/schema": "^0.1.2",
 						"istanbul-lib-coverage": "^3.0.0",
 						"semver": "^6.3.0"
@@ -8749,9 +7144,9 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -8765,9 +7160,9 @@
 							}
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -8795,9 +7190,9 @@
 							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -8838,9 +7233,9 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 					"requires": {
 						"html-escaper": "^2.0.0",
 						"istanbul-lib-report": "^3.0.0"
@@ -8883,9 +7278,9 @@
 					}
 				},
 				"js-sha3": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-					"integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA="
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 				},
 				"js-tokens": {
 					"version": "3.0.2",
@@ -8893,9 +7288,9 @@
 					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 				},
 				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -9010,23 +7405,12 @@
 					"integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
 				},
 				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+					"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
-				},
-				"keccakjs": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-					"integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-					"requires": {
-						"browserify-sha3": "^0.0.4",
-						"sha3": "^1.2.2"
+						"node-addon-api": "^2.0.0",
+						"node-gyp-build": "^4.2.0"
 					}
 				},
 				"keyv": {
@@ -9065,6 +7449,40 @@
 					"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
 					"requires": {
 						"readable-stream": "^2.0.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"lcid": {
@@ -9089,9 +7507,12 @@
 					}
 				},
 				"level-codec": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-					"integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+					"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+					"requires": {
+						"buffer": "^5.6.0"
+					}
 				},
 				"level-concat-iterator": {
 					"version": "2.0.1",
@@ -9135,6 +7556,11 @@
 								"isarray": "0.0.1",
 								"string_decoder": "~0.10.x"
 							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 						}
 					}
 				},
@@ -9154,6 +7580,11 @@
 							"requires": {
 								"xtend": "~4.0.0"
 							}
+						},
+						"immediate": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+							"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 						},
 						"memdown": {
 							"version": "3.0.0",
@@ -9209,6 +7640,11 @@
 						"xtend": "~4.0.0"
 					},
 					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
 						"level-iterator-stream": {
 							"version": "2.0.3",
 							"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
@@ -9223,6 +7659,33 @@
 							"version": "2.1.3",
 							"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
 							"integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
 						}
 					}
 				},
@@ -9253,6 +7716,11 @@
 								"isarray": "0.0.1",
 								"string_decoder": "~0.10.x"
 							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 						},
 						"xtend": {
 							"version": "2.1.2",
@@ -9292,6 +7760,11 @@
 								"inherits": "^2.0.3"
 							}
 						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
 						"level-iterator-stream": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
@@ -9300,6 +7773,33 @@
 								"inherits": "^2.0.1",
 								"readable-stream": "^2.3.6",
 								"xtend": "^4.0.0"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
@@ -9392,9 +7892,9 @@
 							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 						},
 						"commander": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-							"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+							"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
 						},
 						"debug": {
 							"version": "4.1.1",
@@ -9430,11 +7930,6 @@
 								"braces": "^3.0.1",
 								"picomatch": "^2.0.5"
 							}
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 						},
 						"supports-color": {
 							"version": "7.1.0",
@@ -9611,12 +8106,12 @@
 					"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 				},
 				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 					"requires": {
 						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
+						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
 					},
 					"dependencies": {
@@ -9627,11 +8122,6 @@
 							"requires": {
 								"minimist": "^1.2.0"
 							}
-						},
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 						}
 					}
 				},
@@ -9809,11 +8299,11 @@
 					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 				},
 				"lru-cache": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
-						"pseudomap": "^1.0.1"
+						"yallist": "^3.0.2"
 					}
 				},
 				"ltgt": {
@@ -9941,14 +8431,21 @@
 					},
 					"dependencies": {
 						"abstract-leveldown": {
-							"version": "6.2.2",
-							"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
-							"integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
+							"version": "6.2.3",
+							"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+							"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
 							"requires": {
+								"buffer": "^5.5.0",
+								"immediate": "^3.2.3",
 								"level-concat-iterator": "~2.0.0",
 								"level-supports": "~1.0.0",
 								"xtend": "~4.0.0"
 							}
+						},
+						"immediate": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+							"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 						}
 					}
 				},
@@ -9959,6 +8456,40 @@
 					"requires": {
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"memorystream": {
@@ -10005,18 +8536,23 @@
 							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 						},
 						"level-codec": {
 							"version": "7.0.1",
@@ -10065,10 +8601,46 @@
 								}
 							}
 						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
+						},
 						"semver": {
 							"version": "5.4.1",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
 							"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
 						}
 					}
 				},
@@ -10112,16 +8684,16 @@
 					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 				},
 				"mime-db": {
-					"version": "1.43.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+					"version": "1.44.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
 				},
 				"mime-types": {
-					"version": "2.1.26",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+					"version": "2.1.27",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 					"requires": {
-						"mime-db": "1.43.0"
+						"mime-db": "1.44.0"
 					}
 				},
 				"mimic-fn": {
@@ -10161,9 +8733,9 @@
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				},
 				"minipass": {
 					"version": "2.9.0",
@@ -10183,9 +8755,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -10206,9 +8778,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -10221,17 +8793,17 @@
 					}
 				},
 				"minipass-pipeline": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-					"integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+					"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
 					"requires": {
 						"minipass": "^3.0.0"
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -10288,9 +8860,9 @@
 					}
 				},
 				"mkdirp": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-					"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"mkdirp-promise": {
 					"version": "5.0.1",
@@ -10359,9 +8931,9 @@
 							}
 						},
 						"binary-extensions": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-							"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+							"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
 						},
 						"braces": {
 							"version": "3.0.2",
@@ -10443,9 +9015,9 @@
 							}
 						},
 						"fsevents": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-							"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+							"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 							"optional": true
 						},
 						"get-caller-file": {
@@ -10467,9 +9039,9 @@
 							}
 						},
 						"glob-parent": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-							"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 							"requires": {
 								"is-glob": "^4.0.1"
 							}
@@ -10492,6 +9064,15 @@
 							"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 						},
+						"js-yaml": {
+							"version": "3.13.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+							"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						},
 						"locate-path": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -10509,6 +9090,11 @@
 								"chalk": "^2.0.1"
 							}
 						},
+						"minimist": {
+							"version": "0.0.8",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+						},
 						"mkdirp": {
 							"version": "0.5.1",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -10522,15 +9108,10 @@
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -10659,9 +9240,9 @@
 					"integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q="
 				},
 				"mock-fs": {
-					"version": "4.10.4",
-					"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
-					"integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+					"integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
@@ -10677,11 +9258,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -10702,9 +9283,9 @@
 					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 				},
 				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+					"version": "2.14.1",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+					"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 				},
 				"nano-json-stream-parser": {
 					"version": "0.1.2",
@@ -10740,9 +9321,9 @@
 					"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 				},
 				"neo-async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-					"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+					"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 				},
 				"next-tick": {
 					"version": "1.0.0",
@@ -10753,6 +9334,11 @@
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+				},
+				"node-addon-api": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+					"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
 				},
 				"node-environment-flags": {
 					"version": "1.0.6",
@@ -10774,6 +9360,11 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
 					"integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+				},
+				"node-gyp-build": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+					"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 				},
 				"node-libs-browser": {
 					"version": "2.2.1",
@@ -10815,11 +9406,6 @@
 								"isarray": "^1.0.0"
 							}
 						},
-						"inherits": {
-							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-						},
 						"isarray": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -10835,13 +9421,34 @@
 							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 						},
-						"string_decoder": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-							"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"requires": {
-								"safe-buffer": "~5.2.0"
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"string_decoder": {
+									"version": "1.1.1",
+									"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+									"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+									"requires": {
+										"safe-buffer": "~5.1.0"
+									}
+								}
 							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 						},
 						"util": {
 							"version": "0.11.1",
@@ -10849,6 +9456,13 @@
 							"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 							"requires": {
 								"inherits": "2.0.3"
+							},
+							"dependencies": {
+								"inherits": {
+									"version": "2.0.3",
+									"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+									"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+								}
 							}
 						}
 					}
@@ -10880,12 +9494,9 @@
 					}
 				},
 				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"normalize-url": {
 					"version": "4.5.0",
@@ -10930,9 +9541,9 @@
 					}
 				},
 				"nyc": {
-					"version": "15.0.0",
-					"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-					"integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+					"version": "15.1.0",
+					"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+					"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
 					"requires": {
 						"@istanbuljs/load-nyc-config": "^1.0.0",
 						"@istanbuljs/schema": "^0.1.2",
@@ -10942,6 +9553,7 @@
 						"find-cache-dir": "^3.2.0",
 						"find-up": "^4.1.0",
 						"foreground-child": "^2.0.0",
+						"get-package-type": "^0.1.0",
 						"glob": "^7.1.6",
 						"istanbul-lib-coverage": "^3.0.0",
 						"istanbul-lib-hook": "^3.0.0",
@@ -10949,10 +9561,9 @@
 						"istanbul-lib-processinfo": "^2.0.2",
 						"istanbul-lib-report": "^3.0.0",
 						"istanbul-lib-source-maps": "^4.0.0",
-						"istanbul-reports": "^3.0.0",
-						"js-yaml": "^3.13.1",
+						"istanbul-reports": "^3.0.2",
 						"make-dir": "^3.0.0",
-						"node-preload": "^0.2.0",
+						"node-preload": "^0.2.1",
 						"p-map": "^3.0.0",
 						"process-on-spawn": "^1.0.0",
 						"resolve-from": "^5.0.0",
@@ -10960,7 +9571,6 @@
 						"signal-exit": "^3.0.2",
 						"spawn-wrap": "^2.0.0",
 						"test-exclude": "^6.0.0",
-						"uuid": "^3.3.3",
 						"yargs": "^15.0.2"
 					},
 					"dependencies": {
@@ -11034,17 +9644,17 @@
 							}
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -11086,9 +9696,9 @@
 							"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -11137,9 +9747,9 @@
 							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 						},
 						"yargs": {
-							"version": "15.1.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-							"integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+							"version": "15.4.1",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 							"requires": {
 								"cliui": "^6.0.0",
 								"decamelize": "^1.2.0",
@@ -11151,13 +9761,13 @@
 								"string-width": "^4.2.0",
 								"which-module": "^2.0.0",
 								"y18n": "^4.0.0",
-								"yargs-parser": "^16.1.0"
+								"yargs-parser": "^18.1.2"
 							}
 						},
 						"yargs-parser": {
-							"version": "16.1.0",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-							"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+							"version": "18.1.3",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+							"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -11204,14 +9814,18 @@
 					}
 				},
 				"object-inspect": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
 				},
 				"object-is": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-					"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+					"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.17.5"
+					}
 				},
 				"object-keys": {
 					"version": "0.4.0",
@@ -11326,17 +9940,17 @@
 					}
 				},
 				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.1.tgz",
+					"integrity": "sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==",
 					"requires": {
 						"mimic-fn": "^2.1.0"
 					}
 				},
 				"opencollective-postinstall": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-					"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+					"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
 				},
 				"optionator": {
 					"version": "0.8.3",
@@ -11357,6 +9971,40 @@
 					"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
 					"requires": {
 						"readable-stream": "^2.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"os-browserify": {
@@ -11460,6 +10108,40 @@
 						"cyclist": "^1.0.1",
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"parent-module": {
@@ -11595,9 +10277,9 @@
 					}
 				},
 				"pbkdf2": {
-					"version": "3.0.17",
-					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-					"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+					"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
 					"requires": {
 						"create-hash": "^1.1.2",
 						"create-hmac": "^1.1.4",
@@ -11617,9 +10299,9 @@
 					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 				},
 				"picomatch": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-					"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
 				},
 				"pify": {
 					"version": "4.0.1",
@@ -11666,21 +10348,21 @@
 					}
 				},
 				"portfinder": {
-					"version": "1.0.25",
-					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-					"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+					"version": "1.0.28",
+					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+					"integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
 					"requires": {
 						"async": "^2.6.2",
 						"debug": "^3.1.1",
-						"mkdirp": "^0.5.1"
+						"mkdirp": "^0.5.5"
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -11758,12 +10440,12 @@
 					}
 				},
 				"proxy-addr": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-					"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+					"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
 					"requires": {
 						"forwarded": "~0.1.2",
-						"ipaddr.js": "1.9.0"
+						"ipaddr.js": "1.9.1"
 					}
 				},
 				"prr": {
@@ -11777,9 +10459,9 @@
 					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 				},
 				"psl": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-					"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+					"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 				},
 				"public-encrypt": {
 					"version": "4.0.3",
@@ -11958,23 +10640,43 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"micromatch": "^3.1.10",
+						"readable-stream": "^2.0.2"
 					},
 					"dependencies": {
 						"isarray": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
@@ -11991,16 +10693,6 @@
 						}
 					}
 				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
 				"rechoir": {
 					"version": "0.6.2",
 					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -12010,9 +10702,9 @@
 					}
 				},
 				"regenerate": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-					"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+					"integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A=="
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
@@ -12126,9 +10818,9 @@
 					}
 				},
 				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+					"integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
 				},
 				"replace-homedir": {
 					"version": "1.0.0",
@@ -12141,9 +10833,9 @@
 					}
 				},
 				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+					"version": "2.88.2",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 					"requires": {
 						"aws-sign2": "~0.7.0",
 						"aws4": "^1.8.0",
@@ -12152,7 +10844,7 @@
 						"extend": "~3.0.2",
 						"forever-agent": "~0.6.1",
 						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
+						"har-validator": "~5.1.3",
 						"http-signature": "~1.2.0",
 						"is-typedarray": "~1.0.0",
 						"isstream": "~0.1.2",
@@ -12162,7 +10854,7 @@
 						"performance-now": "^2.1.0",
 						"qs": "~6.5.2",
 						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
+						"tough-cookie": "~2.5.0",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.3.2"
 					},
@@ -12190,9 +10882,9 @@
 					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"resolve": {
-					"version": "1.14.2",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-					"integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -12287,20 +10979,17 @@
 					}
 				},
 				"rlp": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-					"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+					"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 					"requires": {
 						"bn.js": "^4.11.1"
 					}
 				},
 				"run-async": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 				},
 				"run-queue": {
 					"version": "1.0.3",
@@ -12316,17 +11005,17 @@
 					"integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
 				},
 				"rxjs": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+					"version": "6.6.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+					"integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
 					"requires": {
 						"tslib": "^1.9.0"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"safe-event-emitter": {
 					"version": "1.0.1",
@@ -12350,11 +11039,12 @@
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 				},
 				"schema-utils": {
-					"version": "2.6.4",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
-					"integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
 					"requires": {
-						"ajv": "^6.10.2",
+						"@types/json-schema": "^7.0.4",
+						"ajv": "^6.12.2",
 						"ajv-keywords": "^3.4.1"
 					}
 				},
@@ -12368,9 +11058,9 @@
 					}
 				},
 				"scrypt-js": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-					"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 				},
 				"scrypt.js": {
 					"version": "0.3.0",
@@ -12392,25 +11082,13 @@
 					}
 				},
 				"secp256k1": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-					"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+					"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 					"requires": {
-						"bindings": "^1.5.0",
-						"bip66": "^1.1.5",
-						"bn.js": "^4.11.8",
-						"create-hash": "^1.2.0",
-						"drbg.js": "^1.0.1",
 						"elliptic": "^6.5.2",
-						"nan": "^2.14.0",
-						"safe-buffer": "^5.1.2"
-					},
-					"dependencies": {
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-						}
+						"node-addon-api": "^2.0.0",
+						"node-gyp-build": "^4.2.0"
 					}
 				},
 				"seedrandom": {
@@ -12419,11 +11097,11 @@
 					"integrity": "sha512-1/02Y/rUeU1CJBAGLebiC5Lbo5FnB22gQbIFFYTLkwvp1xdABZJH1sn4ZT1MzXmPpzv+Rf/Lu2NcsLJiK4rcDg=="
 				},
 				"seek-bzip": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-					"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+					"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
 					"requires": {
-						"commander": "~2.8.1"
+						"commander": "^2.8.1"
 					}
 				},
 				"semaphore": {
@@ -12569,14 +11247,6 @@
 						"safe-buffer": "^5.0.1"
 					}
 				},
-				"sha3": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
-					"integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
-					"requires": {
-						"nan": "2.13.2"
-					}
-				},
 				"shebang-command": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -12591,14 +11261,14 @@
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 				},
 				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 				},
 				"simple-concat": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-					"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+					"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
 				},
 				"simple-get": {
 					"version": "2.8.1",
@@ -12787,11 +11457,6 @@
 								"rimraf": "^2.2.8"
 							}
 						},
-						"js-sha3": {
-							"version": "0.8.0",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-							"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-						},
 						"jsonfile": {
 							"version": "2.4.0",
 							"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -12870,17 +11535,17 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -12901,23 +11566,23 @@
 					}
 				},
 				"spdx-correct": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-					"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+					"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-					"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+					"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
 				},
 				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+					"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -12974,9 +11639,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -13024,6 +11689,40 @@
 					"requires": {
 						"inherits": "~2.0.1",
 						"readable-stream": "^2.0.2"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-each": {
@@ -13050,6 +11749,40 @@
 						"readable-stream": "^2.3.6",
 						"to-arraybuffer": "^1.0.0",
 						"xtend": "^4.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-shift": {
@@ -13098,28 +11831,31 @@
 						"function-bind": "^1.1.1"
 					}
 				},
-				"string.prototype.trimleft": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+				"string.prototype.trimend": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+					"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
 					"requires": {
 						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"es-abstract": "^1.17.5"
 					}
 				},
-				"string.prototype.trimright": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+				"string.prototype.trimstart": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+					"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
 					"requires": {
 						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"es-abstract": "^1.17.5"
 					}
 				},
 				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
 				},
 				"stringify-object": {
 					"version": "3.3.0",
@@ -13174,9 +11910,9 @@
 					}
 				},
 				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 				},
 				"supports-color": {
 					"version": "2.0.0",
@@ -13314,9 +12050,9 @@
 					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
 				},
 				"tape": {
-					"version": "4.13.0",
-					"resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
-					"integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
+					"version": "4.13.3",
+					"resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+					"integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
 					"requires": {
 						"deep-equal": "~1.1.1",
 						"defined": "~1.0.0",
@@ -13327,18 +12063,26 @@
 						"has": "~1.0.3",
 						"inherits": "~2.0.4",
 						"is-regex": "~1.0.5",
-						"minimist": "~1.2.0",
+						"minimist": "~1.2.5",
 						"object-inspect": "~1.7.0",
-						"resolve": "~1.14.2",
+						"resolve": "~1.17.0",
 						"resumer": "~0.0.0",
 						"string.prototype.trim": "~1.2.1",
 						"through": "~2.3.8"
 					},
 					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						"is-regex": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+							"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+							"requires": {
+								"has": "^1.0.3"
+							}
+						},
+						"object-inspect": {
+							"version": "1.7.0",
+							"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+							"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 						}
 					}
 				},
@@ -13357,11 +12101,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -13378,6 +12122,40 @@
 						"readable-stream": "^2.3.0",
 						"to-buffer": "^1.1.1",
 						"xtend": "^4.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"temp": {
@@ -13399,20 +12177,13 @@
 					}
 				},
 				"terser": {
-					"version": "4.6.3",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
-					"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
+					"version": "4.8.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+					"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
 					"requires": {
 						"commander": "^2.20.0",
 						"source-map": "~0.6.1",
 						"source-map-support": "~0.5.12"
-					},
-					"dependencies": {
-						"commander": {
-							"version": "2.20.3",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-						}
 					}
 				},
 				"terser-webpack-plugin": {
@@ -13457,6 +12228,40 @@
 					"requires": {
 						"readable-stream": "~2.3.6",
 						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"through2-filter": {
@@ -13575,19 +12380,12 @@
 					"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 				},
 				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					},
-					"dependencies": {
-						"punycode": {
-							"version": "1.4.1",
-							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-						}
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
 					}
 				},
 				"trim-right": {
@@ -13596,9 +12394,9 @@
 					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 				},
 				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 				},
 				"tty-browserify": {
 					"version": "0.0.0",
@@ -13614,14 +12412,14 @@
 					}
 				},
 				"tweetnacl": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.2.tgz",
-					"integrity": "sha512-+8aPRjmXgf1VqvyxSlBUzKzeYqVS9Ai8vZ28g+mL7dNQl1jlUTCMDZnvNQdAS1xTywMkIXwJsfipsR/6s2+syw=="
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+					"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
 				},
 				"tweetnacl-util": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
-					"integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU="
+					"version": "0.15.1",
+					"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+					"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
 				},
 				"type": {
 					"version": "1.2.0",
@@ -13687,9 +12485,9 @@
 					"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 				},
 				"unbzip2-stream": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-					"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+					"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 					"requires": {
 						"buffer": "^5.2.1",
 						"through": "^2.3.8"
@@ -13922,14 +12720,14 @@
 					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				},
 				"v8-compile-cache": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-					"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+					"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
 				},
 				"v8flags": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-					"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+					"integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
 					"requires": {
 						"homedir-polyfill": "^1.0.1"
 					}
@@ -13998,6 +12796,40 @@
 						"value-or-function": "^3.0.0",
 						"vinyl": "^2.0.0",
 						"vinyl-sourcemap": "^1.1.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"vinyl-sourcemap": {
@@ -14012,6 +12844,16 @@
 						"now-and-later": "^2.0.0",
 						"remove-bom-buffer": "^3.0.0",
 						"vinyl": "^2.0.0"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
 					}
 				},
 				"vm-browserify": {
@@ -14020,13 +12862,123 @@
 					"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
 				},
 				"watchpack": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-					"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+					"version": "1.7.4",
+					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+					"integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
 					"requires": {
-						"chokidar": "^2.0.2",
+						"chokidar": "^3.4.1",
 						"graceful-fs": "^4.1.2",
-						"neo-async": "^2.5.0"
+						"neo-async": "^2.5.0",
+						"watchpack-chokidar2": "^2.0.0"
+					},
+					"dependencies": {
+						"anymatch": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+							"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+							"optional": true,
+							"requires": {
+								"normalize-path": "^3.0.0",
+								"picomatch": "^2.0.4"
+							}
+						},
+						"binary-extensions": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+							"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+							"optional": true
+						},
+						"braces": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+							"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+							"optional": true,
+							"requires": {
+								"fill-range": "^7.0.1"
+							}
+						},
+						"chokidar": {
+							"version": "3.4.1",
+							"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+							"integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+							"optional": true,
+							"requires": {
+								"anymatch": "~3.1.1",
+								"braces": "~3.0.2",
+								"fsevents": "~2.1.2",
+								"glob-parent": "~5.1.0",
+								"is-binary-path": "~2.1.0",
+								"is-glob": "~4.0.1",
+								"normalize-path": "~3.0.0",
+								"readdirp": "~3.4.0"
+							}
+						},
+						"fill-range": {
+							"version": "7.0.1",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+							"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+							"optional": true,
+							"requires": {
+								"to-regex-range": "^5.0.1"
+							}
+						},
+						"fsevents": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+							"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+							"optional": true
+						},
+						"glob-parent": {
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+							"optional": true,
+							"requires": {
+								"is-glob": "^4.0.1"
+							}
+						},
+						"is-binary-path": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+							"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+							"optional": true,
+							"requires": {
+								"binary-extensions": "^2.0.0"
+							}
+						},
+						"is-number": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+							"optional": true
+						},
+						"readdirp": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+							"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+							"optional": true,
+							"requires": {
+								"picomatch": "^2.2.1"
+							}
+						},
+						"to-regex-range": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+							"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+							"optional": true,
+							"requires": {
+								"is-number": "^7.0.0"
+							}
+						}
+					}
+				},
+				"watchpack-chokidar2": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+					"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+					"optional": true,
+					"requires": {
+						"chokidar": "^2.1.8"
 					}
 				},
 				"web3": {
@@ -14045,9 +12997,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -14063,9 +13015,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "10.17.14",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-							"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+							"version": "10.17.28",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+							"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
 						}
 					}
 				},
@@ -14084,9 +13036,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -14174,9 +13126,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "10.17.14",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-							"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+							"version": "10.17.28",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+							"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
 						},
 						"aes-js": {
 							"version": "3.0.0",
@@ -14224,6 +13176,11 @@
 							"version": "0.5.7",
 							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
 							"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+						},
+						"scrypt-js": {
+							"version": "2.0.3",
+							"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+							"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
 						},
 						"setimmediate": {
 							"version": "1.0.4",
@@ -14311,6 +13268,13 @@
 					"requires": {
 						"bn.js": "4.11.8",
 						"web3-utils": "1.2.4"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+							"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+						}
 					}
 				},
 				"web3-eth-personal": {
@@ -14327,9 +13291,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -14393,17 +13357,17 @@
 							},
 							"dependencies": {
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
@@ -14447,30 +13411,17 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
-							},
-							"dependencies": {
-								"keccak": {
-									"version": "1.4.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-									"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-									"requires": {
-										"bindings": "^1.2.1",
-										"inherits": "^2.0.3",
-										"nan": "^2.2.1",
-										"safe-buffer": "^5.1.0"
-									}
-								}
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -14504,28 +13455,17 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -14540,36 +13480,61 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
 						},
-						"keccak": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-							"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"requires": {
-								"bindings": "^1.5.0",
-								"inherits": "^2.0.4",
-								"nan": "^2.14.0",
-								"safe-buffer": "^5.2.0"
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
 							}
 						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
 						},
 						"ws": {
 							"version": "5.2.2",
@@ -14636,6 +13601,11 @@
 						"utf8": "3.0.0"
 					},
 					"dependencies": {
+						"bn.js": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+							"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+						},
 						"eth-lib": {
 							"version": "0.2.7",
 							"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -14679,14 +13649,14 @@
 					},
 					"dependencies": {
 						"acorn": {
-							"version": "6.4.0",
-							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-							"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+							"version": "6.4.1",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+							"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 						},
 						"cacache": {
-							"version": "12.0.3",
-							"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-							"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+							"version": "12.0.4",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+							"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
 							"requires": {
 								"bluebird": "^3.5.5",
 								"chownr": "^1.1.1",
@@ -14741,14 +13711,6 @@
 								"path-exists": "^3.0.0"
 							}
 						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"requires": {
-								"yallist": "^3.0.2"
-							}
-						},
 						"make-dir": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -14759,17 +13721,17 @@
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -14815,6 +13777,14 @@
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 						},
+						"serialize-javascript": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+							"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+							"requires": {
+								"randombytes": "^2.1.0"
+							}
+						},
 						"ssri": {
 							"version": "6.0.1",
 							"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -14824,15 +13794,15 @@
 							}
 						},
 						"terser-webpack-plugin": {
-							"version": "1.4.3",
-							"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-							"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+							"version": "1.4.4",
+							"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+							"integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
 							"requires": {
 								"cacache": "^12.0.2",
 								"find-cache-dir": "^2.1.0",
 								"is-wsl": "^1.1.0",
 								"schema-utils": "^1.0.0",
-								"serialize-javascript": "^2.1.2",
+								"serialize-javascript": "^3.1.0",
 								"source-map": "^0.6.1",
 								"terser": "^4.1.2",
 								"webpack-sources": "^1.4.0",
@@ -14854,13 +13824,6 @@
 						"commander": "^2.19.0",
 						"filesize": "^3.6.1",
 						"humanize": "0.0.9"
-					},
-					"dependencies": {
-						"commander": {
-							"version": "2.20.3",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-						}
 					}
 				},
 				"webpack-cli": {
@@ -14946,6 +13909,11 @@
 							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 							"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 						},
+						"emojis-list": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+							"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+						},
 						"enhanced-resolve": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
@@ -15001,6 +13969,11 @@
 								"which": "^1.3.1"
 							}
 						},
+						"interpret": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+							"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+						},
 						"invert-kv": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -15011,12 +13984,30 @@
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 						},
+						"json5": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+							"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+							"requires": {
+								"minimist": "^1.2.0"
+							}
+						},
 						"lcid": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 							"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 							"requires": {
 								"invert-kv": "^2.0.0"
+							}
+						},
+						"loader-utils": {
+							"version": "1.2.3",
+							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+							"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+							"requires": {
+								"big.js": "^5.2.2",
+								"emojis-list": "^2.0.0",
+								"json5": "^1.0.1"
 							}
 						},
 						"locate-path": {
@@ -15047,9 +14038,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -15170,9 +14161,9 @@
 							}
 						},
 						"yargs-parser": {
-							"version": "13.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-							"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+							"version": "13.1.2",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+							"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -15283,19 +14274,19 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
 				},
 				"write-file-atomic": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-					"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
 					"requires": {
 						"imurmurhash": "^0.1.4",
 						"is-typedarray": "^1.0.0",
@@ -15346,11 +14337,11 @@
 					}
 				},
 				"xhr-request-promise": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-					"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+					"integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
 					"requires": {
-						"xhr-request": "^1.0.1"
+						"xhr-request": "^1.1.0"
 					}
 				},
 				"xhr2-cookies": {
@@ -15387,17 +14378,14 @@
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				},
 				"yaml": {
-					"version": "1.7.2",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-					"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-					"requires": {
-						"@babel/runtime": "^7.6.3"
-					}
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+					"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 				},
 				"yargs": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+					"integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
 					"requires": {
 						"camelcase": "^3.0.0",
 						"cliui": "^3.2.0",
@@ -15411,15 +14399,16 @@
 						"string-width": "^1.0.2",
 						"which-module": "^1.0.0",
 						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
+						"yargs-parser": "5.0.0-security.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"version": "5.0.0-security.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+					"integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "^3.0.0",
+						"object.assign": "^4.1.0"
 					}
 				},
 				"yargs-unparser": {
@@ -15493,14 +14482,14 @@
 							}
 						},
 						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -15567,9 +14556,9 @@
 							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 						},
 						"yargs": {
-							"version": "13.3.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-							"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+							"version": "13.3.2",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+							"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 							"requires": {
 								"cliui": "^5.0.0",
 								"find-up": "^3.0.0",
@@ -15580,13 +14569,13 @@
 								"string-width": "^3.0.0",
 								"which-module": "^2.0.0",
 								"y18n": "^4.0.0",
-								"yargs-parser": "^13.1.1"
+								"yargs-parser": "^13.1.2"
 							}
 						},
 						"yargs-parser": {
-							"version": "13.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-							"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+							"version": "13.1.2",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+							"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -15605,460 +14594,16 @@
 				}
 			}
 		},
-		"get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
-		"get-proxy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
-			"dev": true,
-			"requires": {
-				"npm-conf": "^1.1.0"
-			}
-		},
-		"get-stream": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-			"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-			"requires": {
-				"object-assign": "^4.0.1",
-				"pinkie-promise": "^2.0.0"
-			}
-		},
-		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"glob-parent": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-			"dev": true,
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
-		"global-dirs": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.4"
-			}
-		},
-		"got": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-			"dev": true,
-			"requires": {
-				"@sindresorhus/is": "^0.7.0",
-				"cacheable-request": "^2.1.1",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"into-stream": "^3.1.0",
-				"is-retry-allowed": "^1.1.0",
-				"isurl": "^1.0.0-alpha5",
-				"lowercase-keys": "^1.0.0",
-				"mimic-response": "^1.0.0",
-				"p-cancelable": "^0.4.0",
-				"p-timeout": "^2.0.1",
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1",
-				"timed-out": "^4.0.1",
-				"url-parse-lax": "^3.0.0",
-				"url-to-options": "^1.0.1"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"has-symbol-support-x": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
-		},
-		"has-to-string-tag-x": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"dev": true,
-			"requires": {
-				"has-symbol-support-x": "^1.4.1"
-			}
-		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"http-cache-semantics": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
-		},
-		"http-errors": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			}
-		},
-		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-			"dev": true,
-			"requires": {
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
-		"immediate": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-			"dev": true
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
-		},
-		"into-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"dev": true,
-			"requires": {
-				"from2": "^2.1.1",
-				"p-is-promise": "^1.1.0"
-			}
-		},
-		"io-ts": {
-			"version": "1.10.4",
-			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
-			"integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
-			"dev": true,
-			"requires": {
-				"fp-ts": "^1.0.0"
-			}
-		},
-		"is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-			"dev": true
-		},
-		"is-callable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-			"dev": true
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
-		},
-		"is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.1"
-			}
-		},
-		"is-hex-prefixed": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-			"dev": true
-		},
-		"is-installed-globally": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.2.0.tgz",
-			"integrity": "sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==",
-			"dev": true,
-			"requires": {
-				"global-dirs": "^0.1.1",
-				"is-path-inside": "^2.1.0"
-			}
-		},
-		"is-natural-number": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-		},
-		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-			"dev": true
-		},
-		"is-path-inside": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-			"dev": true,
-			"requires": {
-				"path-is-inside": "^1.0.2"
-			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
-		},
-		"is-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-retry-allowed": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-			"dev": true
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"isurl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-			"dev": true,
-			"requires": {
-				"has-to-string-tag-x": "^1.2.0",
-				"is-object": "^1.0.1"
-			}
-		},
-		"js-sha3": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-			"dev": true
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -16070,1250 +14615,22 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"keccak": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-			"dev": true,
-			"requires": {
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"keyv": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"dev": true,
-			"requires": {
-				"json-buffer": "3.0.0"
-			}
-		},
-		"klaw": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.9"
-			}
-		},
-		"level-codec": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-			"integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-			"dev": true
-		},
-		"level-errors": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-			"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-			"dev": true,
-			"requires": {
-				"errno": "~0.1.1"
-			}
-		},
-		"level-iterator-stream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"level-errors": "^1.0.3",
-				"readable-stream": "^1.0.33",
-				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"level-mem": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-			"integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-			"dev": true,
-			"requires": {
-				"level-packager": "~4.0.0",
-				"memdown": "~3.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"immediate": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-					"dev": true
-				},
-				"memdown": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-					"integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"functional-red-black-tree": "~1.0.1",
-						"immediate": "~3.2.3",
-						"inherits": "~2.0.1",
-						"ltgt": "~2.2.0",
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
-			}
-		},
-		"level-packager": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-			"integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-			"dev": true,
-			"requires": {
-				"encoding-down": "~5.0.0",
-				"levelup": "^3.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"deferred-leveldown": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-					"integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"inherits": "^2.0.3"
-					}
-				},
-				"level-errors": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
-					"requires": {
-						"errno": "~0.1.1"
-					}
-				},
-				"level-iterator-stream": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-					"integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.3.6",
-						"xtend": "^4.0.0"
-					}
-				},
-				"levelup": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-					"integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-					"dev": true,
-					"requires": {
-						"deferred-leveldown": "~4.0.0",
-						"level-errors": "~2.0.0",
-						"level-iterator-stream": "~3.0.0",
-						"xtend": "~4.0.0"
-					}
-				}
-			}
-		},
-		"level-ws": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.0.15",
-				"xtend": "~2.1.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-					"dev": true,
-					"requires": {
-						"object-keys": "~0.4.0"
-					}
-				}
-			}
-		},
-		"levelup": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-			"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-			"dev": true,
-			"requires": {
-				"deferred-leveldown": "~1.2.1",
-				"level-codec": "~7.0.0",
-				"level-errors": "~1.0.3",
-				"level-iterator-stream": "~1.3.0",
-				"prr": "~1.0.1",
-				"semver": "~5.4.1",
-				"xtend": "~4.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-					"dev": true
-				}
-			}
-		},
-		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
-			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			}
-		},
-		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-			"dev": true
-		},
-		"log-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2"
-			}
-		},
-		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
-		},
-		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
-			"requires": {
-				"yallist": "^3.0.2"
-			}
-		},
-		"lru_map": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-			"integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
-			"dev": true
-		},
-		"ltgt": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-			"dev": true
-		},
-		"make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"requires": {
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
-			}
-		},
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"memdown": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~2.7.1",
-				"functional-red-black-tree": "^1.0.1",
-				"immediate": "^3.2.3",
-				"inherits": "~2.0.1",
-				"ltgt": "~2.2.0",
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
-				}
-			}
-		},
-		"memorystream": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-			"dev": true
-		},
-		"merkle-patricia-tree": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-			"integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"ethereumjs-util": "^5.2.0",
-				"level-mem": "^3.0.1",
-				"level-ws": "^1.0.0",
-				"readable-stream": "^3.0.6",
-				"rlp": "^2.0.0",
-				"semaphore": ">=1.0.1"
-			},
-			"dependencies": {
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"level-ws": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-					"integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.8",
-						"xtend": "^4.0.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-							"dev": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
-		"miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-			"dev": true
-		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true
-		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"mocha": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "3.2.3",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.3.0",
-				"debug": "3.2.6",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"find-up": "3.0.0",
-				"glob": "7.1.3",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.13.1",
-				"log-symbols": "3.0.0",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.5",
-				"ms": "2.1.1",
-				"node-environment-flags": "1.0.6",
-				"object.assign": "4.1.0",
-				"strip-json-comments": "2.0.1",
-				"supports-color": "6.0.0",
-				"which": "1.3.1",
-				"wide-align": "1.1.3",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "1.6.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-					"dev": true
-				},
-				"chokidar": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-					"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-					"dev": true,
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.1",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.2.0"
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"diff": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"readdirp": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-					"dev": true,
-					"requires": {
-						"picomatch": "^2.0.4"
-					}
-				},
-				"supports-color": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-			"dev": true
-		},
-		"node-environment-flags": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-			"integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-			"dev": true,
-			"requires": {
-				"object.getownpropertydescriptors": "^2.0.3",
-				"semver": "^5.7.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-			"dev": true
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-			"dev": true
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"normalize-url": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0",
-				"query-string": "^5.0.1",
-				"sort-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"sort-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-					"dev": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				}
-			}
-		},
-		"npm-conf": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
-			"dev": true,
-			"requires": {
-				"config-chain": "^1.1.11",
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"object-inspect": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
-		},
-		"p-cancelable": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-			"dev": true
-		},
-		"p-event": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
-			"integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
-			"dev": true,
-			"requires": {
-				"p-timeout": "^2.0.1"
-			}
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
-		},
-		"p-is-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-			"dev": true
-		},
-		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
-			"requires": {
-				"p-try": "^1.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
-			"requires": {
-				"p-limit": "^1.1.0"
-			}
-		},
-		"p-timeout": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
-		},
-		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
-		},
-		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
-		},
-		"pbkdf2": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-			"dev": true,
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-		},
-		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
-		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
-		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
-		"proto-list": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true
-		},
-		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-			"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-			"dev": true
-		},
-		"query-string": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-			"dev": true,
-			"requires": {
-				"decode-uri-component": "^0.2.0",
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"raw-body": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.3",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-			"dev": true,
-			"requires": {
-				"picomatch": "^2.2.1"
-			}
-		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
-			"requires": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
-		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
-		"rlp": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.1"
-			}
-		},
-		"rustbn.js": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-			"integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
-			"dev": true
-		},
-		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
-		},
-		"scrypt-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-			"dev": true
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"dev": true,
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"seek-bzip": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-			"requires": {
-				"commander": "^2.8.1"
-			}
-		},
-		"semaphore": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
-			"dev": true
-		},
-		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
-		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-			"dev": true
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
-		},
-		"solc": {
-			"version": "0.6.8",
-			"resolved": "https://registry.npmjs.org/solc/-/solc-0.6.8.tgz",
-			"integrity": "sha512-7URBAisWVjO7dwWNpEkQ5dpRSpSF4Wm0aD5EB82D5BQKh+q7jhOxhgkG4K5gax/geM0kPZUAxnaLcgl2ZXBgMQ==",
-			"dev": true,
-			"requires": {
-				"command-exists": "^1.2.8",
-				"commander": "3.0.2",
-				"fs-extra": "^0.30.0",
-				"js-sha3": "0.8.0",
-				"memorystream": "^0.3.1",
-				"require-from-string": "^2.0.0",
-				"semver": "^5.5.0",
-				"tmp": "0.0.33"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-					"dev": true
-				},
-				"fs-extra": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0",
-						"klaw": "^1.0.0",
-						"path-is-absolute": "^1.0.0",
-						"rimraf": "^2.2.8"
-					}
-				},
-				"jsonfile": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^1.0.0"
-			}
-		},
-		"sort-keys-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
-			"integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
-			"dev": true,
-			"requires": {
-				"sort-keys": "^1.0.0"
-			}
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -17329,182 +14646,6 @@
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
-		},
-		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
-			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			}
-		},
-		"string.prototype.trimend": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"string.prototype.trimstart": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-dirs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-			"requires": {
-				"is-natural-number": "^4.0.1"
-			}
-		},
-		"strip-hex-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-			"dev": true,
-			"requires": {
-				"is-hex-prefixed": "1.0.0"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
-		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-		},
-		"timed-out": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
-		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
-		},
-		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^7.0.0"
-			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-			"dev": true
-		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
 			}
 		},
 		"ts-essentials": {
@@ -17524,9 +14665,9 @@
 			}
 		},
 		"ts-interface-checker": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.11.tgz",
-			"integrity": "sha512-Jx6cFBiuCQrRl3CgoIOamIE/toZ8jQJbIlsLGpkBiUpCEUyFcyZ2pvjP8kSXIcz8V5v/murgm/5EfIQapUmh6A=="
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
 		},
 		"ts-node": {
 			"version": "8.10.2",
@@ -17541,49 +14682,10 @@
 				"yn": "3.1.1"
 			}
 		},
-		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-			"dev": true
-		},
-		"tsort": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
-			"integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
-			"dev": true
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-			"dev": true
-		},
-		"tweetnacl-util": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-			"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-			"dev": true
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
-		},
-		"type-fest": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
 			"dev": true
 		},
 		"typescript": {
@@ -17592,274 +14694,11 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			}
-		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
-		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0"
-			}
-		},
-		"url-to-options": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-			"dev": true
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
-		},
-		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"ws": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-		},
-		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
-		},
-		"yargs": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-			"dev": true,
-			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-			"dev": true,
-			"requires": {
-				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
-				"yargs": "^13.3.0"
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
 		},
 		"yn": {
 			"version": "3.1.1",

--- a/packages/buidler-solhint/package-lock.json
+++ b/packages/buidler-solhint/package-lock.json
@@ -5,32 +5,32 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-			"integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"requires": {
-				"@babel/highlight": "^7.10.1"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-			"integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
 		},
 		"@babel/highlight": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-			"integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.1",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/fs-extra": {
@@ -43,9 +43,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
 			"dev": true
 		},
 		"acorn": {
@@ -54,14 +54,14 @@
 			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 		},
 		"acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
 		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -248,11 +248,11 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"deep-eql": {
@@ -377,9 +377,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
 		},
 		"espree": {
 			"version": "5.0.1",
@@ -405,18 +405,25 @@
 			},
 			"dependencies": {
 				"estraverse": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
 				}
 			}
 		},
 		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+				}
 			}
 		},
 		"estraverse": {
@@ -440,9 +447,9 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -690,9 +697,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
@@ -873,9 +880,9 @@
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 		},
 		"rxjs": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-			"integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+			"integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -1053,9 +1060,9 @@
 			"dev": true
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/packages/buidler-solpp/package-lock.json
+++ b/packages/buidler-solpp/package-lock.json
@@ -13,9 +13,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/fs-extra": {
@@ -28,9 +28,25 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"antlr4": {
 			"version": "4.8.0",
@@ -57,21 +73,18 @@
 				"is-buffer": "^2.0.2"
 			}
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn-str-256": {
 			"version": "1.9.1",
@@ -103,6 +116,24 @@
 				"evp_bytestokey": "^1.0.3",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer-xor": {
@@ -191,20 +222,10 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -215,18 +236,40 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethjs-util": {
@@ -246,11 +289,6 @@
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
 			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
@@ -334,20 +372,18 @@
 			}
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -384,10 +420,15 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -404,6 +445,26 @@
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
+		},
+		"pbkdf2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"readable-stream": {
 			"version": "3.6.0",
@@ -433,9 +494,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -445,25 +506,30 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -507,9 +573,9 @@
 			}
 		},
 		"thenify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"requires": {
 				"any-promise": "^1.0.0"
 			}

--- a/packages/buidler-truffle4/package-lock.json
+++ b/packages/buidler-truffle4/package-lock.json
@@ -17,12 +17,6 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha512-D8uQwKYUw2KESkorZ27ykzXgvkDJYXVEihGklgfp5I4HUP8D6IxtcdLTMB1emjQiWzV7WZ5ihm1cxIzVwjoleQ=="
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
@@ -33,12 +27,11 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -50,9 +43,25 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"ajv": {
 			"version": "5.5.2",
@@ -70,25 +79,22 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"bignumber.js": {
 			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
 			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn.js": {
 			"version": "4.11.9",
@@ -111,6 +117,24 @@
 				"evp_bytestokey": "^1.0.3",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer-xor": {
@@ -196,20 +220,10 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -220,18 +234,40 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethjs-abi": {
@@ -278,11 +314,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fs-extra": {
 			"version": "7.0.1",
@@ -362,14 +393,12 @@
 			}
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"md5.js": {
@@ -397,10 +426,15 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"number-to-bn": {
 			"version": "1.7.0",
@@ -423,6 +457,26 @@
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
+		"pbkdf2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"readable-stream": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -443,9 +497,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -455,20 +509,25 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",

--- a/packages/buidler-truffle4/src/index.ts
+++ b/packages/buidler-truffle4/src/index.ts
@@ -14,7 +14,7 @@ import {
   lazyObject,
   NomicLabsBuidlerPluginError,
 } from "@nomiclabs/buidler/plugins";
-import { BuidlerNetworkConfig } from "@nomiclabs/buidler/types";
+import { ResolvedBuidlerNetworkConfig } from "@nomiclabs/buidler/types";
 import { join } from "path";
 
 import { TruffleEnvironmentArtifacts } from "./artifacts";
@@ -58,9 +58,7 @@ export default function () {
         if (accounts === undefined) {
           const { privateToAddress, bufferToHex } = require("ethereumjs-util");
 
-          const netConfig = env.network.config as Required<
-            BuidlerNetworkConfig
-          >;
+          const netConfig = env.network.config as ResolvedBuidlerNetworkConfig;
 
           accounts = netConfig.accounts.map((acc) =>
             bufferToHex(privateToAddress(acc.privateKey))

--- a/packages/buidler-truffle5/package-lock.json
+++ b/packages/buidler-truffle5/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nomiclabs/buidler-truffle5",
-	"version": "1.99.0",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -42,9 +42,9 @@
 			}
 		},
 		"@truffle/contract-schema": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.0.tgz",
-			"integrity": "sha512-yeb4UoK9cbrT5/Nuz0I0p2XKbf0K1wEmyyBQmo3Q4JOrLidxf59LtDupo9Uq74RtlTAxZC0cy9DnsfWeWVma4A==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.5.tgz",
+			"integrity": "sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==",
 			"requires": {
 				"ajv": "^6.10.0",
 				"crypto-js": "^3.1.9-1",
@@ -57,9 +57,9 @@
 			"integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ=="
 		},
 		"@truffle/interface-adapter": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.8.tgz",
-			"integrity": "sha512-pTD4Vr5vfYcMTCUPefznA2mM060vKScn24o1QhfUYyBbas/fc0dDstrnCv886l0dhqnV/q2ebSzaxVWUyPSfgg==",
+			"version": "0.4.16",
+			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.16.tgz",
+			"integrity": "sha512-lsxk26Lz/h0n8fe37K1ZxowxokXj0AZeNR10QHltDvkHukuTIC4L6fXvrUi74mCwI9hShl4CSBas1Q8kAyJyOA==",
 			"requires": {
 				"bn.js": "^4.11.8",
 				"ethers": "^4.0.32",
@@ -76,15 +76,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
-		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ=="
 		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
@@ -96,12 +90,11 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -113,9 +106,25 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.17.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-			"integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+			"version": "10.17.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+			"integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -132,9 +141,9 @@
 			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
 		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -161,13 +170,14 @@
 			}
 		},
 		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -196,9 +206,17 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+		},
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -218,30 +236,19 @@
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
 			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
 			}
+		},
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -334,15 +341,15 @@
 			}
 		},
 		"browserify-sign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-			"integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
 			"requires": {
 				"bn.js": "^5.1.1",
 				"browserify-rsa": "^4.0.1",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.2",
+				"elliptic": "^6.5.3",
 				"inherits": "^2.0.4",
 				"parse-asn1": "^5.1.5",
 				"readable-stream": "^3.6.0",
@@ -350,9 +357,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-					"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
 				},
 				"readable-stream": {
 					"version": "3.6.0",
@@ -364,6 +371,24 @@
 						"util-deprecate": "^1.0.1"
 					}
 				}
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer": {
@@ -434,9 +459,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -502,12 +527,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-			"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-			"requires": {
-				"graceful-readlink": ">= 1.0.0"
-			}
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -574,12 +596,12 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 			"requires": {
 				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"elliptic": "^6.5.3"
 			}
 		},
 		"create-hash": {
@@ -648,11 +670,11 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decode-uri-component": {
@@ -801,16 +823,6 @@
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
 			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -831,9 +843,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -918,6 +930,49 @@
 				"xhr-request-promise": "^0.1.2"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			},
+			"dependencies": {
+				"hash.js": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+					"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.1"
+					}
+				},
+				"scrypt-js": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				}
+			}
+		},
 		"ethereum-ens": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.8.0.tgz",
@@ -932,27 +987,27 @@
 			}
 		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethers": {
-			"version": "4.0.47",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
-			"integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+			"version": "4.0.48",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+			"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
 			"requires": {
 				"aes-js": "3.0.0",
 				"bn.js": "^4.4.0",
-				"elliptic": "6.5.2",
+				"elliptic": "6.5.3",
 				"hash.js": "1.1.3",
 				"js-sha3": "0.5.7",
 				"scrypt-js": "2.0.4",
@@ -1099,9 +1154,9 @@
 			},
 			"dependencies": {
 				"type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+					"integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
 				}
 			}
 		},
@@ -1116,9 +1171,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -1137,11 +1192,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"finalhandler": {
 			"version": "1.1.2",
@@ -1273,22 +1323,17 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -1532,14 +1577,12 @@
 			}
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"keyv": {
@@ -1681,9 +1724,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
-			"integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+			"integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
 		},
 		"mold-source-map": {
 			"version": "0.4.0",
@@ -1725,6 +1768,16 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"normalize-url": {
 			"version": "4.5.0",
@@ -1805,13 +1858,12 @@
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
 			"requires": {
-				"asn1.js": "^4.0.0",
+				"asn1.js": "^5.2.0",
 				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
@@ -1838,9 +1890,9 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pbkdf2": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -2064,9 +2116,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -2092,26 +2144,21 @@
 			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
 		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"seek-bzip": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
 			"requires": {
-				"commander": "~2.8.1"
+				"commander": "^2.8.1"
 			}
 		},
 		"semver": {
@@ -2204,9 +2251,9 @@
 			}
 		},
 		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
 		},
 		"simple-get": {
 			"version": "2.8.1",
@@ -2511,9 +2558,9 @@
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/packages/buidler-truffle5/package.json
+++ b/packages/buidler-truffle5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomiclabs/buidler-truffle5",
-  "version": "1.99.1",
+  "version": "1.3.4",
   "description": "Truffle 5 Buidler compatibility plugin",
   "repository": "github:nomiclabs/buidler",
   "homepage": "https://github.com/nomiclabs/buidler/tree/master/packages/buidler-truffle5",

--- a/packages/buidler-truffle5/src/index.ts
+++ b/packages/buidler-truffle5/src/index.ts
@@ -14,7 +14,7 @@ import {
   lazyObject,
   NomicLabsBuidlerPluginError,
 } from "@nomiclabs/buidler/plugins";
-import { BuidlerNetworkConfig } from "@nomiclabs/buidler/types";
+import { ResolvedBuidlerNetworkConfig } from "@nomiclabs/buidler/types";
 import { join } from "path";
 
 import { TruffleEnvironmentArtifacts } from "./artifacts";
@@ -138,9 +138,7 @@ export default function () {
             bufferToHex,
           } = require("ethereumjs-util");
 
-          const netConfig = env.network.config as Required<
-            BuidlerNetworkConfig
-          >;
+          const netConfig = env.network.config as ResolvedBuidlerNetworkConfig;
 
           accounts = netConfig.accounts.map((acc) =>
             toChecksumAddress(bufferToHex(privateToAddress(acc.privateKey)))

--- a/packages/buidler-vyper/package-lock.json
+++ b/packages/buidler-vyper/package-lock.json
@@ -13,15 +13,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
-			"dev": true
-		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/fs-extra": {
@@ -34,12 +28,11 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -51,9 +44,25 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+		},
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"antlr4": {
 			"version": "4.8.0",
@@ -85,21 +94,18 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn-str-256": {
 			"version": "1.9.1",
@@ -140,6 +146,24 @@
 				"evp_bytestokey": "^1.0.3",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer-xor": {
@@ -233,20 +257,10 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -257,18 +271,40 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethjs-util": {
@@ -288,11 +324,6 @@
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
 			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
@@ -403,20 +434,18 @@
 			}
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -461,10 +490,15 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -495,6 +529,26 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"readable-stream": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -523,9 +577,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"requires": {
 				"bn.js": "^4.11.1"
 			}
@@ -535,25 +589,30 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -597,9 +656,9 @@
 			}
 		},
 		"thenify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"requires": {
 				"any-promise": "^1.0.0"
 			}

--- a/packages/buidler-waffle/package-lock.json
+++ b/packages/buidler-waffle/package-lock.json
@@ -5,15 +5,13 @@
 	"requires": true,
 	"dependencies": {
 		"@ensdomains/ens": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.4.tgz",
-			"integrity": "sha512-Qya0A4pd0dd3fF4tPqJve9eyEHp82jIMv17ElZU4dSHy68xN8sEpuiyI6Z8+2sGeHLRQ55LaCM6p293YHnYRlQ==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",
+			"integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.2",
 				"eth-ens-namehash": "^2.0.8",
-				"ethereumjs-testrpc": "^6.0.3",
-				"ganache-cli": "^6.1.0",
 				"solc": "^0.4.20",
 				"testrpc": "0.0.1",
 				"web3-utils": "^1.0.0-beta.31"
@@ -26,19 +24,19 @@
 			"dev": true
 		},
 		"@ethereum-waffle/chai": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.0.0.tgz",
-			"integrity": "sha512-4fd5AOD7DxwgJi/234rhWMkZMqkpXgqjCJV0ZhF6sOyZ4jPBLllYJNtEfxWaA8a1NBCHr1B98o6NvYGG0gD7vA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.1.0.tgz",
+			"integrity": "sha512-erBoZoseFXZPEEbv9GHqJKjGAG4u1m/NzTRvXUGFDngdZYsBzMDTVU63vIrGVlVu3Cu7Wd5KfdhYib+/iH2xcQ==",
 			"dev": true,
 			"requires": {
-				"@ethereum-waffle/provider": "^3.0.0",
+				"@ethereum-waffle/provider": "^3.1.0",
 				"ethers": "^5.0.0"
 			}
 		},
 		"@ethereum-waffle/compiler": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.0.0.tgz",
-			"integrity": "sha512-Tc9TqaD7QBxh6cLRkp5t41ZFNZpc7zBWDv9wq4EqgAg021lX6HS0KeGl3dLp4ajHie+PNCVKvQivEH7e7Jql+A==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.1.0.tgz",
+			"integrity": "sha512-qFwy9OHbbvltns4tz12mpbSryg8rCpATsdjM+PtSSXSJ7s04fcDlKWJgFERE3jsxE7GMGH8mfr4e7Jqncxxh7w==",
 			"dev": true,
 			"requires": {
 				"@resolver-engine/imports": "^0.3.3",
@@ -64,9 +62,9 @@
 					"dev": true
 				},
 				"solc": {
-					"version": "0.6.10",
-					"resolved": "https://registry.npmjs.org/solc/-/solc-0.6.10.tgz",
-					"integrity": "sha512-+oHwIvNjg3bxXvL9yua/Z4ZFEdkCkgRSh7aIGGb+mf/gzoA8PRKiKGYDsjMaj0CJLH1BTBOUpNFeYhhnUFfjRg==",
+					"version": "0.6.12",
+					"resolved": "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz",
+					"integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
 					"dev": true,
 					"requires": {
 						"command-exists": "^1.2.8",
@@ -82,9 +80,9 @@
 			}
 		},
 		"@ethereum-waffle/ens": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ethereum-waffle/ens/-/ens-3.0.0.tgz",
-			"integrity": "sha512-ZH1vFx+AKkL0Q7mbJRz09LblurgxvYh1f6gxhnOWwACg6lt+H3wMGTdMSBZ8ttkxjfSa0CB2kFi3B6YKH/7iyQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@ethereum-waffle/ens/-/ens-3.1.0.tgz",
+			"integrity": "sha512-Q0/MUBJQsiPseZv0Sv/GFOVdWGn0wRChWtUd30r94qlcM7OqmXLdx4YQSMGu7BhRPdp2DQE2CYMFTKjiznfRkA==",
 			"dev": true,
 			"requires": {
 				"@ensdomains/ens": "^0.4.4",
@@ -93,9 +91,9 @@
 			}
 		},
 		"@ethereum-waffle/mock-contract": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.0.0.tgz",
-			"integrity": "sha512-xv3O0uygk/RbQ4aa+u7GSiC4MUpF3FA01oyBKzPmcd/X1DOyAmq5/+1jDvSgb3NYEjCW4gufyN9hPpDkGoW8ew==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.1.0.tgz",
+			"integrity": "sha512-mhvyb9P5aM7D2qHmaAH2ONbR95L7pVveRR9s7zfcxYdzJP0KCjy2IZfPmhOZDe/lW1tXuM3m/OL+oHfKTRYbdw==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/abi": "^5.0.1",
@@ -103,307 +101,294 @@
 			}
 		},
 		"@ethereum-waffle/provider": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.0.0.tgz",
-			"integrity": "sha512-aCxjI9zNA4Iu7pubvH6W9bSJe7mv+SpqO+ggX+41HgbY2GBEVU44+0KEgVgBhQednmlDO9l7WBnXZFB1TO3pqA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.1.0.tgz",
+			"integrity": "sha512-MPlmtYWVEjObSrneZQKHprRe00Da768IdT1+hyWq5x6uXluYdqo5hZc9LVNTd2f9WfHasZ8YWZLUC/wsEb86ig==",
 			"dev": true,
 			"requires": {
-				"@ethereum-waffle/ens": "^3.0.0",
+				"@ethereum-waffle/ens": "^3.1.0",
 				"ethers": "^5.0.1",
-				"ganache-core": "^2.10.2"
+				"ganache-core": "^2.10.2",
+				"patch-package": "^6.2.2",
+				"postinstall-postinstall": "^2.1.0"
 			}
 		},
 		"@ethersproject/abi": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.1.tgz",
-			"integrity": "sha512-9fqSa3jEYV4nN8tijW+jz4UnT/Ma9/b8y4+nHlsvuWqr32E2kYsT9SCIVpk/51iM6NOud7xsA6UxCox9zBeHKg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+			"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/abstract-provider": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.1.tgz",
-			"integrity": "sha512-/KOw65ayviYPtKLqFE1qozeIJJlfI1wE/tNA+iKUPUai6bU6vg2tbfLFGarRTCQe3HoWV1t7xSsD/z9T9xg74g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+			"integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6"
 			}
 		},
 		"@ethersproject/abstract-signer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.1.tgz",
-			"integrity": "sha512-Rp8DP+cLcSNFkd1YhwPSBcgEWLRipNakitwIwHngAmhbo4zdiWgALD/OLqdQ7SKF75CufF1W4BCuXcQgiWaRow==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz",
+			"integrity": "sha512-nwSZKtCTKhJADlW42c+a//lWxQlnA7jYLTnabJ3YCfgGU6ic9jnT9nRDlAyT1U3kCMeqPL7fTcKbdWCVrM0xsw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
-			"integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+			"integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/rlp": "^5.0.3",
 				"bn.js": "^4.4.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/base64": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.1.tgz",
-			"integrity": "sha512-WZDa+TYl6BQfUm9EQIDDfJFL0GiuYXNZPIWoiZx3uds7P1XMsvcW3k71AyjYUxIkU5AKW7awwPbzCbBeP1uXsA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
+			"integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4"
 			}
 		},
 		"@ethersproject/basex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.1.tgz",
-			"integrity": "sha512-ssL2+p/A5bZgkZkiWy0iQDVz2mVJxZfzpf7dpw8t0sKF9VpoM3ZiMthRapH/QBhd4Rr6TNbr619pFLAGmMi9Ug==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
+			"integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.1.tgz",
-			"integrity": "sha512-srGDO7ksT0avdDw5pBtj6F81psv5xiJMInwSSatfIKplitubFb6yVwoHGObGRd0Pp3TvrkIDfJkuskoSMj4OHQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+			"integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"bn.js": "^4.4.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
-			"integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+			"integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
-			"integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+			"integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7"
 			}
 		},
 		"@ethersproject/contracts": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.1.tgz",
-			"integrity": "sha512-1uPajmkvw3Oy/dxs5TKUsGaXzQ3s5qiXKSVpw9ZrhGG6fMRO3gNyUA+uSWk9IXK0ulj5P95F7vW8HmYOkzep/Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+			"integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
-			"integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+			"integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/hdnode": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.1.tgz",
-			"integrity": "sha512-L2OZP4SKKxNtHUdwfK8cND09kHRH62ncxXW33WAJU9shKo8Sbz31HVqSdov84bMAGm8QfEKZbfbAJV/7DM6DjQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+			"integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/basex": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/json-wallets": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.1.tgz",
-			"integrity": "sha512-QjqQCh1a0a6wRVHdnqVccCLWX0vAgxnvGZeGqpOk2NbyNE8HTzV7GpOE+4LU+iCc8oonfy1gYd4hpsf+iEUWGg==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+			"integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
 				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1",
-				"uuid": "2.0.1"
+				"scrypt-js": "3.0.1"
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
-			"integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+			"integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
 				"js-sha3": "0.5.7"
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
-			"integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+			"integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
 			"dev": true
 		},
 		"@ethersproject/networks": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.1.tgz",
-			"integrity": "sha512-Pe34JCTC6Apm/DkK3z97xotvEyu9YHKIFlDIu5hGV6yFDb4/sUfY2SHKYSGdUrV0418ZZVrwYDveJtBFMmYu2Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
+			"integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/pbkdf2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.1.tgz",
-			"integrity": "sha512-4wc8Aov0iJmiomu6Dv1JNGOlhm3L7omITjLmChz/vgeDnW4Unv4J/nGybCeWKgY4hnjyQMVXkdkQ15BCRbkaYg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
+			"integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/sha2": "^5.0.3"
 			}
 		},
 		"@ethersproject/properties": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
-			"integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+			"integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/providers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.2.tgz",
-			"integrity": "sha512-28ABJmHB9ii/73F3P9CXLBvlRkitiOGHCrUZqjQ6FELuAtKEROqA/yDklT9o/r/BpGcGTeeWpWfvdfgDHjshiw==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.9.tgz",
+			"integrity": "sha512-UtGrlJxekFNV7lriPOxQbnYminyiwTgjHMPX83pG7N/W/t+PekQK8V9rdlvMr2bRyGgafHml0ZZMaTV4FxiBYg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/web": "^5.0.6",
+				"bech32": "1.1.4",
 				"ws": "7.2.3"
 			}
 		},
 		"@ethersproject/random": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.1.tgz",
-			"integrity": "sha512-nYzNhcp5Th4dCocV3yceZmh80bRmSQxqNRgND7Y/YgEgYJSSnknScpfRHACG//kgbsY8zui8ajXJeEnzS7yFbQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
+			"integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
-			"integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+			"integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/sha2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.1.tgz",
-			"integrity": "sha512-5wNdULNDMJKwyzqrTH66e2TZPZTSqqluS7RNtuuuQSTP+yIALoID7ewLjDoj31g4kZyq/pqQbackKJLOXejTKw==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
+			"integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"hash.js": "1.1.3"
 			},
 			"dependencies": {
@@ -420,377 +405,116 @@
 			}
 		},
 		"@ethersproject/signing-key": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.1.tgz",
-			"integrity": "sha512-Z3yMPFFf4KkWltndDNi/tpese7qZh6ZWKbGu3DHd8xOX0PJqbScdAs6gCfFeMatO06qyX307Y52soc/Ayf8ZSg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+			"integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"elliptic": "6.5.2"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				},
-				"elliptic": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"elliptic": "6.5.3"
 			}
 		},
 		"@ethersproject/solidity": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.1.tgz",
-			"integrity": "sha512-3L+xI1LaJmd2zBJxnK9Y4cd1vb2aJLFvL6fxvjWpzcMiFiZ4dbPwj3kharv5f5mAlbGwAs6NiPJaFWvbOpm96Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+			"integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
-			"integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+			"integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/transactions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
-			"integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+			"integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0"
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4"
 			}
 		},
 		"@ethersproject/units": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.1.tgz",
-			"integrity": "sha512-7J7Jmm4hMZ+yFiqEd7D5oeVK/V74GDwQlT0Om1yxXLYX6UPcV5ChHkUz/xpHPT9JXQlQ+2D69HBf1dzvdflrmQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+			"integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/wallet": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.1.tgz",
-			"integrity": "sha512-1/QPpFngJtUGtdVOLSoIN3vf+zEWyEVxQ0lhRCwGkiBqL2SoVoDHB7/nCfcv7wwlZkdnegFfo/8DxeyYjTZN7w==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+			"integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"@ethersproject/web": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.1.tgz",
-			"integrity": "sha512-lWPg8BR6KoyiIKYRIM6j+XO9bT9vGM1JnxFj2HmhIvOrOjba7ZRd8ANBOsDVGfw5igLUdfqAUOf9WpSsH//TzA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.7.tgz",
+			"integrity": "sha512-BM8FdGrzdcULYaOIyMXDKvxv+qOwGne8FKpPxUrifZIWAWPrq/y+oBOZlzadIKsP3wvYbAcMN2CgOLO1E3yIfw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/wordlists": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.1.tgz",
-			"integrity": "sha512-R7boLmpewucz5v4jD7cWwI0BGHR/DstiZtjdhUOft6XdMqM1OGb1UTL0GBQeS4vDXzCLuJEHddjJ69beGVN/4Q==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+			"integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
-			}
-		},
-		"@nomiclabs/buidler": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.4.5.tgz",
-			"integrity": "sha512-jaaVvG7OsrObhEBnLtQ/8L3J92+Jgioaw2+296dDO4Uc+MO/kprORbnpbE/WKvPL1geKQ4uj6VdCpM7qNCwL3g==",
-			"dev": true,
-			"requires": {
-				"@nomiclabs/ethereumjs-vm": "^4.1.1",
-				"@sentry/node": "^5.18.1",
-				"@solidity-parser/parser": "^0.5.2",
-				"@types/bn.js": "^4.11.5",
-				"@types/lru-cache": "^5.1.0",
-				"abort-controller": "^3.0.0",
-				"ansi-escapes": "^4.3.0",
-				"chalk": "^2.4.2",
-				"chokidar": "^3.4.0",
-				"ci-info": "^2.0.0",
-				"debug": "^4.1.1",
-				"deepmerge": "^2.1.0",
-				"download": "^7.1.0",
-				"enquirer": "^2.3.0",
-				"eth-sig-util": "^2.5.2",
-				"ethereum-cryptography": "^0.1.2",
-				"ethereumjs-abi": "^0.6.8",
-				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.0",
-				"ethereumjs-common": "^1.3.2",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "^6.1.0",
-				"find-up": "^2.1.0",
-				"fp-ts": "1.19.3",
-				"fs-extra": "^7.0.1",
-				"glob": "^7.1.3",
-				"io-ts": "1.10.4",
-				"is-installed-globally": "^0.2.0",
-				"lodash": "^4.17.11",
-				"merkle-patricia-tree": "^3.0.0",
-				"mocha": "^7.1.2",
-				"node-fetch": "^2.6.0",
-				"qs": "^6.7.0",
-				"raw-body": "^2.4.1",
-				"semver": "^6.3.0",
-				"slash": "^3.0.0",
-				"solc": "0.6.8",
-				"source-map-support": "^0.5.13",
-				"ts-essentials": "^2.0.7",
-				"tsort": "0.0.1",
-				"uuid": "^3.3.2",
-				"ws": "^7.2.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.9.4",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-					"dev": true
-				},
-				"require-from-string": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-					"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-					"dev": true
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"solc": {
-					"version": "0.6.8",
-					"resolved": "https://registry.npmjs.org/solc/-/solc-0.6.8.tgz",
-					"integrity": "sha512-7URBAisWVjO7dwWNpEkQ5dpRSpSF4Wm0aD5EB82D5BQKh+q7jhOxhgkG4K5gax/geM0kPZUAxnaLcgl2ZXBgMQ==",
-					"dev": true,
-					"requires": {
-						"command-exists": "^1.2.8",
-						"commander": "3.0.2",
-						"fs-extra": "^0.30.0",
-						"js-sha3": "0.8.0",
-						"memorystream": "^0.3.1",
-						"require-from-string": "^2.0.0",
-						"semver": "^5.5.0",
-						"tmp": "0.0.33"
-					},
-					"dependencies": {
-						"fs-extra": {
-							"version": "0.30.0",
-							"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-							"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.2",
-								"jsonfile": "^2.1.0",
-								"klaw": "^1.0.0",
-								"path-is-absolute": "^1.0.0",
-								"rimraf": "^2.2.8"
-							}
-						},
-						"jsonfile": {
-							"version": "2.4.0",
-							"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-							"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.6"
-							}
-						},
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
-					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
-			}
-		},
-		"@nomiclabs/buidler-ethers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/buidler-ethers/-/buidler-ethers-2.0.0.tgz",
-			"integrity": "sha512-Lf5XLClEeWYo6jVrGAqGBAcKTOP6IAChAR4qcDS36BkQnWakoRKcoSbwhr2YmTNTRAvgDWTmjQYbV17udJ+Alw==",
-			"dev": true
-		},
-		"@nomiclabs/ethereumjs-vm": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
-			"integrity": "sha512-+XwqoO941bILTO4KDLIUJ37U42ySxw6it7jyoi0tKv0/VUcOrWKF1TCQWMv6dBDRlxpPQd273n9o5SVlYYLRWQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.1.2",
-				"async-eventemitter": "^0.2.2",
-				"core-js-pure": "^3.0.1",
-				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.2",
-				"ethereumjs-blockchain": "^4.0.3",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-tx": "^2.1.2",
-				"ethereumjs-util": "^6.2.0",
-				"fake-merkle-patricia-tree": "^1.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"merkle-patricia-tree": "^2.3.2",
-				"rustbn.js": "~0.2.0",
-				"safe-buffer": "^5.1.1",
-				"util.promisify": "^1.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				},
-				"merkle-patricia-tree": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-					"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-					"dev": true,
-					"requires": {
-						"async": "^1.4.2",
-						"ethereumjs-util": "^5.0.0",
-						"level-ws": "0.0.0",
-						"levelup": "^1.2.1",
-						"memdown": "^1.0.0",
-						"readable-stream": "^2.0.0",
-						"rlp": "^2.0.0",
-						"semaphore": ">=1.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-							"dev": true
-						},
-						"ethereumjs-util": {
-							"version": "5.2.1",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-							"dev": true,
-							"requires": {
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"elliptic": "^6.5.2",
-								"ethereum-cryptography": "^0.1.3",
-								"ethjs-util": "^0.1.3",
-								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1"
-							}
-						}
-					}
-				}
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@resolver-engine/core": {
@@ -875,12 +599,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
-				},
-				"path-browserify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-					"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-					"dev": true
 				}
 			}
 		},
@@ -912,99 +630,6 @@
 				}
 			}
 		},
-		"@sentry/core": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.22.3.tgz",
-			"integrity": "sha512-eGL5uUarw3o4i9QUb9JoFHnhriPpWCaqeaIBB06HUpdcvhrjoowcKZj1+WPec5lFg5XusE35vez7z/FPzmJUDw==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/minimal": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/hub": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.22.3.tgz",
-			"integrity": "sha512-INo47m6N5HFEs/7GMP9cqxOIt7rmRxdERunA3H2L37owjcr77MwHVeeJ9yawRS6FMtbWXplgWTyTIWIYOuqVbw==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/minimal": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.22.3.tgz",
-			"integrity": "sha512-HoINpYnVYCpNjn2XIPIlqH5o4BAITpTljXjtAftOx6Hzj+Opjg8tR8PWliyKDvkXPpc4kXK9D6TpEDw8MO0wZA==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/node": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.22.3.tgz",
-			"integrity": "sha512-TCCKO7hJKiQi1nGmJcQfvbbqv98P08LULh7pb/NaO5pV20t1FtICfGx8UMpORRDehbcAiYq/f7rPOF6X/Xl5iw==",
-			"dev": true,
-			"requires": {
-				"@sentry/core": "5.22.3",
-				"@sentry/hub": "5.22.3",
-				"@sentry/tracing": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"cookie": "^0.4.1",
-				"https-proxy-agent": "^5.0.0",
-				"lru_map": "^0.3.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/tracing": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.22.3.tgz",
-			"integrity": "sha512-Zp59kMCk5v56ZAyErqjv/QvGOWOQ5fRltzeVQVp8unIDTk6gEFXfhwPsYHOokJe1mfkmrgPDV6xAkYgtL3KCDQ==",
-			"dev": true,
-			"requires": {
-				"@sentry/hub": "5.22.3",
-				"@sentry/minimal": "5.22.3",
-				"@sentry/types": "5.22.3",
-				"@sentry/utils": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sentry/types": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.22.3.tgz",
-			"integrity": "sha512-cv+VWK0YFgCVDvD1/HrrBWOWYG3MLuCUJRBTkV/Opdy7nkdNjhCAJQrEyMM9zX0sac8FKWKOHT0sykNh8KgmYw==",
-			"dev": true
-		},
-		"@sentry/utils": {
-			"version": "5.22.3",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.22.3.tgz",
-			"integrity": "sha512-AHNryXMBvIkIE+GQxTlmhBXD0Ksh+5w1SwM5qi6AttH+1qjWLvV6WB4+4pvVvEoS8t5F+WaVUZPQLmCCWp6zKw==",
-			"dev": true,
-			"requires": {
-				"@sentry/types": "5.22.3",
-				"tslib": "^1.9.3"
-			}
-		},
-		"@sindresorhus/is": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-			"dev": true
-		},
-		"@solidity-parser/parser": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
-			"integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==",
-			"dev": true
-		},
 		"@types/bn.js": {
 			"version": "4.11.6",
 			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -1014,9 +639,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ=="
 		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
@@ -1026,12 +651,6 @@
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/lru-cache": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-			"integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
-			"dev": true
 		},
 		"@types/mkdirp": {
 			"version": "0.5.2",
@@ -1043,9 +662,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "14.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-			"integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -1070,28 +689,10 @@
 				}
 			}
 		},
-		"@types/pbkdf2": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/sinon": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.4.tgz",
-			"integrity": "sha512-sJmb32asJZY6Z2u09bl0G2wglSxDlROlAejCjsnor+LzBMz17gu8IU7vKC/vWDnv9zEq2wqADHVXFjf4eE8Gdw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",
+			"integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
 			"requires": {
 				"@types/sinonjs__fake-timers": "*"
 			}
@@ -1111,9 +712,9 @@
 			"integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
 		},
 		"@types/underscore": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.0.tgz",
-			"integrity": "sha512-ZAbqul7QAKpM2h1PFGa5ETN27ulmqtj0QviYHasw9LffvXZvVHuraOx/FOsIPPDNGZN0Qo1nASxxSfMYOtSoCw=="
+			"version": "1.10.23",
+			"resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.23.tgz",
+			"integrity": "sha512-vX1NPekXhrLquFWskH2thcvFAha187F/lM6xYOoEMZWwJ/6alSk0/ttmGP/YRqcqtCv0TMbZjYAdZyHAEcuU4g=="
 		},
 		"@types/web3": {
 			"version": "1.0.19",
@@ -1124,46 +725,11 @@
 				"@types/underscore": "*"
 			}
 		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^5.0.0"
-			}
-		},
-		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-			"dev": true,
-			"requires": {
-				"xtend": "~4.0.0"
-			}
-		},
-		"acorn": {
-			"version": "5.7.4",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+		"@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
 			"dev": true
-		},
-		"acorn-dynamic-import": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true,
-			"requires": {
-				"acorn": "^4.0.3"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-					"dev": true
-				}
-			}
 		},
 		"aes-js": {
 			"version": "3.0.0",
@@ -1171,74 +737,16 @@
 			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
 			"dev": true
 		},
-		"agent-base": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
-			"dev": true,
-			"requires": {
-				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
-			}
-		},
-		"ajv-keywords": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
-			"integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
-			"dev": true
-		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			}
-		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
-		},
-		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.11.0"
 			}
 		},
 		"ansi-regex": {
@@ -1256,69 +764,29 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			}
-		},
-		"archive-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
-			"integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
-			"dev": true,
-			"requires": {
-				"file-type": "^4.2.0"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-					"integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
-					"dev": true
-				}
-			}
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -1327,52 +795,6 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
-			}
-		},
-		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"assert": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.1",
-				"util": "0.10.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
-				},
-				"util": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.1"
-					}
-				}
 			}
 		},
 		"assert-plus": {
@@ -1391,33 +813,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true,
-			"optional": true
-		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"async-each": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-			"dev": true,
-			"optional": true
-		},
-		"async-eventemitter": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-			"dev": true,
-			"requires": {
-				"async": "^2.4.0"
-			}
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1429,8 +825,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -1439,9 +834,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -1455,7 +850,6 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -1471,7 +865,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -1481,7 +874,6 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -1491,7 +883,6 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -1501,35 +892,13 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
 				}
 			}
-		},
-		"base-x": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -1540,42 +909,10 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"big.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true
-		},
-		"binary-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-			"dev": true,
-			"optional": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"blakejs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
 			"dev": true
 		},
 		"bluebird": {
@@ -1585,9 +922,9 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-			"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -1601,12 +938,32 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -1615,195 +972,10 @@
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 			"dev": true
 		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
-		"browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
-			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"browserify-rsa": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"browserify-sign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-			"integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.2",
-				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				}
-			}
-		},
-		"browserify-zlib": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
-			"requires": {
-				"pako": "~1.0.5"
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"dev": true,
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"dev": true,
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-			"dev": true,
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
-			}
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-		},
-		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
 		"buffer-to-arraybuffer": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
 			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-			"dev": true
-		},
-		"buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
-		},
-		"builtin-status-codes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cache-base": {
@@ -1811,7 +983,6 @@
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -1824,33 +995,10 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"cacheable-request": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"dev": true,
-			"requires": {
-				"clone-response": "1.0.2",
-				"get-stream": "3.0.0",
-				"http-cache-semantics": "3.8.1",
-				"keyv": "3.0.0",
-				"lowercase-keys": "1.0.0",
-				"normalize-url": "2.0.1",
-				"responselike": "1.0.2"
-			},
-			"dependencies": {
-				"lowercase-keys": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-					"dev": true
-				}
-			}
-		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 			"dev": true
 		},
 		"caseless": {
@@ -1858,28 +1006,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"caw": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
-			"dev": true,
-			"requires": {
-				"get-proxy": "^2.0.0",
-				"isurl": "^1.0.0-alpha5",
-				"tunnel-agent": "^0.6.0",
-				"url-to-options": "^1.0.1"
-			}
-		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			}
 		},
 		"chai": {
 			"version": "4.2.0",
@@ -1904,23 +1030,6 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"check-error": {
@@ -1929,53 +1038,17 @@
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
-		"checkpoint-store": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
-			"integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
-			"dev": true,
-			"requires": {
-				"functional-red-black-tree": "^1.0.1"
-			}
-		},
-		"chokidar": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-			"integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
-			"dev": true,
-			"requires": {
-				"anymatch": "~3.1.1",
-				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
-				"glob-parent": "~5.1.0",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
-			}
-		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"dev": true
 		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -1988,7 +1061,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -1996,23 +1068,14 @@
 			}
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"dev": true,
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
-			}
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"code-point-at": {
@@ -2026,7 +1089,6 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -2072,8 +1134,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2081,144 +1142,29 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"config-chain": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.4",
-				"proto-list": "~1.2.1"
-			}
-		},
-		"console-browserify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-			"dev": true
-		},
-		"constants-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
-		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"dev": true
-		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true,
-			"optional": true
-		},
-		"core-js-pure": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
 			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			}
-		},
-		"crypto-browserify": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
-			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
-			}
-		},
-		"d": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-			"dev": true,
-			"requires": {
-				"es5-ext": "^0.10.50",
-				"type": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -2235,7 +1181,6 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -2252,21 +1197,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-			"requires": {
-				"decompress-tar": "^4.0.0",
-				"decompress-tarbz2": "^4.0.0",
-				"decompress-targz": "^4.0.0",
-				"decompress-unzip": "^4.0.1",
-				"graceful-fs": "^4.1.10",
-				"make-dir": "^1.0.0",
-				"pify": "^2.3.0",
-				"strip-dirs": "^2.0.0"
-			}
-		},
 		"decompress-response": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -2274,86 +1204,6 @@
 			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
-			}
-		},
-		"decompress-tar": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-			"requires": {
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0",
-				"tar-stream": "^1.5.2"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-				}
-			}
-		},
-		"decompress-tarbz2": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-			"requires": {
-				"decompress-tar": "^4.1.0",
-				"file-type": "^6.1.0",
-				"is-stream": "^1.1.0",
-				"seek-bzip": "^1.0.5",
-				"unbzip2-stream": "^1.0.9"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
-				}
-			}
-		},
-		"decompress-targz": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-			"requires": {
-				"decompress-tar": "^4.1.1",
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-				}
-			}
-		},
-		"decompress-unzip": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-			"requires": {
-				"file-type": "^3.8.0",
-				"get-stream": "^2.2.0",
-				"pify": "^2.3.0",
-				"yauzl": "^2.4.2"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-				},
-				"get-stream": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-					"requires": {
-						"object-assign": "^4.0.1",
-						"pinkie-promise": "^2.0.0"
-					}
-				}
 			}
 		},
 		"deep-eql": {
@@ -2365,44 +1215,11 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"deepmerge": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
-			"dev": true
-		},
-		"deferred-leveldown": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~2.6.0"
-			}
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -2413,7 +1230,6 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2423,7 +1239,6 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2433,19 +1248,11 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
 				}
 			}
 		},
@@ -2455,91 +1262,10 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
-		"des.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
-		"diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
 		"dom-walk": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
 			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-			"dev": true
-		},
-		"domain-browser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
-		},
-		"download": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
-			"integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
-			"dev": true,
-			"requires": {
-				"archive-type": "^4.0.0",
-				"caw": "^2.0.1",
-				"content-disposition": "^0.5.2",
-				"decompress": "^4.2.0",
-				"ext-name": "^5.0.0",
-				"file-type": "^8.1.0",
-				"filenamify": "^2.0.0",
-				"get-stream": "^3.0.0",
-				"got": "^8.3.1",
-				"make-dir": "^1.2.0",
-				"p-event": "^2.1.0",
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
 		},
 		"ecc-jsbn": {
@@ -2565,116 +1291,6 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
-		"emojis-list": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-			"dev": true
-		},
-		"encoding-down": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-			"integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "^5.0.0",
-				"inherits": "^2.0.3",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0",
-				"xtend": "^4.0.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
-				"level-codec": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-					"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.6.0"
-					}
-				},
-				"level-errors": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
-					"requires": {
-						"errno": "~0.1.1"
-					}
-				}
-			}
-		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
-		"enhanced-resolve": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"object-assign": "^4.0.1",
-				"tapable": "^0.2.7"
-			}
-		},
-		"enquirer": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "^4.1.1"
-			}
-		},
-		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
-			"requires": {
-				"prr": "~1.0.1"
 			}
 		},
 		"error-ex": {
@@ -2686,164 +1302,10 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"es-abstract": {
-			"version": "1.17.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-			"dev": true,
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.2.0",
-				"is-regex": "^1.1.0",
-				"object-inspect": "^1.7.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimend": "^1.0.1",
-				"string.prototype.trimstart": "^1.0.1"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			}
-		},
-		"es5-ext": {
-			"version": "0.10.53",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-			"dev": true,
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.3",
-				"next-tick": "~1.0.0"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-map": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-set": "~0.1.5",
-				"es6-symbol": "~3.1.1",
-				"event-emitter": "~0.3.5"
-			}
-		},
-		"es6-set": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
-			},
-			"dependencies": {
-				"es6-symbol": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-					"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-					"dev": true,
-					"requires": {
-						"d": "1",
-						"es5-ext": "~0.10.14"
-					}
-				}
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-			"dev": true,
-			"requires": {
-				"d": "^1.0.1",
-				"ext": "^1.1.2"
-			}
-		},
-		"es6-weak-map": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.46",
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.1"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"escope": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"dev": true,
-			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			}
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
-			"requires": {
-				"estraverse": "^4.1.0"
-			}
-		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"eth-ens-namehash": {
@@ -2857,137 +1319,14 @@
 			}
 		},
 		"eth-lib": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-			"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+			"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.11.6",
 				"elliptic": "^6.4.0",
 				"xhr-request-promise": "^0.1.2"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"eth-sig-util": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.3.tgz",
-			"integrity": "sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"elliptic": "^6.4.0",
-				"ethereumjs-abi": "0.6.5",
-				"ethereumjs-util": "^5.1.1",
-				"tweetnacl": "^1.0.0",
-				"tweetnacl-util": "^0.15.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
-				"ethereumjs-abi": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-					"integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.10.0",
-						"ethereumjs-util": "^4.3.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "4.5.1",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-							"integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
-							"dev": true,
-							"requires": {
-								"bn.js": "^4.8.0",
-								"create-hash": "^1.1.2",
-								"elliptic": "^6.5.2",
-								"ethereum-cryptography": "^0.1.3",
-								"rlp": "^2.0.0"
-							}
-						}
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-					"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-					"dev": true
-				}
-			}
-		},
-		"ethashjs": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
-			"integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
-			"dev": true,
-			"requires": {
-				"async": "^2.1.2",
-				"buffer-xor": "^2.0.1",
-				"ethereumjs-util": "^7.0.2",
-				"miller-rabin": "^4.0.0"
-			},
-			"dependencies": {
-				"buffer-xor": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
-					"integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"ethereumjs-util": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
-					"integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
-					"dev": true,
-					"requires": {
-						"@types/bn.js": "^4.11.3",
-						"bn.js": "^5.1.2",
-						"create-hash": "^1.1.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "0.1.6",
-						"rlp": "^2.2.4"
-					}
-				}
 			}
 		},
 		"ethereum-bloom-filters": {
@@ -3007,249 +1346,55 @@
 				}
 			}
 		},
-		"ethereum-cryptography": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-			"dev": true,
-			"requires": {
-				"@types/pbkdf2": "^3.0.0",
-				"@types/secp256k1": "^4.0.1",
-				"blakejs": "^1.1.0",
-				"browserify-aes": "^1.2.0",
-				"bs58check": "^2.1.2",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"hash.js": "^1.1.7",
-				"keccak": "^3.0.0",
-				"pbkdf2": "^3.0.17",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.1.2",
-				"scrypt-js": "^3.0.0",
-				"secp256k1": "^4.0.1",
-				"setimmediate": "^1.0.5"
-			}
-		},
 		"ethereum-waffle": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.0.0.tgz",
-			"integrity": "sha512-r7hQHGs6uuUIcZxcwsxXbntk6XQkdC4HST4lFN493H9Ac9JLnYbaQ3Yp2qeGK7P7BqrDUqGZwylSIT+1odtAmA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.1.0.tgz",
+			"integrity": "sha512-QSEzYhxBAjJAgVXZcR1lMB4Px1lAtf8M3QQPIflasNwHpw/VZWaYqN4o2fl615iPtOc3FFtMu1JSEbiuYojk/w==",
 			"dev": true,
 			"requires": {
-				"@ethereum-waffle/chai": "^3.0.0",
-				"@ethereum-waffle/compiler": "^3.0.0",
-				"@ethereum-waffle/mock-contract": "^3.0.0",
-				"@ethereum-waffle/provider": "^3.0.0",
+				"@ethereum-waffle/chai": "^3.1.0",
+				"@ethereum-waffle/compiler": "^3.1.0",
+				"@ethereum-waffle/mock-contract": "^3.1.0",
+				"@ethereum-waffle/provider": "^3.1.0",
 				"ethers": "^5.0.1"
 			}
 		},
-		"ethereumjs-abi": {
-			"version": "0.6.8",
-			"resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-			"integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.8",
-				"ethereumjs-util": "^6.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"ethereumjs-account": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
-			"integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-util": "^6.0.0",
-				"rlp": "^2.2.1",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"ethereumjs-block": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-			"integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-			"dev": true,
-			"requires": {
-				"async": "^2.0.1",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "^5.0.0",
-				"merkle-patricia-tree": "^2.1.2"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				},
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"merkle-patricia-tree": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-					"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-					"dev": true,
-					"requires": {
-						"async": "^1.4.2",
-						"ethereumjs-util": "^5.0.0",
-						"level-ws": "0.0.0",
-						"levelup": "^1.2.1",
-						"memdown": "^1.0.0",
-						"readable-stream": "^2.0.0",
-						"rlp": "^2.0.0",
-						"semaphore": ">=1.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"ethereumjs-blockchain": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
-			"integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"ethashjs": "~0.0.7",
-				"ethereumjs-block": "~2.2.2",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.1.0",
-				"flow-stoplight": "^1.0.0",
-				"level-mem": "^3.0.1",
-				"lru-cache": "^5.1.1",
-				"rlp": "^2.2.2",
-				"semaphore": "^1.1.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
-				}
-			}
-		},
-		"ethereumjs-common": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
-			"dev": true
-		},
-		"ethereumjs-testrpc": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.3.tgz",
-			"integrity": "sha512-lAxxsxDKK69Wuwqym2K49VpXtBvLEsXr1sryNG4AkvL5DomMdeCBbu3D87UEevKenLHBiT8GTjARwN6Yj039gA==",
-			"dev": true,
-			"requires": {
-				"webpack": "^3.0.0"
-			}
-		},
-		"ethereumjs-tx": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-			"integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.0.0"
-			}
-		},
-		"ethereumjs-util": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-			"dev": true,
-			"requires": {
-				"@types/bn.js": "^4.11.3",
-				"bn.js": "^4.11.0",
-				"create-hash": "^1.1.2",
-				"elliptic": "^6.5.2",
-				"ethereum-cryptography": "^0.1.3",
-				"ethjs-util": "0.1.6",
-				"rlp": "^2.2.3"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
 		"ethers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.2.tgz",
-			"integrity": "sha512-hAWTPQXvjFlrtnPLCnOOJJuqiqmJv820egPHpOwcWTIQxXRrcfZyse2692eaqsXMeYLNM2CRfYgEomBiBGvgjw==",
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz",
+			"integrity": "sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/abi": "^5.0.0",
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/contracts": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/json-wallets": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/providers": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/solidity": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/units": "^5.0.0",
-				"@ethersproject/wallet": "^5.0.0",
-				"@ethersproject/web": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
+				"@ethersproject/abi": "^5.0.5",
+				"@ethersproject/abstract-provider": "^5.0.4",
+				"@ethersproject/abstract-signer": "^5.0.4",
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/base64": "^5.0.3",
+				"@ethersproject/basex": "^5.0.3",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/contracts": "^5.0.4",
+				"@ethersproject/hash": "^5.0.4",
+				"@ethersproject/hdnode": "^5.0.4",
+				"@ethersproject/json-wallets": "^5.0.6",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/networks": "^5.0.3",
+				"@ethersproject/pbkdf2": "^5.0.3",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/providers": "^5.0.8",
+				"@ethersproject/random": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/sha2": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4",
+				"@ethersproject/solidity": "^5.0.4",
+				"@ethersproject/strings": "^5.0.4",
+				"@ethersproject/transactions": "^5.0.5",
+				"@ethersproject/units": "^5.0.4",
+				"@ethersproject/wallet": "^5.0.4",
+				"@ethersproject/web": "^5.0.6",
+				"@ethersproject/wordlists": "^5.0.4"
 			}
 		},
 		"ethjs-unit": {
@@ -3270,69 +1415,11 @@
 				}
 			}
 		},
-		"ethjs-util": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-			"dev": true,
-			"requires": {
-				"is-hex-prefixed": "1.0.0",
-				"strip-hex-prefix": "1.0.0"
-			}
-		},
-		"event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true
-		},
-		"events": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-			"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
-			"dev": true
-		},
-		"evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			}
-		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -3348,7 +1435,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -3358,47 +1444,10 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
-			}
-		},
-		"ext": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-			"dev": true,
-			"requires": {
-				"type": "^2.0.0"
-			},
-			"dependencies": {
-				"type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
-					"dev": true
-				}
-			}
-		},
-		"ext-list": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
-			"dev": true,
-			"requires": {
-				"mime-db": "^1.28.0"
-			}
-		},
-		"ext-name": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
-			"dev": true,
-			"requires": {
-				"ext-list": "^2.0.0",
-				"sort-keys-length": "^1.0.0"
 			}
 		},
 		"extend": {
@@ -3412,7 +1461,6 @@
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -3423,7 +1471,6 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -3435,7 +1482,6 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -3452,7 +1498,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -3462,7 +1507,6 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -3472,7 +1516,6 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3482,7 +1525,6 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3492,19 +1534,11 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
 				}
 			}
 		},
@@ -3513,15 +1547,6 @@
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
-		},
-		"fake-merkle-patricia-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
-			"integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
-			"dev": true,
-			"requires": {
-				"checkpoint-store": "^1.1.0"
-			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -3535,92 +1560,76 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"requires": {
-				"pend": "~1.2.0"
-			}
-		},
-		"file-type": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-			"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
-			"dev": true
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
-		},
-		"filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-			"dev": true
-		},
-		"filenamify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
-			"dev": true,
-			"requires": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.0",
-				"trim-repeated": "^1.0.0"
-			}
-		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
-		},
-		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
-			}
-		},
-		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "~2.0.3"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-					"dev": true
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
 				}
 			}
 		},
-		"flow-stoplight": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
-			"integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=",
-			"dev": true
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
+			"requires": {
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
+			}
+		},
+		"find-yarn-workspace-root": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+			"integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^4.0.3",
+				"micromatch": "^3.1.4"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				}
+			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -3639,36 +1648,14 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"fp-ts": {
-			"version": "1.19.3",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
-			"integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
-			"dev": true
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"from2": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
-			}
-		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-extra": {
 			"version": "0.30.0",
@@ -3689,702 +1676,10 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"dev": true,
-			"optional": true
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
-		},
-		"ganache-cli": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.9.1.tgz",
-			"integrity": "sha512-VPBumkNUZzXDRQwVOby5YyQpd5t1clkr06xMgB28lZdEIn5ht1GMwUskOTFOAxdkQ4J12IWP0gdeacVRGowqbA==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-util": "6.1.0",
-				"source-map-support": "0.5.12",
-				"yargs": "13.2.4"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"bindings": {
-					"version": "1.5.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"file-uri-to-path": "1.0.0"
-					}
-				},
-				"bip66": {
-					"version": "1.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"bn.js": {
-					"version": "4.11.8",
-					"bundled": true,
-					"dev": true
-				},
-				"brorand": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"browserify-aes": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-xor": "^1.0.3",
-						"cipher-base": "^1.0.0",
-						"create-hash": "^1.1.0",
-						"evp_bytestokey": "^1.0.3",
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"buffer-from": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"buffer-xor": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"bundled": true,
-					"dev": true
-				},
-				"cipher-base": {
-					"version": "1.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"bundled": true,
-					"dev": true
-				},
-				"create-hash": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cipher-base": "^1.0.1",
-						"inherits": "^2.0.1",
-						"md5.js": "^1.3.4",
-						"ripemd160": "^2.0.1",
-						"sha.js": "^2.4.0"
-					}
-				},
-				"create-hmac": {
-					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cipher-base": "^1.0.3",
-						"create-hash": "^1.1.0",
-						"inherits": "^2.0.1",
-						"ripemd160": "^2.0.0",
-						"safe-buffer": "^5.0.1",
-						"sha.js": "^2.4.8"
-					}
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"drbg.js": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"browserify-aes": "^1.0.6",
-						"create-hash": "^1.1.2",
-						"create-hmac": "^1.1.4"
-					}
-				},
-				"elliptic": {
-					"version": "6.5.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"end-of-stream": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "^1.4.0"
-					}
-				},
-				"ethereumjs-util": {
-					"version": "6.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "0.1.6",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"ethjs-util": {
-					"version": "0.1.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-hex-prefixed": "1.0.0",
-						"strip-hex-prefix": "1.0.0"
-					}
-				},
-				"evp_bytestokey": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"md5.js": "^1.3.4",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"file-uri-to-path": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"bundled": true,
-					"dev": true
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"hash-base": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"hash.js": {
-					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.1"
-					}
-				},
-				"hmac-drbg": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hash.js": "^1.0.3",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"bundled": true,
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-hex-prefixed": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"map-age-cleaner": {
-					"version": "0.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-defer": "^1.0.0"
-					}
-				},
-				"md5.js": {
-					"version": "1.3.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hash-base": "^3.0.0",
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.1.2"
-					}
-				},
-				"mem": {
-					"version": "4.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^2.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"minimalistic-assert": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"minimalistic-crypto-utils": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"nan": {
-					"version": "2.14.0",
-					"bundled": true,
-					"dev": true
-				},
-				"nice-try": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-defer": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-finally": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-is-promise": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"pump": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"ripemd160": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hash-base": "^3.0.0",
-						"inherits": "^2.0.1"
-					}
-				},
-				"rlp": {
-					"version": "2.2.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.1",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"secp256k1": {
-					"version": "3.7.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"bip66": "^1.1.5",
-						"bn.js": "^4.11.8",
-						"create-hash": "^1.2.0",
-						"drbg.js": "^1.0.1",
-						"elliptic": "^6.4.1",
-						"nan": "^2.14.0",
-						"safe-buffer": "^5.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"bundled": true,
-					"dev": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"sha.js": {
-					"version": "2.4.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"bundled": true,
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.12",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"strip-hex-prefix": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-hex-prefixed": "1.0.0"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"yargs": {
-					"version": "13.2.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"os-locale": "^3.1.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"ganache-core": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.10.2.tgz",
-			"integrity": "sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==",
+			"version": "2.11.3",
+			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.3.tgz",
+			"integrity": "sha512-SsFJUnyiZI+jW3I43XluXi3TvJC3Ke6vZkvN6NjbWpXvi6dOrmafkyq9Rq07+Qrri6BLGKWoZcG8HfH6ietuqg==",
 			"dev": true,
 			"requires": {
 				"abstract-leveldown": "3.0.0",
@@ -4401,12 +1696,13 @@
 				"ethereumjs-common": "1.5.0",
 				"ethereumjs-tx": "2.1.2",
 				"ethereumjs-util": "6.2.0",
-				"ethereumjs-vm": "4.1.3",
+				"ethereumjs-vm": "4.2.0",
 				"ethereumjs-wallet": "0.6.3",
 				"heap": "0.2.6",
 				"level-sublevel": "6.6.4",
 				"levelup": "3.1.1",
 				"lodash": "4.17.14",
+				"lru-cache": "5.1.1",
 				"merkle-patricia-tree": "2.3.2",
 				"seedrandom": "3.0.1",
 				"source-map-support": "0.5.12",
@@ -4417,30 +1713,31 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"requires": {
-						"@babel/highlight": "^7.8.3"
+						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/core": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-					"integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+					"version": "7.11.1",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+					"integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.3",
-						"@babel/helpers": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/traverse": "^7.8.3",
-						"@babel/types": "^7.8.3",
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.11.0",
+						"@babel/helper-module-transforms": "^7.11.0",
+						"@babel/helpers": "^7.10.4",
+						"@babel/parser": "^7.11.1",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.11.0",
+						"@babel/types": "^7.11.0",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.13",
+						"json5": "^2.1.2",
+						"lodash": "^4.17.19",
 						"resolve": "^1.3.2",
 						"semver": "^5.4.1",
 						"source-map": "^0.5.0"
@@ -4455,17 +1752,17 @@
 							}
 						},
 						"json5": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-							"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+							"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 							"requires": {
-								"minimist": "^1.2.0"
+								"minimist": "^1.2.5"
 							}
 						},
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"semver": {
 							"version": "5.7.1",
@@ -4480,13 +1777,12 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-					"integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+					"integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
 					"requires": {
-						"@babel/types": "^7.8.3",
+						"@babel/types": "^7.11.0",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					},
 					"dependencies": {
@@ -4503,48 +1799,118 @@
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-get-function-arity": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
 					"requires": {
-						"@babel/types": "^7.8.3"
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+					"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.10.4",
+						"@babel/helper-simple-access": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.11.0",
+						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+						}
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+					"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+					"requires": {
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 					"requires": {
-						"@babel/types": "^7.8.3"
+						"@babel/types": "^7.11.0"
 					}
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
 				"@babel/helpers": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-					"integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+					"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
 					"requires": {
-						"@babel/template": "^7.8.3",
-						"@babel/traverse": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					},
 					"dependencies": {
@@ -4582,49 +1948,34 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-					"integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
-				},
-				"@babel/runtime": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-					"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					},
-					"dependencies": {
-						"regenerator-runtime": {
-							"version": "0.13.3",
-							"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-							"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-						}
-					}
+					"version": "7.11.2",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
 				},
 				"@babel/template": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-					"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/types": "^7.8.3"
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-					"integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+					"integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
 					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.3",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.3",
-						"@babel/types": "^7.8.3",
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.11.0",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.11.0",
+						"@babel/types": "^7.11.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
+						"lodash": "^4.17.19"
 					},
 					"dependencies": {
 						"debug": {
@@ -4639,19 +1990,29 @@
 							"version": "11.12.0",
 							"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 							"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+						},
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-					"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+					"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					},
 					"dependencies": {
+						"lodash": {
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+						},
 						"to-fast-properties": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -4660,12 +2021,13 @@
 					}
 				},
 				"@istanbuljs/load-nyc-config": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-					"integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+					"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 					"requires": {
 						"camelcase": "^5.3.1",
 						"find-up": "^4.1.0",
+						"get-package-type": "^0.1.0",
 						"js-yaml": "^3.13.1",
 						"resolve-from": "^5.0.0"
 					},
@@ -4693,9 +2055,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -4772,15 +2134,38 @@
 					"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 					"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 				},
+				"@types/json-schema": {
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+					"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+				},
 				"@types/node": {
-					"version": "13.5.2",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
-					"integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
+					"version": "14.0.27",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+					"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
 				},
 				"@types/parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+				},
+				"@types/pbkdf2": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+					"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/secp256k1": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+					"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*"
+					}
 				},
 				"@types/web3": {
 					"version": "1.2.2",
@@ -4835,11 +2220,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 						}
 					}
 				},
@@ -5030,14 +2410,14 @@
 					}
 				},
 				"acorn": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
 				},
 				"acorn-jsx": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-					"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 				},
 				"aes-js": {
 					"version": "3.1.2",
@@ -5063,9 +2443,9 @@
 					}
 				},
 				"ajv": {
-					"version": "6.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-					"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+					"version": "6.12.3",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+					"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -5079,9 +2459,9 @@
 					"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 				},
 				"ajv-keywords": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-					"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 				},
 				"ansi-colors": {
 					"version": "1.1.0",
@@ -5093,11 +2473,18 @@
 					}
 				},
 				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
 					"requires": {
-						"type-fest": "^0.8.1"
+						"type-fest": "^0.11.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.11.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+							"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+						}
 					}
 				},
 				"ansi-gray": {
@@ -5142,6 +2529,16 @@
 					"requires": {
 						"micromatch": "^3.1.4",
 						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
 					}
 				},
 				"append-buffer": {
@@ -5424,9 +2821,9 @@
 					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 				},
 				"aws4": {
-					"version": "1.9.1",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-					"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+					"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
@@ -6029,12 +3426,12 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"dev": true,
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"source-map": {
@@ -6220,11 +3617,10 @@
 					}
 				},
 				"base-x": {
-					"version": "3.0.7",
-					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-					"integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+					"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -6300,7 +3696,56 @@
 					"requires": {
 						"readable-stream": "^2.3.5",
 						"safe-buffer": "^5.1.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+								}
+							}
+						}
 					}
+				},
+				"blakejs": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+					"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+					"dev": true
 				},
 				"bluebird": {
 					"version": "3.7.2",
@@ -6308,9 +3753,9 @@
 					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+					"version": "4.11.9",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 				},
 				"body-parser": {
 					"version": "1.19.0",
@@ -6442,28 +3887,27 @@
 						"randombytes": "^2.0.1"
 					}
 				},
-				"browserify-sha3": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-					"integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-					"dev": true,
-					"requires": {
-						"js-sha3": "^0.6.1",
-						"safe-buffer": "^5.1.1"
-					}
-				},
 				"browserify-sign": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-					"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+					"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
 					"requires": {
-						"bn.js": "^4.1.1",
-						"browserify-rsa": "^4.0.0",
-						"create-hash": "^1.1.0",
-						"create-hmac": "^1.1.2",
-						"elliptic": "^6.0.0",
-						"inherits": "^2.0.1",
-						"parse-asn1": "^5.0.0"
+						"bn.js": "^5.1.1",
+						"browserify-rsa": "^4.0.1",
+						"create-hash": "^1.2.0",
+						"create-hmac": "^1.1.7",
+						"elliptic": "^6.5.3",
+						"inherits": "^2.0.4",
+						"parse-asn1": "^5.1.5",
+						"readable-stream": "^3.6.0",
+						"safe-buffer": "^5.2.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+							"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+						}
 					}
 				},
 				"browserify-zlib": {
@@ -6489,7 +3933,6 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"base-x": "^3.0.2"
 					}
@@ -6499,7 +3942,6 @@
 					"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
 					"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"bs58": "^4.0.0",
 						"create-hash": "^1.1.0",
@@ -6507,9 +3949,9 @@
 					}
 				},
 				"buffer": {
-					"version": "5.4.3",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-					"integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -6622,35 +4064,20 @@
 								"minipass": "^3.0.0"
 							}
 						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"requires": {
-								"yallist": "^3.0.2"
-							},
-							"dependencies": {
-								"yallist": {
-									"version": "3.1.1",
-									"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-									"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-								}
-							}
-						},
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"p-map": {
@@ -6731,6 +4158,15 @@
 							"requires": {
 								"xtend": "~4.0.0"
 							}
+						},
+						"lru-cache": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+							"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+							"dev": true,
+							"requires": {
+								"pseudomap": "^1.0.1"
+							}
 						}
 					}
 				},
@@ -6746,9 +4182,9 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -6772,9 +4208,9 @@
 					"dev": true
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001023",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
-					"integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
+					"version": "1.0.30001111",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
+					"integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
 					"dev": true
 				},
 				"caseless": {
@@ -6825,19 +4261,12 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-						}
 					}
 				},
 				"chownr": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-					"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 				},
 				"chrome-trace-event": {
 					"version": "1.0.2",
@@ -6912,9 +4341,9 @@
 					}
 				},
 				"cli-width": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+					"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -6962,32 +4391,50 @@
 						"inherits": "^2.0.1",
 						"process-nextick-args": "^2.0.0",
 						"readable-stream": "^2.3.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-				},
-				"coinstring": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
-					"integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"bs58": "^2.0.1",
-						"create-hash": "^1.1.1"
-					},
-					"dependencies": {
-						"bs58": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-							"integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
-							"dev": true,
-							"optional": true
-						}
-					}
 				},
 				"collection-map": {
 					"version": "1.0.0",
@@ -7037,17 +4484,14 @@
 					}
 				},
 				"command-exists": {
-					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-					"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+					"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
 				},
 				"commander": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				},
 				"commondir": {
 					"version": "1.0.1",
@@ -7073,6 +4517,40 @@
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.2.2",
 						"typedarray": "^0.0.6"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"console-browserify": {
@@ -7154,11 +4632,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -7184,9 +4662,9 @@
 					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"core-js-pure": {
-					"version": "3.6.4",
-					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-					"integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
+					"version": "3.6.5",
+					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+					"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
 					"dev": true
 				},
 				"core-util-is": {
@@ -7216,9 +4694,9 @@
 					},
 					"dependencies": {
 						"parse-json": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-							"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+							"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
 							"requires": {
 								"@babel/code-frame": "^7.0.0",
 								"error-ex": "^1.3.1",
@@ -7234,31 +4712,24 @@
 					}
 				},
 				"coveralls": {
-					"version": "3.0.9",
-					"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-					"integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+					"integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
 					"requires": {
 						"js-yaml": "^3.13.1",
 						"lcov-parse": "^1.0.0",
 						"log-driver": "^1.2.7",
-						"minimist": "^1.2.0",
-						"request": "^2.88.0"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-						}
+						"minimist": "^1.2.5",
+						"request": "^2.88.2"
 					}
 				},
 				"create-ecdh": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-					"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+					"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 					"requires": {
 						"bn.js": "^4.1.0",
-						"elliptic": "^6.0.0"
+						"elliptic": "^6.5.3"
 					}
 				},
 				"create-hash": {
@@ -7305,9 +4776,9 @@
 					}
 				},
 				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 					"requires": {
 						"path-key": "^3.1.0",
 						"shebang-command": "^2.0.0",
@@ -7386,6 +4857,28 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"decompress": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+					"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+					"requires": {
+						"decompress-tar": "^4.0.0",
+						"decompress-tarbz2": "^4.0.0",
+						"decompress-targz": "^4.0.0",
+						"decompress-unzip": "^4.0.1",
+						"graceful-fs": "^4.1.10",
+						"make-dir": "^1.0.0",
+						"pify": "^2.3.0",
+						"strip-dirs": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
 				},
 				"decompress-response": {
 					"version": "3.3.0",
@@ -7681,9 +5174,9 @@
 					}
 				},
 				"dom-walk": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-					"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+					"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 				},
 				"domain-browser": {
 					"version": "1.2.0",
@@ -7723,6 +5216,40 @@
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"each-props": {
@@ -7750,9 +5277,9 @@
 					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.341",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
-					"integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==",
+					"version": "1.3.521",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.521.tgz",
+					"integrity": "sha512-7/Cf5jUuAfLRY8SjfRES/6+9BDvmHAB2YQotCAaXK0IEacpjoSlyosPoC4s7lfb7vIOBubXvsssu8+8qaRGjcg==",
 					"dev": true
 				},
 				"elegant-spinner": {
@@ -7761,9 +5288,9 @@
 					"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 				},
 				"elliptic": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+					"version": "6.5.3",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 					"requires": {
 						"bn.js": "^4.4.0",
 						"brorand": "^1.0.1",
@@ -7780,9 +5307,9 @@
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
 				"emojis-list": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
 				},
 				"encodeurl": {
 					"version": "1.0.2",
@@ -7790,12 +5317,23 @@
 					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 				},
 				"encoding": {
-					"version": "0.1.12",
-					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"version": "0.1.13",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+					"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 					"dev": true,
 					"requires": {
-						"iconv-lite": "~0.4.13"
+						"iconv-lite": "^0.6.2"
+					},
+					"dependencies": {
+						"iconv-lite": {
+							"version": "0.6.2",
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+							"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+							"dev": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3.0.0"
+							}
+						}
 					}
 				},
 				"encoding-down": {
@@ -7831,15 +5369,20 @@
 					}
 				},
 				"enhanced-resolve": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-					"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+					"integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"memory-fs": "^0.5.0",
 						"tapable": "^1.0.0"
 					},
 					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
 						"memory-fs": {
 							"version": "0.5.0",
 							"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -7847,6 +5390,33 @@
 							"requires": {
 								"errno": "^0.1.3",
 								"readable-stream": "^2.0.1"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
@@ -7868,21 +5438,21 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"version": "1.17.6",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+					"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
+						"is-callable": "^1.2.0",
+						"is-regex": "^1.1.0",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
 					},
 					"dependencies": {
 						"object-keys": {
@@ -8053,27 +5623,27 @@
 							}
 						},
 						"glob-parent": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-							"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 							"requires": {
 								"is-glob": "^4.0.1"
 							}
 						},
 						"globals": {
-							"version": "12.3.0",
-							"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-							"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+							"version": "12.4.0",
+							"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+							"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 							"requires": {
 								"type-fest": "^0.8.1"
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"path-key": {
@@ -8123,9 +5693,9 @@
 					"integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA=="
 				},
 				"eslint-import-resolver-node": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-					"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+					"version": "0.3.4",
+					"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+					"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
 					"requires": {
 						"debug": "^2.6.9",
 						"resolve": "^1.13.1"
@@ -8147,9 +5717,9 @@
 					}
 				},
 				"eslint-module-utils": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-					"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+					"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 					"requires": {
 						"debug": "^2.6.9",
 						"pkg-dir": "^2.0.0"
@@ -8171,26 +5741,26 @@
 					}
 				},
 				"eslint-plugin-es": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-					"integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+					"integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
 					"requires": {
 						"eslint-utils": "^2.0.0",
 						"regexpp": "^3.0.0"
 					},
 					"dependencies": {
 						"eslint-utils": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-							"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+							"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 							"requires": {
 								"eslint-visitor-keys": "^1.1.0"
 							}
 						},
 						"regexpp": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-							"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+							"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
 						}
 					}
 				},
@@ -8312,17 +5882,17 @@
 					},
 					"dependencies": {
 						"eslint-utils": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-							"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+							"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 							"requires": {
 								"eslint-visitor-keys": "^1.1.0"
 							}
 						},
 						"ignore": {
-							"version": "5.1.4",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-							"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+							"version": "5.1.8",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+							"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
 						},
 						"semver": {
 							"version": "6.3.0",
@@ -8342,9 +5912,9 @@
 					"integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ=="
 				},
 				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
@@ -8359,17 +5929,17 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
 				},
 				"espree": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-					"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 					"requires": {
-						"acorn": "^7.1.0",
-						"acorn-jsx": "^5.1.0",
+						"acorn": "^7.1.1",
+						"acorn-jsx": "^5.2.0",
 						"eslint-visitor-keys": "^1.1.0"
 					}
 				},
@@ -8379,11 +5949,18 @@
 					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"esquery": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-					"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+					"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 					"requires": {
-						"estraverse": "^4.0.0"
+						"estraverse": "^5.1.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+						}
 					}
 				},
 				"esrecurse": {
@@ -8435,18 +6012,18 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"pify": {
@@ -8555,18 +6132,18 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -8602,30 +6179,18 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"dev": true,
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"dev": true,
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -8641,39 +6206,21 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"dev": true,
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
-									}
-								},
-								"keccak": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-									"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-									"dev": true,
-									"requires": {
-										"bindings": "^1.5.0",
-										"inherits": "^2.0.4",
-										"nan": "^2.14.0",
-										"safe-buffer": "^5.2.0"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-							"dev": true
 						}
 					}
 				},
@@ -8725,33 +6272,33 @@
 							},
 							"dependencies": {
 								"ethereumjs-util": {
-									"version": "4.5.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-									"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+									"version": "4.5.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+									"integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
 									"dev": true,
 									"requires": {
 										"bn.js": "^4.8.0",
 										"create-hash": "^1.1.2",
-										"keccakjs": "^0.2.0",
-										"rlp": "^2.0.0",
-										"secp256k1": "^3.0.1"
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
+										"rlp": "^2.0.0"
 									}
 								}
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						}
 					}
@@ -8823,18 +6370,18 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -8870,30 +6417,18 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"dev": true,
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"dev": true,
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -8909,88 +6444,73 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"dev": true,
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
-									}
-								},
-								"keccak": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-									"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-									"dev": true,
-									"requires": {
-										"bindings": "^1.5.0",
-										"inherits": "^2.0.4",
-										"nan": "^2.14.0",
-										"safe-buffer": "^5.2.0"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-							"dev": true
 						}
 					}
 				},
 				"ethashjs": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
-					"integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+					"integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
 					"dev": true,
 					"requires": {
-						"async": "^1.4.2",
-						"buffer-xor": "^1.0.3",
-						"ethereumjs-util": "^4.0.1",
+						"async": "^2.1.2",
+						"buffer-xor": "^2.0.1",
+						"ethereumjs-util": "^7.0.2",
 						"miller-rabin": "^4.0.0"
 					},
 					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+						"bn.js": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+							"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
 							"dev": true
 						},
-						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+						"buffer-xor": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+							"integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
 							"dev": true,
 							"requires": {
-								"bn.js": "^4.8.0",
+								"safe-buffer": "^5.1.1"
+							}
+						},
+						"ethereumjs-util": {
+							"version": "7.0.4",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
+							"integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
+							"dev": true,
+							"requires": {
+								"@types/bn.js": "^4.11.3",
+								"bn.js": "^5.1.2",
 								"create-hash": "^1.1.2",
-								"keccakjs": "^0.2.0",
-								"rlp": "^2.0.0",
-								"secp256k1": "^3.0.1"
+								"ethereum-cryptography": "^0.1.3",
+								"ethjs-util": "0.1.6",
+								"rlp": "^2.2.4"
 							}
 						}
 					}
 				},
 				"ethereum-bloom-filters": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
-					"integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+					"integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
 					"requires": {
 						"js-sha3": "^0.8.0"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.8.0",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-							"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-						}
 					}
 				},
 				"ethereum-common": {
@@ -8998,6 +6518,29 @@
 					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 					"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
 					"dev": true
+				},
+				"ethereum-cryptography": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+					"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+					"dev": true,
+					"requires": {
+						"@types/pbkdf2": "^3.0.0",
+						"@types/secp256k1": "^4.0.1",
+						"blakejs": "^1.1.0",
+						"browserify-aes": "^1.2.0",
+						"bs58check": "^2.1.2",
+						"create-hash": "^1.2.0",
+						"create-hmac": "^1.1.7",
+						"hash.js": "^1.1.7",
+						"keccak": "^3.0.0",
+						"pbkdf2": "^3.0.17",
+						"randombytes": "^2.1.0",
+						"safe-buffer": "^5.1.2",
+						"scrypt-js": "^3.0.0",
+						"secp256k1": "^4.0.1",
+						"setimmediate": "^1.0.5"
+					}
 				},
 				"ethereumjs-abi": {
 					"version": "0.6.7",
@@ -9034,64 +6577,38 @@
 					},
 					"dependencies": {
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
 						}
 					}
 				},
 				"ethereumjs-blockchain": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
-					"integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+					"integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
 					"dev": true,
 					"requires": {
 						"async": "^2.6.1",
 						"ethashjs": "~0.0.7",
 						"ethereumjs-block": "~2.2.2",
 						"ethereumjs-common": "^1.5.0",
-						"ethereumjs-util": "~6.1.0",
+						"ethereumjs-util": "^6.1.0",
 						"flow-stoplight": "^1.0.0",
 						"level-mem": "^3.0.1",
 						"lru-cache": "^5.1.1",
 						"rlp": "^2.2.2",
 						"semaphore": "^1.1.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-							"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-							"dev": true,
-							"requires": {
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"ethjs-util": "0.1.6",
-								"keccak": "^1.0.2",
-								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
-							}
-						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"dev": true,
-							"requires": {
-								"yallist": "^3.0.2"
-							}
-						}
 					}
 				},
 				"ethereumjs-common": {
@@ -9133,17 +6650,27 @@
 								"safe-buffer": "^5.2.0"
 							}
 						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+						"secp256k1": {
+							"version": "3.8.0",
+							"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+							"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+							"requires": {
+								"bindings": "^1.5.0",
+								"bip66": "^1.1.5",
+								"bn.js": "^4.11.8",
+								"create-hash": "^1.2.0",
+								"drbg.js": "^1.0.1",
+								"elliptic": "^6.5.2",
+								"nan": "^2.14.0",
+								"safe-buffer": "^5.1.2"
+							}
 						}
 					}
 				},
 				"ethereumjs-vm": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.3.tgz",
-					"integrity": "sha512-RTrD0y7My4O6Qr1P2ZIsMfD6RzL6kU/RhBZ0a5XrPzAeR61crBS7or66ohDrvxDI/rDBxMi+6SnsELih6fzalw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+					"integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
 					"dev": true,
 					"requires": {
 						"async": "^2.1.2",
@@ -9161,41 +6688,6 @@
 						"rustbn.js": "~0.2.0",
 						"safe-buffer": "^5.1.1",
 						"util.promisify": "^1.0.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "6.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-							"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-							"dev": true,
-							"requires": {
-								"@types/bn.js": "^4.11.3",
-								"bn.js": "^4.11.0",
-								"create-hash": "^1.1.2",
-								"ethjs-util": "0.1.6",
-								"keccak": "^2.0.0",
-								"rlp": "^2.2.3",
-								"secp256k1": "^3.0.1"
-							}
-						},
-						"keccak": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-							"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-							"dev": true,
-							"requires": {
-								"bindings": "^1.5.0",
-								"inherits": "^2.0.4",
-								"nan": "^2.14.0",
-								"safe-buffer": "^5.2.0"
-							}
-						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-							"dev": true
-						}
 					}
 				},
 				"ethereumjs-wallet": {
@@ -9236,6 +6728,20 @@
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
 							"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+						},
+						"elliptic": {
+							"version": "6.5.2",
+							"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+							"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+							"requires": {
+								"bn.js": "^4.4.0",
+								"brorand": "^1.0.1",
+								"hash.js": "^1.0.0",
+								"hmac-drbg": "^1.0.0",
+								"inherits": "^2.0.1",
+								"minimalistic-assert": "^1.0.0",
+								"minimalistic-crypto-utils": "^1.0.0"
+							}
 						},
 						"hash.js": {
 							"version": "1.1.3",
@@ -9299,9 +6805,9 @@
 					"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 				},
 				"events": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-					"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+					"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
 				},
 				"evp_bytestokey": {
 					"version": "1.0.3",
@@ -9604,9 +7110,9 @@
 					}
 				},
 				"fast-deep-equal": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.1.0",
@@ -9648,14 +7154,14 @@
 					}
 				},
 				"figgy-pudding": {
-					"version": "3.5.1",
-					"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+					"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
 				},
 				"figures": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+					"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
 					}
@@ -9734,12 +7240,12 @@
 					}
 				},
 				"find-cache-dir": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.0",
+						"make-dir": "^3.0.2",
 						"pkg-dir": "^4.1.0"
 					},
 					"dependencies": {
@@ -9761,17 +7267,17 @@
 							}
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -9885,9 +7391,9 @@
 					}
 				},
 				"flatted": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-					"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+					"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
 				},
 				"flow-stoplight": {
 					"version": "1.0.0",
@@ -9902,6 +7408,40 @@
 					"requires": {
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.3.6"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"for-each": {
@@ -9976,12 +7516,46 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"fromentries": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-					"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+					"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw=="
 				},
 				"fs-constants": {
 					"version": "1.0.0",
@@ -10025,385 +7599,17 @@
 						"iferr": "^0.1.5",
 						"imurmurhash": "^0.1.4",
 						"readable-stream": "1 || 2"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"fsevents": {
-					"version": "1.2.11",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-					"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1",
-						"node-pre-gyp": "*"
 					},
 					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.5",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.1.3",
-							"bundled": true,
-							"optional": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "3.2.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						},
-						"deep-extend": {
-							"version": "0.6.0",
-							"bundled": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.7",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.6.0"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.4",
-							"bundled": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.3.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.9.0"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.4.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"debug": "^3.2.6",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.14.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.1",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.2.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4.4.2"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.1.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"npm-normalize-package-bin": "^1.0.1"
-							}
-						},
-						"npm-normalize-package-bin": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.4.7",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.8",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.6.0",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"optional": true
-								}
-							}
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 						},
 						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"optional": true,
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
 								"inherits": "~2.0.3",
@@ -10414,112 +7620,34 @@
 								"util-deprecate": "~1.0.1"
 							}
 						},
-						"rimraf": {
-							"version": "2.7.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.7.1",
-							"bundled": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
-							"optional": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
 							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"optional": true
-						},
-						"tar": {
-							"version": "4.4.13",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.8.6",
-								"minizlib": "^1.2.1",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.3"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.3",
-							"bundled": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2 || 2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.1.1",
-							"bundled": true,
-							"optional": true
 						}
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
 					}
 				},
 				"function-bind": {
@@ -10552,6 +7680,11 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
 					"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+				},
+				"get-package-type": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+					"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
 				},
 				"get-stream": {
 					"version": "4.1.0",
@@ -10622,12 +7755,50 @@
 						"remove-trailing-separator": "^1.0.1",
 						"to-absolute-glob": "^2.0.0",
 						"unique-stream": "^2.0.2"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"glob-watcher": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
-					"integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
+					"integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
 					"dev": true,
 					"requires": {
 						"anymatch": "^2.0.0",
@@ -10635,6 +7806,7 @@
 						"chokidar": "^2.0.0",
 						"is-negated-glob": "^1.0.0",
 						"just-debounce": "^1.0.0",
+						"normalize-path": "^3.0.0",
 						"object.defaults": "^1.1.0"
 					}
 				},
@@ -10703,14 +7875,9 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-				},
-				"graceful-readlink": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-					"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 				},
 				"growl": {
 					"version": "1.10.5",
@@ -10730,9 +7897,9 @@
 					},
 					"dependencies": {
 						"gulp-cli": {
-							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-							"integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+							"integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
 							"dev": true,
 							"requires": {
 								"ansi-colors": "^1.0.1",
@@ -10743,7 +7910,7 @@
 								"copy-props": "^2.0.1",
 								"fancy-log": "^1.3.2",
 								"gulplog": "^1.0.0",
-								"interpret": "^1.1.0",
+								"interpret": "^1.4.0",
 								"isobject": "^3.0.1",
 								"liftoff": "^3.1.0",
 								"matchdep": "^2.0.0",
@@ -10751,7 +7918,7 @@
 								"pretty-hrtime": "^1.0.0",
 								"replace-homedir": "^1.0.0",
 								"semver-greatest-satisfied-range": "^1.1.0",
-								"v8flags": "^3.0.1",
+								"v8flags": "^3.2.0",
 								"yargs": "^7.1.0"
 							}
 						}
@@ -10772,11 +7939,11 @@
 					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 				},
 				"har-validator": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-					"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+					"version": "5.1.5",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+					"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 					"requires": {
-						"ajv": "^6.5.5",
+						"ajv": "^6.12.3",
 						"har-schema": "^2.0.0"
 					}
 				},
@@ -10849,12 +8016,13 @@
 					}
 				},
 				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+					"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
 					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.6.0",
+						"safe-buffer": "^5.2.0"
 					}
 				},
 				"hash.js": {
@@ -10867,9 +8035,9 @@
 					}
 				},
 				"hasha": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-					"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+					"integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
 					"requires": {
 						"is-stream": "^2.0.0",
 						"type-fest": "^0.8.0"
@@ -10883,15 +8051,34 @@
 					}
 				},
 				"hdkey": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
-					"integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
+					"integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"coinstring": "^2.0.0",
+						"bs58check": "^2.1.2",
 						"safe-buffer": "^5.1.1",
 						"secp256k1": "^3.0.1"
+					},
+					"dependencies": {
+						"secp256k1": {
+							"version": "3.8.0",
+							"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+							"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"bindings": "^1.5.0",
+								"bip66": "^1.1.5",
+								"bn.js": "^4.11.8",
+								"create-hash": "^1.2.0",
+								"drbg.js": "^1.0.1",
+								"elliptic": "^6.5.2",
+								"nan": "^2.14.0",
+								"safe-buffer": "^5.1.2"
+							}
+						}
 					}
 				},
 				"he": {
@@ -10934,19 +8121,19 @@
 					}
 				},
 				"hosted-git-info": {
-					"version": "2.8.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-					"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+					"version": "2.8.8",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 				},
 				"html-escaper": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-					"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+					"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
 				},
 				"http-cache-semantics": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-					"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 				},
 				"http-errors": {
 					"version": "1.7.2",
@@ -11066,9 +8253,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -11153,9 +8340,10 @@
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 				},
 				"immediate": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+					"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+					"dev": true
 				},
 				"import-fresh": {
 					"version": "3.2.1",
@@ -11193,9 +8381,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -11263,22 +8451,22 @@
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 				},
 				"inquirer": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-					"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+					"version": "7.3.3",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+					"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
 					"requires": {
 						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
+						"chalk": "^4.1.0",
 						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
+						"cli-width": "^3.0.0",
 						"external-editor": "^3.0.3",
 						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
+						"lodash": "^4.17.19",
 						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
+						"run-async": "^2.4.0",
+						"rxjs": "^6.6.0",
 						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
+						"strip-ansi": "^6.0.0",
 						"through": "^2.3.6"
 					},
 					"dependencies": {
@@ -11288,22 +8476,40 @@
 							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 						},
 						"ansi-styles": {
-							"version": "3.2.1",
-							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"version": "4.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+							"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 							"requires": {
-								"color-convert": "^1.9.0"
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
 							}
 						},
 						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
 							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+						},
+						"has-flag": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 						},
 						"is-fullwidth-code-point": {
 							"version": "3.0.0",
@@ -11311,9 +8517,9 @@
 							"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 						},
 						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"string-width": {
 							"version": "4.2.0",
@@ -11323,47 +8529,31 @@
 								"emoji-regex": "^8.0.0",
 								"is-fullwidth-code-point": "^3.0.0",
 								"strip-ansi": "^6.0.0"
-							},
-							"dependencies": {
-								"strip-ansi": {
-									"version": "6.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-									"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-									"requires": {
-										"ansi-regex": "^5.0.0"
-									}
-								}
 							}
 						},
 						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 							"requires": {
-								"ansi-regex": "^4.1.0"
-							},
-							"dependencies": {
-								"ansi-regex": {
-									"version": "4.1.0",
-									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-									"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-								}
+								"ansi-regex": "^5.0.0"
 							}
 						},
 						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"version": "7.1.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+							"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 							"requires": {
-								"has-flag": "^3.0.0"
+								"has-flag": "^4.0.0"
 							}
 						}
 					}
 				},
 				"interpret": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+					"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.4",
@@ -11381,9 +8571,9 @@
 					"dev": true
 				},
 				"ipaddr.js": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-					"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+					"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 				},
 				"is-absolute": {
 					"version": "1.0.0",
@@ -11438,9 +8628,9 @@
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+					"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
@@ -11493,13 +8683,10 @@
 					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-finite": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+					"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+					"dev": true
 				},
 				"is-fn": {
 					"version": "1.0.0",
@@ -11516,9 +8703,9 @@
 					}
 				},
 				"is-function": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-					"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+					"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
 				},
 				"is-glob": {
 					"version": "4.0.1",
@@ -11594,16 +8781,16 @@
 					}
 				},
 				"is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-					"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+					"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
 				},
 				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 					"requires": {
-						"has": "^1.0.3"
+						"has-symbols": "^1.0.1"
 					}
 				},
 				"is-regexp": {
@@ -11714,14 +8901,11 @@
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
-					"integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 					"requires": {
 						"@babel/core": "^7.7.5",
-						"@babel/parser": "^7.7.5",
-						"@babel/template": "^7.7.4",
-						"@babel/traverse": "^7.7.4",
 						"@istanbuljs/schema": "^0.1.2",
 						"istanbul-lib-coverage": "^3.0.0",
 						"semver": "^6.3.0"
@@ -11749,9 +8933,9 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -11765,9 +8949,9 @@
 							}
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -11795,9 +8979,9 @@
 							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
@@ -11838,9 +9022,9 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 					"requires": {
 						"html-escaper": "^2.0.0",
 						"istanbul-lib-report": "^3.0.0"
@@ -11883,10 +9067,9 @@
 					}
 				},
 				"js-sha3": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-					"integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
-					"dev": true
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 				},
 				"js-tokens": {
 					"version": "3.0.2",
@@ -11895,9 +9078,9 @@
 					"dev": true
 				},
 				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -12020,25 +9203,13 @@
 					"dev": true
 				},
 				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+					"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 					"dev": true,
 					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
-				},
-				"keccakjs": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-					"integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-					"dev": true,
-					"requires": {
-						"browserify-sha3": "^0.0.4",
-						"sha3": "^1.2.2"
+						"node-addon-api": "^2.0.0",
+						"node-gyp-build": "^4.2.0"
 					}
 				},
 				"keyv": {
@@ -12079,6 +9250,44 @@
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.0.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"lcid": {
@@ -12105,10 +9314,13 @@
 					}
 				},
 				"level-codec": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-					"integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
-					"dev": true
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+					"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+					"dev": true,
+					"requires": {
+						"buffer": "^5.6.0"
+					}
 				},
 				"level-concat-iterator": {
 					"version": "2.0.1",
@@ -12156,6 +9368,12 @@
 								"isarray": "0.0.1",
 								"string_decoder": "~0.10.x"
 							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+							"dev": true
 						}
 					}
 				},
@@ -12177,6 +9395,12 @@
 							"requires": {
 								"xtend": "~4.0.0"
 							}
+						},
+						"immediate": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+							"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+							"dev": true
 						},
 						"memdown": {
 							"version": "3.0.0",
@@ -12237,6 +9461,12 @@
 						"xtend": "~4.0.0"
 					},
 					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
 						"level-iterator-stream": {
 							"version": "2.0.3",
 							"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
@@ -12253,6 +9483,36 @@
 							"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
 							"integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
 							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
 						}
 					}
 				},
@@ -12285,6 +9545,12 @@
 								"isarray": "0.0.1",
 								"string_decoder": "~0.10.x"
 							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+							"dev": true
 						},
 						"xtend": {
 							"version": "2.1.2",
@@ -12328,6 +9594,12 @@
 								"inherits": "^2.0.3"
 							}
 						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
 						"level-iterator-stream": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
@@ -12337,6 +9609,36 @@
 								"inherits": "^2.0.1",
 								"readable-stream": "^2.3.6",
 								"xtend": "^4.0.0"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
@@ -12430,9 +9732,9 @@
 							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 						},
 						"commander": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-							"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+							"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
 						},
 						"debug": {
 							"version": "4.1.1",
@@ -12468,11 +9770,6 @@
 								"braces": "^3.0.1",
 								"picomatch": "^2.0.5"
 							}
-						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 						},
 						"supports-color": {
 							"version": "7.1.0",
@@ -12651,12 +9948,12 @@
 					"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 				},
 				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 					"requires": {
 						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
+						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
 					},
 					"dependencies": {
@@ -12667,11 +9964,6 @@
 							"requires": {
 								"minimist": "^1.2.0"
 							}
-						},
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 						}
 					}
 				},
@@ -12851,12 +10143,11 @@
 					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 				},
 				"lru-cache": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-					"dev": true,
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
-						"pseudomap": "^1.0.1"
+						"yallist": "^3.0.2"
 					}
 				},
 				"ltgt": {
@@ -12988,14 +10279,21 @@
 					},
 					"dependencies": {
 						"abstract-leveldown": {
-							"version": "6.2.2",
-							"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
-							"integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
+							"version": "6.2.3",
+							"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+							"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
 							"requires": {
+								"buffer": "^5.5.0",
+								"immediate": "^3.2.3",
 								"level-concat-iterator": "~2.0.0",
 								"level-supports": "~1.0.0",
 								"xtend": "~4.0.0"
 							}
+						},
+						"immediate": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+							"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 						}
 					}
 				},
@@ -13006,6 +10304,40 @@
 					"requires": {
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"memorystream": {
@@ -13055,19 +10387,25 @@
 							"dev": true
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
+								"safe-buffer": "^5.1.1"
 							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
 						},
 						"level-codec": {
 							"version": "7.0.1",
@@ -13121,11 +10459,51 @@
 								}
 							}
 						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+									"dev": true
+								}
+							}
+						},
 						"semver": {
 							"version": "5.4.1",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
 							"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
 							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+									"dev": true
+								}
+							}
 						}
 					}
 				},
@@ -13169,16 +10547,16 @@
 					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 				},
 				"mime-db": {
-					"version": "1.43.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+					"version": "1.44.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
 				},
 				"mime-types": {
-					"version": "2.1.26",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+					"version": "2.1.27",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 					"requires": {
-						"mime-db": "1.43.0"
+						"mime-db": "1.44.0"
 					}
 				},
 				"mimic-fn": {
@@ -13218,9 +10596,9 @@
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				},
 				"minipass": {
 					"version": "2.9.0",
@@ -13240,9 +10618,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -13263,9 +10641,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -13278,17 +10656,17 @@
 					}
 				},
 				"minipass-pipeline": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-					"integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+					"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
 					"requires": {
 						"minipass": "^3.0.0"
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -13345,9 +10723,9 @@
 					}
 				},
 				"mkdirp": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-					"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
 				"mkdirp-promise": {
 					"version": "5.0.1",
@@ -13416,9 +10794,9 @@
 							}
 						},
 						"binary-extensions": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-							"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+							"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
 						},
 						"braces": {
 							"version": "3.0.2",
@@ -13500,9 +10878,9 @@
 							}
 						},
 						"fsevents": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-							"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+							"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 							"optional": true
 						},
 						"get-caller-file": {
@@ -13524,9 +10902,9 @@
 							}
 						},
 						"glob-parent": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-							"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 							"requires": {
 								"is-glob": "^4.0.1"
 							}
@@ -13549,6 +10927,15 @@
 							"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 						},
+						"js-yaml": {
+							"version": "3.13.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+							"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						},
 						"locate-path": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -13566,6 +10953,11 @@
 								"chalk": "^2.0.1"
 							}
 						},
+						"minimist": {
+							"version": "0.0.8",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+						},
 						"mkdirp": {
 							"version": "0.5.1",
 							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -13579,15 +10971,10 @@
 							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 						},
-						"normalize-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -13716,9 +11103,9 @@
 					"integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q="
 				},
 				"mock-fs": {
-					"version": "4.10.4",
-					"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
-					"integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+					"integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
@@ -13734,11 +11121,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -13760,9 +11147,9 @@
 					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 				},
 				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+					"version": "2.14.1",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+					"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 				},
 				"nano-json-stream-parser": {
 					"version": "0.1.2",
@@ -13798,9 +11185,9 @@
 					"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 				},
 				"neo-async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-					"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+					"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 				},
 				"next-tick": {
 					"version": "1.0.0",
@@ -13811,6 +11198,12 @@
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+				},
+				"node-addon-api": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+					"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+					"dev": true
 				},
 				"node-environment-flags": {
 					"version": "1.0.6",
@@ -13832,6 +11225,12 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
 					"integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+					"dev": true
+				},
+				"node-gyp-build": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+					"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
 					"dev": true
 				},
 				"node-libs-browser": {
@@ -13874,11 +11273,6 @@
 								"isarray": "^1.0.0"
 							}
 						},
-						"inherits": {
-							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-						},
 						"isarray": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -13894,13 +11288,34 @@
 							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 						},
-						"string_decoder": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-							"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"requires": {
-								"safe-buffer": "~5.2.0"
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"string_decoder": {
+									"version": "1.1.1",
+									"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+									"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+									"requires": {
+										"safe-buffer": "~5.1.0"
+									}
+								}
 							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 						},
 						"util": {
 							"version": "0.11.1",
@@ -13908,6 +11323,13 @@
 							"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 							"requires": {
 								"inherits": "2.0.3"
+							},
+							"dependencies": {
+								"inherits": {
+									"version": "2.0.3",
+									"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+									"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+								}
 							}
 						}
 					}
@@ -13939,12 +11361,9 @@
 					}
 				},
 				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"normalize-url": {
 					"version": "4.5.0",
@@ -13990,9 +11409,9 @@
 					}
 				},
 				"nyc": {
-					"version": "15.0.0",
-					"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-					"integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+					"version": "15.1.0",
+					"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+					"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
 					"requires": {
 						"@istanbuljs/load-nyc-config": "^1.0.0",
 						"@istanbuljs/schema": "^0.1.2",
@@ -14002,6 +11421,7 @@
 						"find-cache-dir": "^3.2.0",
 						"find-up": "^4.1.0",
 						"foreground-child": "^2.0.0",
+						"get-package-type": "^0.1.0",
 						"glob": "^7.1.6",
 						"istanbul-lib-coverage": "^3.0.0",
 						"istanbul-lib-hook": "^3.0.0",
@@ -14009,10 +11429,9 @@
 						"istanbul-lib-processinfo": "^2.0.2",
 						"istanbul-lib-report": "^3.0.0",
 						"istanbul-lib-source-maps": "^4.0.0",
-						"istanbul-reports": "^3.0.0",
-						"js-yaml": "^3.13.1",
+						"istanbul-reports": "^3.0.2",
 						"make-dir": "^3.0.0",
-						"node-preload": "^0.2.0",
+						"node-preload": "^0.2.1",
 						"p-map": "^3.0.0",
 						"process-on-spawn": "^1.0.0",
 						"resolve-from": "^5.0.0",
@@ -14020,7 +11439,6 @@
 						"signal-exit": "^3.0.2",
 						"spawn-wrap": "^2.0.0",
 						"test-exclude": "^6.0.0",
-						"uuid": "^3.3.3",
 						"yargs": "^15.0.2"
 					},
 					"dependencies": {
@@ -14094,17 +11512,17 @@
 							}
 						},
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -14146,9 +11564,9 @@
 							"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -14197,9 +11615,9 @@
 							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 						},
 						"yargs": {
-							"version": "15.1.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-							"integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+							"version": "15.4.1",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+							"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 							"requires": {
 								"cliui": "^6.0.0",
 								"decamelize": "^1.2.0",
@@ -14211,13 +11629,13 @@
 								"string-width": "^4.2.0",
 								"which-module": "^2.0.0",
 								"y18n": "^4.0.0",
-								"yargs-parser": "^16.1.0"
+								"yargs-parser": "^18.1.2"
 							}
 						},
 						"yargs-parser": {
-							"version": "16.1.0",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-							"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+							"version": "18.1.3",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+							"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -14264,15 +11682,19 @@
 					}
 				},
 				"object-inspect": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
 				},
 				"object-is": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-					"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-					"dev": true
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+					"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.17.5"
+					}
 				},
 				"object-keys": {
 					"version": "0.4.0",
@@ -14391,17 +11813,17 @@
 					}
 				},
 				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.1.tgz",
+					"integrity": "sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==",
 					"requires": {
 						"mimic-fn": "^2.1.0"
 					}
 				},
 				"opencollective-postinstall": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-					"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+					"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
 				},
 				"optionator": {
 					"version": "0.8.3",
@@ -14423,6 +11845,44 @@
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"os-browserify": {
@@ -14528,6 +11988,40 @@
 						"cyclist": "^1.0.1",
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"parent-module": {
@@ -14670,9 +12164,9 @@
 					}
 				},
 				"pbkdf2": {
-					"version": "3.0.17",
-					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-					"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+					"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
 					"requires": {
 						"create-hash": "^1.1.2",
 						"create-hmac": "^1.1.4",
@@ -14692,9 +12186,9 @@
 					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 				},
 				"picomatch": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-					"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
 				},
 				"pify": {
 					"version": "4.0.1",
@@ -14741,21 +12235,21 @@
 					}
 				},
 				"portfinder": {
-					"version": "1.0.25",
-					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-					"integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+					"version": "1.0.28",
+					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+					"integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
 					"requires": {
 						"async": "^2.6.2",
 						"debug": "^3.1.1",
-						"mkdirp": "^0.5.1"
+						"mkdirp": "^0.5.5"
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -14837,12 +12331,12 @@
 					}
 				},
 				"proxy-addr": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-					"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+					"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
 					"requires": {
 						"forwarded": "~0.1.2",
-						"ipaddr.js": "1.9.0"
+						"ipaddr.js": "1.9.1"
 					}
 				},
 				"prr": {
@@ -14857,9 +12351,9 @@
 					"dev": true
 				},
 				"psl": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-					"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+					"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 				},
 				"public-encrypt": {
 					"version": "4.0.3",
@@ -15047,23 +12541,43 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"micromatch": "^3.1.10",
+						"readable-stream": "^2.0.2"
 					},
 					"dependencies": {
 						"isarray": {
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
@@ -15080,16 +12594,6 @@
 						}
 					}
 				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
 				"rechoir": {
 					"version": "0.6.2",
 					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -15100,9 +12604,9 @@
 					}
 				},
 				"regenerate": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-					"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+					"integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
 					"dev": true
 				},
 				"regenerator-runtime": {
@@ -15225,9 +12729,9 @@
 					}
 				},
 				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+					"integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
 					"dev": true
 				},
 				"replace-homedir": {
@@ -15242,9 +12746,9 @@
 					}
 				},
 				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+					"version": "2.88.2",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 					"requires": {
 						"aws-sign2": "~0.7.0",
 						"aws4": "^1.8.0",
@@ -15253,7 +12757,7 @@
 						"extend": "~3.0.2",
 						"forever-agent": "~0.6.1",
 						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
+						"har-validator": "~5.1.3",
 						"http-signature": "~1.2.0",
 						"is-typedarray": "~1.0.0",
 						"isstream": "~0.1.2",
@@ -15263,7 +12767,7 @@
 						"performance-now": "^2.1.0",
 						"qs": "~6.5.2",
 						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
+						"tough-cookie": "~2.5.0",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.3.2"
 					},
@@ -15292,9 +12796,9 @@
 					"dev": true
 				},
 				"resolve": {
-					"version": "1.14.2",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-					"integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -15391,20 +12895,17 @@
 					}
 				},
 				"rlp": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-					"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+					"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 					"requires": {
 						"bn.js": "^4.11.1"
 					}
 				},
 				"run-async": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 				},
 				"run-queue": {
 					"version": "1.0.3",
@@ -15421,17 +12922,17 @@
 					"dev": true
 				},
 				"rxjs": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+					"version": "6.6.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+					"integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
 					"requires": {
 						"tslib": "^1.9.0"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				},
 				"safe-event-emitter": {
 					"version": "1.0.1",
@@ -15456,11 +12957,12 @@
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 				},
 				"schema-utils": {
-					"version": "2.6.4",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
-					"integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
 					"requires": {
-						"ajv": "^6.10.2",
+						"@types/json-schema": "^7.0.4",
+						"ajv": "^6.12.2",
 						"ajv-keywords": "^3.4.1"
 					}
 				},
@@ -15475,9 +12977,10 @@
 					}
 				},
 				"scrypt-js": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-					"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+					"dev": true
 				},
 				"scrypt.js": {
 					"version": "0.3.0",
@@ -15501,25 +13004,14 @@
 					}
 				},
 				"secp256k1": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-					"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+					"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+					"dev": true,
 					"requires": {
-						"bindings": "^1.5.0",
-						"bip66": "^1.1.5",
-						"bn.js": "^4.11.8",
-						"create-hash": "^1.2.0",
-						"drbg.js": "^1.0.1",
 						"elliptic": "^6.5.2",
-						"nan": "^2.14.0",
-						"safe-buffer": "^5.1.2"
-					},
-					"dependencies": {
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-						}
+						"node-addon-api": "^2.0.0",
+						"node-gyp-build": "^4.2.0"
 					}
 				},
 				"seedrandom": {
@@ -15529,11 +13021,11 @@
 					"dev": true
 				},
 				"seek-bzip": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-					"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+					"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
 					"requires": {
-						"commander": "~2.8.1"
+						"commander": "^2.8.1"
 					}
 				},
 				"semaphore": {
@@ -15682,15 +13174,6 @@
 						"safe-buffer": "^5.0.1"
 					}
 				},
-				"sha3": {
-					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
-					"integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
-					"dev": true,
-					"requires": {
-						"nan": "2.13.2"
-					}
-				},
 				"shebang-command": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15705,14 +13188,14 @@
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 				},
 				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 				},
 				"simple-concat": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-					"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+					"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
 				},
 				"simple-get": {
 					"version": "2.8.1",
@@ -15902,11 +13385,6 @@
 								"rimraf": "^2.2.8"
 							}
 						},
-						"js-sha3": {
-							"version": "0.8.0",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-							"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-						},
 						"jsonfile": {
 							"version": "2.4.0",
 							"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -15986,17 +13464,17 @@
 					},
 					"dependencies": {
 						"make-dir": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-							"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+							"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 							"requires": {
 								"semver": "^6.0.0"
 							}
 						},
 						"rimraf": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-							"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+							"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 							"requires": {
 								"glob": "^7.1.3"
 							}
@@ -16017,23 +13495,23 @@
 					}
 				},
 				"spdx-correct": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-					"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+					"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-					"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+					"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
 				},
 				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+					"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -16090,9 +13568,9 @@
 					},
 					"dependencies": {
 						"minipass": {
-							"version": "3.1.1",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-							"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+							"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
 							"requires": {
 								"yallist": "^4.0.0"
 							}
@@ -16141,6 +13619,40 @@
 					"requires": {
 						"inherits": "~2.0.1",
 						"readable-stream": "^2.0.2"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-each": {
@@ -16168,6 +13680,40 @@
 						"readable-stream": "^2.3.6",
 						"to-arraybuffer": "^1.0.0",
 						"xtend": "^4.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-shift": {
@@ -16219,29 +13765,31 @@
 						"function-bind": "^1.1.1"
 					}
 				},
-				"string.prototype.trimleft": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+				"string.prototype.trimend": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+					"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
 					"requires": {
 						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"es-abstract": "^1.17.5"
 					}
 				},
-				"string.prototype.trimright": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+				"string.prototype.trimstart": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+					"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
 					"requires": {
 						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"es-abstract": "^1.17.5"
 					}
 				},
 				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
 				},
 				"stringify-object": {
 					"version": "3.3.0",
@@ -16297,9 +13845,9 @@
 					}
 				},
 				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 				},
 				"supports-color": {
 					"version": "2.0.0",
@@ -16438,9 +13986,9 @@
 					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
 				},
 				"tape": {
-					"version": "4.13.0",
-					"resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
-					"integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
+					"version": "4.13.3",
+					"resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+					"integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
 					"dev": true,
 					"requires": {
 						"deep-equal": "~1.1.1",
@@ -16452,18 +14000,27 @@
 						"has": "~1.0.3",
 						"inherits": "~2.0.4",
 						"is-regex": "~1.0.5",
-						"minimist": "~1.2.0",
+						"minimist": "~1.2.5",
 						"object-inspect": "~1.7.0",
-						"resolve": "~1.14.2",
+						"resolve": "~1.17.0",
 						"resumer": "~0.0.0",
 						"string.prototype.trim": "~1.2.1",
 						"through": "~2.3.8"
 					},
 					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+						"is-regex": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+							"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+							"dev": true,
+							"requires": {
+								"has": "^1.0.3"
+							}
+						},
+						"object-inspect": {
+							"version": "1.7.0",
+							"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+							"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
 							"dev": true
 						}
 					}
@@ -16483,11 +14040,11 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
@@ -16504,6 +14061,40 @@
 						"readable-stream": "^2.3.0",
 						"to-buffer": "^1.1.1",
 						"xtend": "^4.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"temp": {
@@ -16525,20 +14116,13 @@
 					}
 				},
 				"terser": {
-					"version": "4.6.3",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
-					"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
+					"version": "4.8.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+					"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
 					"requires": {
 						"commander": "^2.20.0",
 						"source-map": "~0.6.1",
 						"source-map-support": "~0.5.12"
-					},
-					"dependencies": {
-						"commander": {
-							"version": "2.20.3",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-						}
 					}
 				},
 				"terser-webpack-plugin": {
@@ -16583,6 +14167,40 @@
 					"requires": {
 						"readable-stream": "~2.3.6",
 						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"through2-filter": {
@@ -16707,19 +14325,12 @@
 					"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 				},
 				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					},
-					"dependencies": {
-						"punycode": {
-							"version": "1.4.1",
-							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-						}
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
 					}
 				},
 				"trim-right": {
@@ -16729,9 +14340,9 @@
 					"dev": true
 				},
 				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 				},
 				"tty-browserify": {
 					"version": "0.0.0",
@@ -16747,15 +14358,15 @@
 					}
 				},
 				"tweetnacl": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.2.tgz",
-					"integrity": "sha512-+8aPRjmXgf1VqvyxSlBUzKzeYqVS9Ai8vZ28g+mL7dNQl1jlUTCMDZnvNQdAS1xTywMkIXwJsfipsR/6s2+syw==",
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+					"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
 					"dev": true
 				},
 				"tweetnacl-util": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
-					"integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU=",
+					"version": "0.15.1",
+					"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+					"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
 					"dev": true
 				},
 				"type": {
@@ -16825,9 +14436,9 @@
 					"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 				},
 				"unbzip2-stream": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-					"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+					"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 					"requires": {
 						"buffer": "^5.2.1",
 						"through": "^2.3.8"
@@ -17066,14 +14677,14 @@
 					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				},
 				"v8-compile-cache": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-					"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+					"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
 				},
 				"v8flags": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-					"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+					"integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
 					"dev": true,
 					"requires": {
 						"homedir-polyfill": "^1.0.1"
@@ -17146,6 +14757,44 @@
 						"value-or-function": "^3.0.0",
 						"vinyl": "^2.0.0",
 						"vinyl-sourcemap": "^1.1.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+							"dev": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"vinyl-sourcemap": {
@@ -17161,6 +14810,17 @@
 						"now-and-later": "^2.0.0",
 						"remove-bom-buffer": "^3.0.0",
 						"vinyl": "^2.0.0"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"dev": true,
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
 					}
 				},
 				"vm-browserify": {
@@ -17169,13 +14829,123 @@
 					"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
 				},
 				"watchpack": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-					"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+					"version": "1.7.4",
+					"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+					"integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
 					"requires": {
-						"chokidar": "^2.0.2",
+						"chokidar": "^3.4.1",
 						"graceful-fs": "^4.1.2",
-						"neo-async": "^2.5.0"
+						"neo-async": "^2.5.0",
+						"watchpack-chokidar2": "^2.0.0"
+					},
+					"dependencies": {
+						"anymatch": {
+							"version": "3.1.1",
+							"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+							"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+							"optional": true,
+							"requires": {
+								"normalize-path": "^3.0.0",
+								"picomatch": "^2.0.4"
+							}
+						},
+						"binary-extensions": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+							"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+							"optional": true
+						},
+						"braces": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+							"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+							"optional": true,
+							"requires": {
+								"fill-range": "^7.0.1"
+							}
+						},
+						"chokidar": {
+							"version": "3.4.1",
+							"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+							"integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+							"optional": true,
+							"requires": {
+								"anymatch": "~3.1.1",
+								"braces": "~3.0.2",
+								"fsevents": "~2.1.2",
+								"glob-parent": "~5.1.0",
+								"is-binary-path": "~2.1.0",
+								"is-glob": "~4.0.1",
+								"normalize-path": "~3.0.0",
+								"readdirp": "~3.4.0"
+							}
+						},
+						"fill-range": {
+							"version": "7.0.1",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+							"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+							"optional": true,
+							"requires": {
+								"to-regex-range": "^5.0.1"
+							}
+						},
+						"fsevents": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+							"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+							"optional": true
+						},
+						"glob-parent": {
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+							"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+							"optional": true,
+							"requires": {
+								"is-glob": "^4.0.1"
+							}
+						},
+						"is-binary-path": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+							"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+							"optional": true,
+							"requires": {
+								"binary-extensions": "^2.0.0"
+							}
+						},
+						"is-number": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+							"optional": true
+						},
+						"readdirp": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+							"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+							"optional": true,
+							"requires": {
+								"picomatch": "^2.2.1"
+							}
+						},
+						"to-regex-range": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+							"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+							"optional": true,
+							"requires": {
+								"is-number": "^7.0.0"
+							}
+						}
+					}
+				},
+				"watchpack-chokidar2": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+					"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+					"optional": true,
+					"requires": {
+						"chokidar": "^2.1.8"
 					}
 				},
 				"web3": {
@@ -17194,9 +14964,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -17212,9 +14982,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "10.17.14",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-							"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+							"version": "10.17.28",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+							"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
 						}
 					}
 				},
@@ -17233,9 +15003,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -17323,9 +15093,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "10.17.14",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-							"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+							"version": "10.17.28",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+							"integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
 						},
 						"aes-js": {
 							"version": "3.0.0",
@@ -17373,6 +15143,11 @@
 							"version": "0.5.7",
 							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
 							"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+						},
+						"scrypt-js": {
+							"version": "2.0.3",
+							"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+							"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
 						},
 						"setimmediate": {
 							"version": "1.0.4",
@@ -17460,6 +15235,13 @@
 					"requires": {
 						"bn.js": "4.11.8",
 						"web3-utils": "1.2.4"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+							"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+						}
 					}
 				},
 				"web3-eth-personal": {
@@ -17476,9 +15258,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.12.26",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-							"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+							"version": "12.12.53",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+							"integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
 						}
 					}
 				},
@@ -17546,18 +15328,18 @@
 							},
 							"dependencies": {
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"dev": true,
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
@@ -17605,32 +15387,18 @@
 							}
 						},
 						"ethereumjs-util": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+							"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 							"dev": true,
 							"requires": {
 								"bn.js": "^4.11.0",
 								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
 								"ethjs-util": "^0.1.3",
-								"keccak": "^1.0.2",
 								"rlp": "^2.0.0",
-								"safe-buffer": "^5.1.1",
-								"secp256k1": "^3.0.1"
-							},
-							"dependencies": {
-								"keccak": {
-									"version": "1.4.0",
-									"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-									"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-									"dev": true,
-									"requires": {
-										"bindings": "^1.2.1",
-										"inherits": "^2.0.3",
-										"nan": "^2.2.1",
-										"safe-buffer": "^5.1.0"
-									}
-								}
+								"safe-buffer": "^5.1.1"
 							}
 						},
 						"ethereumjs-vm": {
@@ -17666,30 +15434,18 @@
 									},
 									"dependencies": {
 										"ethereumjs-util": {
-											"version": "5.2.0",
-											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-											"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+											"version": "5.2.1",
+											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+											"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
 											"dev": true,
 											"requires": {
 												"bn.js": "^4.11.0",
 												"create-hash": "^1.1.2",
+												"elliptic": "^6.5.2",
+												"ethereum-cryptography": "^0.1.3",
 												"ethjs-util": "^0.1.3",
-												"keccak": "^1.0.2",
 												"rlp": "^2.0.0",
-												"safe-buffer": "^5.1.1",
-												"secp256k1": "^3.0.1"
-											}
-										},
-										"keccak": {
-											"version": "1.4.0",
-											"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-											"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-											"dev": true,
-											"requires": {
-												"bindings": "^1.2.1",
-												"inherits": "^2.0.3",
-												"nan": "^2.2.1",
-												"safe-buffer": "^5.1.0"
+												"safe-buffer": "^5.1.1"
 											}
 										}
 									}
@@ -17705,39 +15461,67 @@
 									}
 								},
 								"ethereumjs-util": {
-									"version": "6.2.0",
-									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-									"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+									"version": "6.2.1",
+									"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+									"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 									"dev": true,
 									"requires": {
 										"@types/bn.js": "^4.11.3",
 										"bn.js": "^4.11.0",
 										"create-hash": "^1.1.2",
+										"elliptic": "^6.5.2",
+										"ethereum-cryptography": "^0.1.3",
 										"ethjs-util": "0.1.6",
-										"keccak": "^2.0.0",
-										"rlp": "^2.2.3",
-										"secp256k1": "^3.0.1"
+										"rlp": "^2.2.3"
 									}
 								}
 							}
 						},
-						"keccak": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-							"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+						"isarray": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 							"dev": true,
 							"requires": {
-								"bindings": "^1.5.0",
-								"inherits": "^2.0.4",
-								"nan": "^2.14.0",
-								"safe-buffer": "^5.2.0"
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+									"dev": true
+								}
 							}
 						},
-						"nan": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-							"dev": true
+						"string_decoder": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							},
+							"dependencies": {
+								"safe-buffer": {
+									"version": "5.1.2",
+									"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+									"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+									"dev": true
+								}
+							}
 						},
 						"ws": {
 							"version": "5.2.2",
@@ -17805,6 +15589,11 @@
 						"utf8": "3.0.0"
 					},
 					"dependencies": {
+						"bn.js": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+							"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+						},
 						"eth-lib": {
 							"version": "0.2.7",
 							"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -17848,14 +15637,14 @@
 					},
 					"dependencies": {
 						"acorn": {
-							"version": "6.4.0",
-							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-							"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+							"version": "6.4.1",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+							"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 						},
 						"cacache": {
-							"version": "12.0.3",
-							"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-							"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+							"version": "12.0.4",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+							"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
 							"requires": {
 								"bluebird": "^3.5.5",
 								"chownr": "^1.1.1",
@@ -17910,14 +15699,6 @@
 								"path-exists": "^3.0.0"
 							}
 						},
-						"lru-cache": {
-							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-							"requires": {
-								"yallist": "^3.0.2"
-							}
-						},
 						"make-dir": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -17928,17 +15709,17 @@
 							}
 						},
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -17984,6 +15765,14 @@
 							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 						},
+						"serialize-javascript": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+							"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+							"requires": {
+								"randombytes": "^2.1.0"
+							}
+						},
 						"ssri": {
 							"version": "6.0.1",
 							"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -17993,15 +15782,15 @@
 							}
 						},
 						"terser-webpack-plugin": {
-							"version": "1.4.3",
-							"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-							"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+							"version": "1.4.4",
+							"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+							"integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
 							"requires": {
 								"cacache": "^12.0.2",
 								"find-cache-dir": "^2.1.0",
 								"is-wsl": "^1.1.0",
 								"schema-utils": "^1.0.0",
-								"serialize-javascript": "^2.1.2",
+								"serialize-javascript": "^3.1.0",
 								"source-map": "^0.6.1",
 								"terser": "^4.1.2",
 								"webpack-sources": "^1.4.0",
@@ -18023,13 +15812,6 @@
 						"commander": "^2.19.0",
 						"filesize": "^3.6.1",
 						"humanize": "0.0.9"
-					},
-					"dependencies": {
-						"commander": {
-							"version": "2.20.3",
-							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-						}
 					}
 				},
 				"webpack-cli": {
@@ -18115,6 +15897,11 @@
 							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 							"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 						},
+						"emojis-list": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+							"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+						},
 						"enhanced-resolve": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
@@ -18170,6 +15957,11 @@
 								"which": "^1.3.1"
 							}
 						},
+						"interpret": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+							"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+						},
 						"invert-kv": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -18180,12 +15972,30 @@
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 						},
+						"json5": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+							"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+							"requires": {
+								"minimist": "^1.2.0"
+							}
+						},
 						"lcid": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 							"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 							"requires": {
 								"invert-kv": "^2.0.0"
+							}
+						},
+						"loader-utils": {
+							"version": "1.2.3",
+							"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+							"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+							"requires": {
+								"big.js": "^5.2.2",
+								"emojis-list": "^2.0.0",
+								"json5": "^1.0.1"
 							}
 						},
 						"locate-path": {
@@ -18216,9 +16026,9 @@
 							}
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -18339,9 +16149,9 @@
 							}
 						},
 						"yargs-parser": {
-							"version": "13.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-							"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+							"version": "13.1.2",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+							"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -18458,19 +16268,19 @@
 					},
 					"dependencies": {
 						"mkdirp": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+							"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 							"requires": {
-								"minimist": "0.0.8"
+								"minimist": "^1.2.5"
 							}
 						}
 					}
 				},
 				"write-file-atomic": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-					"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
 					"requires": {
 						"imurmurhash": "^0.1.4",
 						"is-typedarray": "^1.0.0",
@@ -18521,11 +16331,11 @@
 					}
 				},
 				"xhr-request-promise": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-					"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+					"integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
 					"requires": {
-						"xhr-request": "^1.0.1"
+						"xhr-request": "^1.1.0"
 					}
 				},
 				"xhr2-cookies": {
@@ -18563,17 +16373,14 @@
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				},
 				"yaml": {
-					"version": "1.7.2",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-					"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-					"requires": {
-						"@babel/runtime": "^7.6.3"
-					}
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+					"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 				},
 				"yargs": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+					"integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
@@ -18588,16 +16395,17 @@
 						"string-width": "^1.0.2",
 						"which-module": "^1.0.0",
 						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
+						"yargs-parser": "5.0.0-security.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"version": "5.0.0-security.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+					"integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "^3.0.0",
+						"object.assign": "^4.1.0"
 					}
 				},
 				"yargs-unparser": {
@@ -18671,14 +16479,14 @@
 							}
 						},
 						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+							"version": "4.17.19",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+							"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 						},
 						"p-limit": {
-							"version": "2.2.2",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-							"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 							"requires": {
 								"p-try": "^2.0.0"
 							}
@@ -18745,9 +16553,9 @@
 							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 						},
 						"yargs": {
-							"version": "13.3.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-							"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+							"version": "13.3.2",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+							"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 							"requires": {
 								"cliui": "^5.0.0",
 								"find-up": "^3.0.0",
@@ -18758,13 +16566,13 @@
 								"string-width": "^3.0.0",
 								"which-module": "^2.0.0",
 								"y18n": "^4.0.0",
-								"yargs-parser": "^13.1.1"
+								"yargs-parser": "^13.1.2"
 							}
 						},
 						"yargs-parser": {
-							"version": "13.1.1",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-							"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+							"version": "13.1.2",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+							"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 							"requires": {
 								"camelcase": "^5.0.0",
 								"decamelize": "^1.2.0"
@@ -18795,27 +16603,11 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
-		"get-proxy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
-			"dev": true,
-			"requires": {
-				"npm-conf": "^1.1.0"
-			}
-		},
-		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
-		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -18840,15 +16632,6 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-parent": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-			"dev": true,
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
@@ -18857,67 +16640,12 @@
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
-			},
-			"dependencies": {
-				"process": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-					"dev": true
-				}
-			}
-		},
-		"global-dirs": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.4"
-			}
-		},
-		"got": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-			"dev": true,
-			"requires": {
-				"@sindresorhus/is": "^0.7.0",
-				"cacheable-request": "^2.1.1",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"into-stream": "^3.1.0",
-				"is-retry-allowed": "^1.1.0",
-				"isurl": "^1.0.0-alpha5",
-				"lowercase-keys": "^1.0.0",
-				"mimic-response": "^1.0.0",
-				"p-cancelable": "^0.4.0",
-				"p-timeout": "^2.0.1",
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1",
-				"timed-out": "^4.0.1",
-				"url-parse-lax": "^3.0.0",
-				"url-to-options": "^1.0.1"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
 		"har-schema": {
@@ -18927,57 +16655,26 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
-		},
-		"has-symbol-support-x": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
-		},
-		"has-to-string-tag-x": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"dev": true,
-			"requires": {
-				"has-symbol-support-x": "^1.4.1"
-			}
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -18989,73 +16686,19 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
-				}
-			}
-		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
 				}
 			}
 		},
@@ -19068,12 +16711,6 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -19092,25 +16729,6 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 			"dev": true
 		},
-		"http-cache-semantics": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
-		},
-		"http-errors": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			}
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -19122,48 +16740,6 @@
 				"sshpk": "^1.7.0"
 			}
 		},
-		"https-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
-		},
-		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-			"dev": true,
-			"requires": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
 		"idna-uts46-hx": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
@@ -19172,17 +16748,6 @@
 			"requires": {
 				"punycode": "2.1.0"
 			}
-		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
-		"immediate": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-			"integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -19197,29 +16762,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
-		},
-		"interpret": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-			"dev": true
-		},
-		"into-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"dev": true,
-			"requires": {
-				"from2": "^2.1.1",
-				"p-is-promise": "^1.1.0"
-			}
 		},
 		"invert-kv": {
 			"version": "1.0.0",
@@ -19227,23 +16771,24 @@
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
 		},
-		"io-ts": {
-			"version": "1.10.4",
-			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
-			"integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
-			"dev": true,
-			"requires": {
-				"fp-ts": "^1.0.0"
-			}
-		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-arrayish": {
@@ -19252,49 +16797,46 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
-		"is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "^2.0.0"
-			}
-		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"is-callable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-			"dev": true
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -19305,8 +16847,7 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
 					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -19314,15 +16855,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true,
-			"optional": true
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
@@ -19339,101 +16872,39 @@
 			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
 			"dev": true
 		},
-		"is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.1"
-			}
-		},
 		"is-hex-prefixed": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
 			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
 			"dev": true
 		},
-		"is-installed-globally": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.2.0.tgz",
-			"integrity": "sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==",
-			"dev": true,
-			"requires": {
-				"global-dirs": "^0.1.1",
-				"is-path-inside": "^2.1.0"
-			}
-		},
-		"is-natural-number": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-		},
 		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"optional": true
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-			"dev": true
-		},
-		"is-path-inside": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			}
-		},
-		"is-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-retry-allowed": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-			"dev": true
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-typedarray": {
@@ -19458,13 +16929,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -19476,8 +16947,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -19485,48 +16955,16 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
-		"isurl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-			"dev": true,
-			"requires": {
-				"has-to-string-tag-x": "^1.2.0",
-				"is-object": "^1.0.1"
-			}
-		},
 		"js-sha3": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
 			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
 			"dev": true
 		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"dev": true
-		},
-		"json-loader": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
 			"dev": true
 		},
 		"json-schema": {
@@ -19545,12 +16983,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
 		},
 		"jsonfile": {
@@ -19574,33 +17006,11 @@
 				"verror": "1.10.0"
 			}
 		},
-		"keccak": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-			"dev": true,
-			"requires": {
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"keyv": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"dev": true,
-			"requires": {
-				"json-buffer": "3.0.0"
-			}
-		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true
 		},
 		"klaw": {
 			"version": "1.3.1",
@@ -19611,11 +17021,14 @@
 				"graceful-fs": "^4.1.9"
 			}
 		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
+		"klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11"
+			}
 		},
 		"lcid": {
 			"version": "1.0.0",
@@ -19626,286 +17039,18 @@
 				"invert-kv": "^1.0.0"
 			}
 		},
-		"level-codec": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-			"integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-			"dev": true
-		},
-		"level-errors": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-			"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-			"dev": true,
-			"requires": {
-				"errno": "~0.1.1"
-			}
-		},
-		"level-iterator-stream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"level-errors": "^1.0.3",
-				"readable-stream": "^1.0.33",
-				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"level-mem": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-			"integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-			"dev": true,
-			"requires": {
-				"level-packager": "~4.0.0",
-				"memdown": "~3.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"immediate": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-					"dev": true
-				},
-				"memdown": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-					"integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"functional-red-black-tree": "~1.0.1",
-						"immediate": "~3.2.3",
-						"inherits": "~2.0.1",
-						"ltgt": "~2.2.0",
-						"safe-buffer": "~5.1.1"
-					}
-				}
-			}
-		},
-		"level-packager": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-			"integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-			"dev": true,
-			"requires": {
-				"encoding-down": "~5.0.0",
-				"levelup": "^3.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"deferred-leveldown": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-					"integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"inherits": "^2.0.3"
-					}
-				},
-				"level-errors": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
-					"requires": {
-						"errno": "~0.1.1"
-					}
-				},
-				"level-iterator-stream": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-					"integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.3.6",
-						"xtend": "^4.0.0"
-					}
-				},
-				"levelup": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-					"integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-					"dev": true,
-					"requires": {
-						"deferred-leveldown": "~4.0.0",
-						"level-errors": "~2.0.0",
-						"level-iterator-stream": "~3.0.0",
-						"xtend": "~4.0.0"
-					}
-				}
-			}
-		},
-		"level-ws": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.0.15",
-				"xtend": "~2.1.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-					"dev": true,
-					"requires": {
-						"object-keys": "~0.4.0"
-					}
-				}
-			}
-		},
-		"levelup": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-			"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-			"dev": true,
-			"requires": {
-				"deferred-leveldown": "~1.2.1",
-				"level-codec": "~7.0.0",
-				"level-errors": "~1.0.3",
-				"level-iterator-stream": "~1.3.0",
-				"prr": "~1.0.1",
-				"semver": "~5.4.1",
-				"xtend": "~4.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-					"dev": true
-				}
-			}
-		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
 				"pify": "^2.0.0",
-				"strip-bom": "^3.0.0"
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
-		},
-		"loader-runner": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
-			"dev": true
-		},
-		"loader-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-			"dev": true,
-			"requires": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				}
-			}
-		},
-		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
-			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			}
-		},
-		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -19913,134 +17058,19 @@
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
 			"dev": true
 		},
-		"log-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2"
-			}
-		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
-		},
-		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
-		},
-		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
-			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"lru_map": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-			"integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
-			"dev": true
-		},
-		"ltgt": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-			"dev": true
-		},
-		"make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"requires": {
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
-			}
-		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
-			"requires": {
-				"mimic-fn": "^1.0.0"
-			}
-		},
-		"memdown": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~2.7.1",
-				"functional-red-black-tree": "^1.0.1",
-				"immediate": "^3.2.3",
-				"inherits": "~2.0.1",
-				"ltgt": "~2.2.0",
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				}
-			}
-		},
-		"memory-fs": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
-			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
 			}
 		},
 		"memorystream": {
@@ -20049,89 +17079,11 @@
 			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
 			"dev": true
 		},
-		"merkle-patricia-tree": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-			"integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"ethereumjs-util": "^5.2.0",
-				"level-mem": "^3.0.1",
-				"level-ws": "^1.0.0",
-				"readable-stream": "^3.0.6",
-				"rlp": "^2.0.0",
-				"semaphore": ">=1.0.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				},
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"level-ws": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-					"integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.8",
-						"xtend": "^4.0.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -20146,122 +17098,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
-			},
-			"dependencies": {
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
-					}
-				}
-			}
-		},
-		"miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
 			}
 		},
 		"mime-db": {
@@ -20278,12 +17114,6 @@
 			"requires": {
 				"mime-db": "1.44.0"
 			}
-		},
-		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -20332,7 +17162,6 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -20343,7 +17172,6 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -20359,284 +17187,17 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"mocha": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "3.2.3",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.3.0",
-				"debug": "3.2.6",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"find-up": "3.0.0",
-				"glob": "7.1.3",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.13.1",
-				"log-symbols": "3.0.0",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.5",
-				"ms": "2.1.1",
-				"node-environment-flags": "1.0.6",
-				"object.assign": "4.1.0",
-				"strip-json-comments": "2.0.1",
-				"supports-color": "6.0.0",
-				"which": "1.3.1",
-				"wide-align": "1.1.3",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "1.6.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"chokidar": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-					"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-					"dev": true,
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.1",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.2.0"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"readdirp": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-					"dev": true,
-					"requires": {
-						"picomatch": "^2.0.4"
-					}
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true,
-			"optional": true
-		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -20649,95 +17210,19 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
-		"neo-async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
-		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-			"dev": true
-		},
-		"node-environment-flags": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-			"integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-			"dev": true,
-			"requires": {
-				"object.getownpropertydescriptors": "^2.0.3",
-				"semver": "^5.7.0"
-			}
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 			"dev": true
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-			"dev": true
-		},
-		"node-libs-browser": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
-			"dev": true,
-			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^3.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.1",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
-				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.11.0",
-				"vm-browserify": "^1.0.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -20749,61 +17234,6 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"normalize-url": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0",
-				"query-string": "^5.0.1",
-				"sort-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"sort-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-					"dev": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				}
-			}
-		},
-		"npm-conf": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
-			"dev": true,
-			"requires": {
-				"config-chain": "^1.1.11",
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
-		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
-			"requires": {
-				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -20839,14 +17269,14 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -20858,63 +17288,28 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
 				}
 			}
-		},
-		"object-inspect": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.0"
-			}
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			},
-			"dependencies": {
-				"object-keys": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-					"dev": true
-				}
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"object.pick": {
@@ -20922,7 +17317,6 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -20931,25 +17325,18 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
 		},
-		"os-browserify": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
-		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -20957,86 +17344,6 @@
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
-		},
-		"p-cancelable": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-			"dev": true
-		},
-		"p-event": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
-			"integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
-			"dev": true,
-			"requires": {
-				"p-timeout": "^2.0.1"
-			}
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
-		},
-		"p-is-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-			"dev": true
-		},
-		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
-			"requires": {
-				"p-try": "^1.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
-			"requires": {
-				"p-limit": "^1.1.0"
-			}
-		},
-		"p-timeout": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
-		},
-		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
-		},
-		"pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true
-		},
-		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
-			"dev": true,
-			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3",
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"parse-headers": {
 			"version": "2.0.3",
@@ -21057,38 +17364,69 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"patch-package": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+			"integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^2.4.2",
+				"cross-spawn": "^6.0.5",
+				"find-yarn-workspace-root": "^1.2.1",
+				"fs-extra": "^7.0.1",
+				"is-ci": "^2.0.0",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.0",
+				"rimraf": "^2.6.3",
+				"semver": "^5.6.0",
+				"slash": "^2.0.0",
+				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				}
+			}
 		},
 		"path-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
 			"dev": true
-		},
-		"path-dirname": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true,
-			"optional": true
 		},
 		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "^2.0.0"
+			}
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 			"dev": true
 		},
 		"path-key": {
@@ -21104,12 +17442,14 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pathval": {
@@ -21118,50 +17458,29 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
-		"pbkdf2": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-			"dev": true,
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
-		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
-		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -21170,42 +17489,18 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+		"postinstall-postinstall": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
+			"integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
 			"dev": true
 		},
 		"process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
-		"proto-list": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true
-		},
-		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
-		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
 			"dev": true
 		},
 		"psl": {
@@ -21213,28 +17508,6 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
-		},
-		"public-encrypt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
 		},
 		"punycode": {
 			"version": "2.1.0",
@@ -21265,12 +17538,6 @@
 			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
 			"dev": true
 		},
-		"querystring-es3": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21280,71 +17547,25 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"raw-body": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.3",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
-		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"picomatch": "^2.2.1"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			}
 		},
 		"regex-not": {
@@ -21352,25 +17573,16 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true,
-			"optional": true
-		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
 			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
@@ -21404,14 +17616,6 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
 			}
 		},
 		"require-directory": {
@@ -21445,33 +17649,13 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true,
-			"optional": true
-		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
-			"requires": {
-				"lowercase-keys": "^1.0.0"
-			}
+			"dev": true
 		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true,
-			"optional": true
-		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.1"
-			}
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.7.1",
@@ -21482,50 +17666,17 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
-		"rlp": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
-			}
-		},
-		"rustbn.js": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-			"integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
-			"dev": true
-		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -21540,38 +17691,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
 			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-			"dev": true
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"dev": true,
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"seek-bzip": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-			"requires": {
-				"commander": "^2.8.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				}
-			}
-		},
-		"semaphore": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
 			"dev": true
 		},
 		"semver": {
@@ -21591,7 +17710,6 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -21604,33 +17722,10 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
-			}
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-			"dev": true
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shebang-command": {
@@ -21648,16 +17743,10 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
-		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
-		},
 		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
 			"dev": true
 		},
 		"simple-get": {
@@ -21672,9 +17761,9 @@
 			}
 		},
 		"slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -21682,7 +17771,6 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -21699,7 +17787,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -21709,7 +17796,6 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -21721,7 +17807,6 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -21733,7 +17818,6 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -21743,7 +17827,6 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -21753,7 +17836,6 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -21763,19 +17845,11 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"kind-of": {
-					"version": "6.0.3",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-					"dev": true,
-					"optional": true
 				}
 			}
 		},
@@ -21784,9 +17858,19 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"solc": {
@@ -21800,187 +17884,7 @@
 				"require-from-string": "^1.1.0",
 				"semver": "^5.3.0",
 				"yargs": "^4.7.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"dev": true,
-					"requires": {
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"lodash.assign": "^4.0.3",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.1",
-						"which-module": "^1.0.0",
-						"window-size": "^0.2.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0",
-						"lodash.assign": "^4.0.6"
-					}
-				}
 			}
-		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^1.0.0"
-			}
-		},
-		"sort-keys-length": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
-			"integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
-			"dev": true,
-			"requires": {
-				"sort-keys": "^1.0.0"
-			}
-		},
-		"source-list-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -21993,7 +17897,6 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
 			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"atob": "^2.1.2",
 				"decode-uri-component": "^0.2.0",
@@ -22002,30 +17905,11 @@
 				"urix": "^0.1.0"
 			}
 		},
-		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -22054,9 +17938,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
 			"dev": true
 		},
 		"split-string": {
@@ -22064,16 +17948,9 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -22097,7 +17974,6 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -22108,40 +17984,10 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				}
-			}
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
-		},
-		"stream-browserify": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"stream-http": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-			"dev": true,
-			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
 			}
 		},
 		"strict-uri-encode": {
@@ -22151,64 +17997,14 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"string.prototype.trimend": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"string.prototype.trimstart": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -22221,24 +18017,13 @@
 			}
 		},
 		"strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
-		},
-		"strip-dirs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
 			"requires": {
-				"is-natural-number": "^4.0.1"
+				"is-utf8": "^0.2.0"
 			}
-		},
-		"strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
 		},
 		"strip-hex-prefix": {
 			"version": "1.0.0",
@@ -22249,48 +18034,13 @@
 				"is-hex-prefixed": "1.0.0"
 			}
 		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
-		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
 		"supports-color": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^2.0.0"
-			}
-		},
-		"tapable": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.9.tgz",
-			"integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==",
-			"dev": true
-		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"testrpc": {
@@ -22299,25 +18049,11 @@
 			"integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
 			"dev": true
 		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 			"dev": true
-		},
-		"timers-browserify": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
-			"dev": true,
-			"requires": {
-				"setimmediate": "^1.0.4"
-			}
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -22328,25 +18064,24 @@
 				"os-tmpdir": "~1.0.2"
 			}
 		},
-		"to-arraybuffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
-		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
@@ -22354,7 +18089,6 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -22363,20 +18097,14 @@
 			}
 		},
 		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"is-number": "^7.0.0"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.5.0",
@@ -22396,39 +18124,6 @@
 				}
 			}
 		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"ts-essentials": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-			"integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
-			"dev": true
-		},
-		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-			"dev": true
-		},
-		"tsort": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
-			"integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
-			"dev": true
-		},
-		"tty-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -22444,92 +18139,11 @@
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 			"dev": true
 		},
-		"tweetnacl-util": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-			"integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-			"dev": true
-		},
-		"type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-			"dev": true
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
-		},
-		"type-fest": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-			"dev": true
-		},
-		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
-			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
-			},
-			"dependencies": {
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
-						"window-size": "0.1.0"
-					}
-				}
-			}
-		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
-			"optional": true
-		},
-		"uglifyjs-webpack-plugin": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-			"dev": true,
-			"requires": {
-				"source-map": "^0.5.6",
-				"uglify-js": "^2.8.29",
-				"webpack-sources": "^1.0.1"
-			}
-		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
 		},
 		"underscore": {
 			"version": "1.9.1",
@@ -22542,7 +18156,6 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -22556,18 +18169,11 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
-		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -22578,7 +18184,6 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -22590,7 +18195,6 @@
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -22601,22 +18205,14 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
-		"upath": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true,
-			"optional": true
-		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -22626,8 +18222,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"url": {
 			"version": "0.11.0",
@@ -22647,33 +18242,17 @@
 				}
 			}
 		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0"
-			}
-		},
 		"url-set-query": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
 			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
 			"dev": true
 		},
-		"url-to-options": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-			"dev": true
-		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"utf8": {
 			"version": "3.0.0",
@@ -22681,44 +18260,10 @@
 			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
 			"dev": true
 		},
-		"util": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				}
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
-		},
 		"uuid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -22742,276 +18287,20 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"vm-browserify": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-			"dev": true
-		},
-		"watchpack": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-			"integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
-			"dev": true,
-			"requires": {
-				"chokidar": "^3.4.0",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.0"
-			}
-		},
-		"watchpack-chokidar2": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-			"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"chokidar": "^2.1.8"
-			},
-			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-					"dev": true,
-					"optional": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					}
-				},
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					}
-				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
-					}
-				}
-			}
-		},
 		"web3-utils": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-			"integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+			"integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"eth-lib": "0.2.7",
+				"bn.js": "^4.11.9",
+				"eth-lib": "0.2.8",
 				"ethereum-bloom-filters": "^1.0.6",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
 				"randombytes": "^2.1.0",
 				"underscore": "1.9.1",
 				"utf8": "3.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-					"dev": true
-				}
-			}
-		},
-		"webpack": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
-			"integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"async": "^2.1.2",
-				"enhanced-resolve": "^3.4.0",
-				"escope": "^3.6.0",
-				"interpret": "^1.0.0",
-				"json-loader": "^0.5.4",
-				"json5": "^0.5.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"mkdirp": "~0.5.0",
-				"node-libs-browser": "^2.0.0",
-				"source-map": "^0.5.3",
-				"supports-color": "^4.2.1",
-				"tapable": "^0.2.7",
-				"uglifyjs-webpack-plugin": "^0.4.6",
-				"watchpack": "^1.4.0",
-				"webpack-sources": "^1.0.1",
-				"yargs": "^8.0.2"
-			}
-		},
-		"webpack-sources": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-			"dev": true,
-			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"which": {
@@ -23024,30 +18313,15 @@
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
 			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
 		},
 		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
-		},
-		"wordwrap": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -23058,25 +18332,13 @@
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"ws": {
 			"version": "7.2.3",
@@ -23123,7 +18385,8 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
@@ -23131,251 +18394,36 @@
 			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 			"dev": true
 		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
-		},
 		"yargs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0",
 				"cliui": "^3.2.0",
 				"decamelize": "^1.1.1",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
+				"lodash.assign": "^4.0.3",
+				"os-locale": "^1.4.0",
+				"read-pkg-up": "^1.0.1",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
+				"string-width": "^1.0.1",
+				"which-module": "^1.0.0",
+				"window-size": "^0.2.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^7.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
-					}
-				}
+				"yargs-parser": "^2.4.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
-			}
-		},
-		"yargs-unparser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-			"dev": true,
-			"requires": {
-				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
-				"yargs": "^13.3.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"camelcase": "^3.0.0",
+				"lodash.assign": "^4.0.6"
 			}
 		}
 	}

--- a/packages/buidler-waffle/src/waffle-provider-adapter.ts
+++ b/packages/buidler-waffle/src/waffle-provider-adapter.ts
@@ -1,4 +1,7 @@
-import { BuidlerNetworkConfig, Network } from "@nomiclabs/buidler/types";
+import {
+  Network,
+  ResolvedBuidlerNetworkConfig,
+} from "@nomiclabs/buidler/types";
 import { providers, Wallet } from "ethers";
 
 // This class is an extension of buidler-ethers' wrapper.
@@ -15,7 +18,8 @@ export class WaffleMockProviderAdapter extends providers.JsonRpcProvider {
 You can use \`await bre.ethers.signers()\` in other networks.`);
     }
 
-    return (this._buidlerNetwork.config as BuidlerNetworkConfig).accounts!.map(
+    return (this._buidlerNetwork
+      .config as ResolvedBuidlerNetworkConfig).accounts!.map(
       (acc) => new Wallet(acc.privateKey, this)
     );
   }

--- a/packages/buidler-waffle/test/index.ts
+++ b/packages/buidler-waffle/test/index.ts
@@ -1,5 +1,5 @@
-import defaultConfig from "@nomiclabs/buidler/internal/core/config/default-config";
-import { BuidlerNetworkConfig } from "@nomiclabs/buidler/types";
+import { BUIDLEREVM_NETWORK_NAME } from "@nomiclabs/buidler/plugins";
+import { ResolvedBuidlerNetworkConfig } from "@nomiclabs/buidler/types";
 import { assert } from "chai";
 import path from "path";
 
@@ -14,8 +14,9 @@ describe("Waffle plugin plugin", function () {
 
           it("Should return a wallet for each of the default accounts", function () {
             const wallets = this.env.waffle.provider.getWallets();
-            const accounts = (defaultConfig.networks!
-              .buidlerevm! as BuidlerNetworkConfig).accounts!;
+            assert.equal(this.env.network.name, BUIDLEREVM_NETWORK_NAME);
+            const accounts = (this.env.network
+              .config as ResolvedBuidlerNetworkConfig).accounts;
             assert.lengthOf(wallets, accounts.length);
 
             for (let i = 0; i < wallets.length; i++) {
@@ -70,8 +71,9 @@ describe("Waffle plugin plugin", function () {
 
             it("Should return a wallet for each of the default accounts", function () {
               const wallets = this.env.waffle.provider.getWallets();
-              const accounts = (defaultConfig.networks!
-                .buidlerevm! as BuidlerNetworkConfig).accounts!;
+              assert.equal(this.env.network.name, BUIDLEREVM_NETWORK_NAME);
+              const accounts = (this.env.network
+                .config as ResolvedBuidlerNetworkConfig).accounts!;
 
               assert.lengthOf(wallets, accounts.length);
 

--- a/packages/buidler-web3-legacy/package-lock.json
+++ b/packages/buidler-web3-legacy/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"assertion-error": {

--- a/packages/buidler-web3/package-lock.json
+++ b/packages/buidler-web3/package-lock.json
@@ -22,68 +22,67 @@
 			}
 		},
 		"@ethersproject/address": {
-			"version": "5.0.0-beta.135",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.135.tgz",
-			"integrity": "sha512-y9r/ajYBCDVM1ZD6kKgTRHBOxgURcQ24qTolw3oGyK373XHNrcY9ufDgZ5KR8h0OvLvczb4SGzYhahYvBnyZwA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+			"integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": ">=5.0.0-beta.138",
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
-				"@ethersproject/keccak256": ">=5.0.0-beta.131",
-				"@ethersproject/logger": ">=5.0.0-beta.137",
-				"@ethersproject/rlp": ">=5.0.0-beta.132",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/rlp": "^5.0.3",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.0.0-beta.139",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.139.tgz",
-			"integrity": "sha512-h1C1okCmPK3UVWwMGUbuCZykplJmD/TdknPQQHJWL/chK5MqBhyQ5o1Cay7mHXKCBnjWrR9BtwjfkAh76pYtFA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+			"integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
-				"@ethersproject/logger": ">=5.0.0-beta.137",
-				"@ethersproject/properties": ">=5.0.0-beta.140",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
 				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.0.0-beta.138",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.138.tgz",
-			"integrity": "sha512-q4vaIthv89RJQ0V6gdzh1xuluJE1uYbnfzBUYTegicaXX6jRTCjDDhyiQhyEnNi7pKrGtuOrR3v3+7WtAR8Imw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+			"integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": ">=5.0.0-beta.137"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/constants": {
-			"version": "5.0.0-beta.134",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.134.tgz",
-			"integrity": "sha512-tKKL7F3ozL+XgZ4+McNmp12rnPxKf+InKr36asVVAiVLa0WxnNsO9m/+0LkW5dMFbqn2i2VJtBwKfl1OE6GInA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+			"integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bignumber": ">=5.0.0-beta.138"
+				"@ethersproject/bignumber": "^5.0.7"
 			}
 		},
 		"@ethersproject/hash": {
-			"version": "5.0.0-beta.134",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.0-beta.134.tgz",
-			"integrity": "sha512-yvHyu+9Mgi4jn41DakA8tgHwngsSlTEyLBavP08GN3oS6fTiqflEMa4AXUFndztpcvk7UdGlowCOp6UupbmRVQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+			"integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
-				"@ethersproject/keccak256": ">=5.0.0-beta.131",
-				"@ethersproject/logger": ">=5.0.0-beta.137",
-				"@ethersproject/strings": ">=5.0.0-beta.136"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.0.0-beta.132",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.132.tgz",
-			"integrity": "sha512-YpkwYGV4nu1QM7Q+mhYKO1bCk/sbiV7AAU/HnHwZhDiwJZSDRwfjiFkAJQpvTbsAR02Ek9LhFEBg4OfLTEhJLg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+			"integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
+				"@ethersproject/bytes": "^5.0.4",
 				"js-sha3": "0.5.7"
 			},
 			"dependencies": {
@@ -96,39 +95,68 @@
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.0.0-beta.137",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.137.tgz",
-			"integrity": "sha512-H36iMhWOY+tco1+o2NZUdQT8Gc6Y9795RSPgvluatvjvyt3X6mHtWXes4F8Rc5N/95px++a/ODYVSkSmlr68+A==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+			"integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
 			"dev": true
 		},
 		"@ethersproject/properties": {
-			"version": "5.0.0-beta.141",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.141.tgz",
-			"integrity": "sha512-jWHVLlH8tmdMw6L9USaidZsiY/IOV4Br01PKM711oDZ8McBXrbW1FzcgpuzV91SNNMYek9kvrJJzAOPL2vANTQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+			"integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/logger": ">=5.0.0-beta.137"
+				"@ethersproject/logger": "^5.0.5"
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.0.0-beta.133",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.133.tgz",
-			"integrity": "sha512-4zwGZov221uYuz6oXqAf2i5dk3ven7mSNkPRYvS2xdAlUn1Qy8GFUswyRuLaGzpWUGNlKIWCEnvomP5L/CtMPQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+			"integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
-				"@ethersproject/logger": ">=5.0.0-beta.137"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
+			}
+		},
+		"@ethersproject/signing-key": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+			"integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
+			"dev": true,
+			"requires": {
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"elliptic": "6.5.3"
 			}
 		},
 		"@ethersproject/strings": {
-			"version": "5.0.0-beta.137",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.137.tgz",
-			"integrity": "sha512-Z1xKXjoBWM5DOlc8HvjpOKO1zZ8kf4nLpf4C8zZjz+GNhaH03z74tXNNpdLf4UV6otMcHcJtO+X5ATE4TCn9Iw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+			"integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
 			"dev": true,
 			"requires": {
-				"@ethersproject/bytes": ">=5.0.0-beta.137",
-				"@ethersproject/constants": ">=5.0.0-beta.133",
-				"@ethersproject/logger": ">=5.0.0-beta.137"
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/logger": "^5.0.5"
+			}
+		},
+		"@ethersproject/transactions": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+			"integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
+			"dev": true,
+			"requires": {
+				"@ethersproject/address": "^5.0.4",
+				"@ethersproject/bignumber": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.4",
+				"@ethersproject/constants": "^5.0.4",
+				"@ethersproject/keccak256": "^5.0.3",
+				"@ethersproject/logger": "^5.0.5",
+				"@ethersproject/properties": "^5.0.3",
+				"@ethersproject/rlp": "^5.0.3",
+				"@ethersproject/signing-key": "^5.0.4"
 			}
 		},
 		"@sindresorhus/is": {
@@ -164,38 +192,33 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
+			"integrity": "sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.17.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-			"integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==",
+			"version": "12.12.62",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+			"integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
 			"dev": true
 		},
-		"@web3-js/scrypt-shim": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
-			"integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
+		"@types/pbkdf2": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
 			"dev": true,
 			"requires": {
-				"scryptsy": "^2.1.0",
-				"semver": "^6.3.0"
+				"@types/node": "*"
 			}
 		},
-		"@web3-js/websocket": {
-			"version": "1.0.30",
-			"resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
-			"integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
+		"@types/secp256k1": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
-				"typedarray-to-buffer": "^3.1.5",
-				"yaeti": "^0.0.6"
+				"@types/node": "*"
 			}
 		},
 		"accepts": {
@@ -209,9 +232,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -236,14 +259,15 @@
 			}
 		},
 		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -277,9 +301,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
 			"dev": true
 		},
 		"base-x": {
@@ -311,23 +335,11 @@
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
+		"blakejs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -413,16 +425,16 @@
 			}
 		},
 		"browserify-sign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-			"integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^5.1.1",
 				"browserify-rsa": "^4.0.1",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.2",
+				"elliptic": "^6.5.3",
 				"inherits": "^2.0.4",
 				"parse-asn1": "^5.1.5",
 				"readable-stream": "^3.6.0",
@@ -430,9 +442,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-					"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
 					"dev": true
 				},
 				"safe-buffer": {
@@ -441,6 +453,26 @@
 					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 					"dev": true
 				}
+			}
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+			"dev": true,
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"dev": true,
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"buffer": {
@@ -465,6 +497,15 @@
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
 			"dev": true
 		},
+		"bufferutil": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+			"integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+			"dev": true,
+			"requires": {
+				"node-gyp-build": "~3.7.0"
+			}
+		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -487,9 +528,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -549,12 +590,12 @@
 			},
 			"dependencies": {
 				"multicodec": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
-					"integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+					"integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
 					"dev": true,
 					"requires": {
-						"buffer": "^5.5.0",
+						"buffer": "^5.6.0",
 						"varint": "^5.0.0"
 					}
 				}
@@ -655,13 +696,13 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"elliptic": "^6.5.3"
 			}
 		},
 		"create-hash": {
@@ -813,17 +854,6 @@
 			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
 			"dev": true
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"dev": true,
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -847,9 +877,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -961,10 +991,33 @@
 				"js-sha3": "^0.8.0"
 			}
 		},
+		"ethereum-cryptography": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+			"dev": true,
+			"requires": {
+				"@types/pbkdf2": "^3.0.0",
+				"@types/secp256k1": "^4.0.1",
+				"blakejs": "^1.1.0",
+				"browserify-aes": "^1.2.0",
+				"bs58check": "^2.1.2",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"hash.js": "^1.1.7",
+				"keccak": "^3.0.0",
+				"pbkdf2": "^3.0.17",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.1.2",
+				"scrypt-js": "^3.0.0",
+				"secp256k1": "^4.0.1",
+				"setimmediate": "^1.0.5"
+			}
+		},
 		"ethereumjs-common": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.1.tgz",
-			"integrity": "sha512-aVUPRLgmXORGXXEVkFYgPhr9TGtpBY2tGhZ9Uh0A3lIUzUDr1x6kQx33SbjPUkLkX3eniPQnIL/2psjkjrOfcQ==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
 			"dev": true
 		},
 		"ethereumjs-tx": {
@@ -978,18 +1031,18 @@
 			}
 		},
 		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
 			"dev": true,
 			"requires": {
 				"@types/bn.js": "^4.11.3",
 				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
+				"elliptic": "^6.5.2",
+				"ethereum-cryptography": "^0.1.3",
 				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
+				"rlp": "^2.2.3"
 			}
 		},
 		"ethjs-unit": {
@@ -1021,9 +1074,9 @@
 			}
 		},
 		"eventemitter3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
 			"dev": true
 		},
 		"evp_bytestokey": {
@@ -1084,9 +1137,9 @@
 			},
 			"dependencies": {
 				"type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+					"integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
 					"dev": true
 				}
 			}
@@ -1104,21 +1157,15 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true
 		},
 		"finalhandler": {
@@ -1251,12 +1298,12 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -1519,21 +1566,19 @@
 			}
 		},
 		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
 			"dev": true,
 			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
 			},
 			"dependencies": {
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+				"node-gyp-build": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+					"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
 					"dev": true
 				}
 			}
@@ -1681,9 +1726,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
-			"integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+			"integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
 			"dev": true
 		},
 		"ms": {
@@ -1712,9 +1757,9 @@
 			}
 		},
 		"multihashes": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-			"integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+			"version": "0.4.21",
+			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+			"integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.5.0",
@@ -1734,12 +1779,6 @@
 				}
 			}
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true
-		},
 		"nano-json-stream-parser": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
@@ -1756,6 +1795,18 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+			"dev": true
+		},
+		"node-gyp-build": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+			"integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
 			"dev": true
 		},
 		"normalize-url": {
@@ -1795,9 +1846,9 @@
 			"dev": true
 		},
 		"oboe": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
-			"integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+			"integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
 			"dev": true,
 			"requires": {
 				"http-https": "^1.0.0"
@@ -1843,14 +1894,13 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
+				"asn1.js": "^5.2.0",
 				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
@@ -1881,9 +1931,9 @@
 			"dev": true
 		},
 		"pbkdf2": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
 			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
@@ -2078,9 +2128,9 @@
 			}
 		},
 		"rlp": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.5.tgz",
-			"integrity": "sha512-y1QxTQOp0OZnjn19FxBmped4p+BSKPHwGndaqrESseyd2xXZtcgR3yuTIosh8CaMaOii9SKIYerBXnV/CpJ3qw==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.11.1"
@@ -2098,33 +2148,30 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"scryptsy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
 			"dev": true
 		},
 		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
 			"dev": true,
 			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
 				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			},
+			"dependencies": {
+				"node-gyp-build": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+					"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+					"dev": true
+				}
 			}
-		},
-		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -2203,9 +2250,9 @@
 			}
 		},
 		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
 			"dev": true
 		},
 		"simple-get": {
@@ -2469,9 +2516,9 @@
 			"dev": true
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -2497,6 +2544,15 @@
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
 			"dev": true
+		},
+		"utf-8-validate": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+			"integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+			"dev": true,
+			"requires": {
+				"node-gyp-build": "~3.7.0"
+			}
 		},
 		"utf8": {
 			"version": "3.0.0",
@@ -2546,161 +2602,154 @@
 			}
 		},
 		"web3": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.8.tgz",
-			"integrity": "sha512-rXUn16VKxn2aIe9v0KX+bSm2JXdq/Vnj3lZ0Rub2Q5YUSycHdCBaDtJRukl/jB5ygAdyr5/cUwvJzhNDJSYsGw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.3.0.tgz",
+			"integrity": "sha512-4q9dna0RecnrlgD/bD1C5S+81Untbd6Z/TBD7rb+D5Bvvc0Wxjr4OP70x+LlnwuRDjDtzBwJbNUblh2grlVArw==",
 			"dev": true,
 			"requires": {
-				"web3-bzz": "1.2.8",
-				"web3-core": "1.2.8",
-				"web3-eth": "1.2.8",
-				"web3-eth-personal": "1.2.8",
-				"web3-net": "1.2.8",
-				"web3-shh": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-bzz": "1.3.0",
+				"web3-core": "1.3.0",
+				"web3-eth": "1.3.0",
+				"web3-eth-personal": "1.3.0",
+				"web3-net": "1.3.0",
+				"web3-shh": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-bzz": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.8.tgz",
-			"integrity": "sha512-jbi24/s2tT7FYuN+ktRvTa5em0GxhqcIYQ8FnD3Zb/ZoEPi+/7rH0Hh+WDol0pSZL+wdz/iM+Z2C9NE42z6EmQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.0.tgz",
+			"integrity": "sha512-ibYAnKab+sgTo/UdfbrvYfWblXjjgSMgyy9/FHa6WXS14n/HVB+HfWqGz2EM3fok8Wy5XoKGMvdqvERQ/mzq1w==",
 			"dev": true,
 			"requires": {
-				"@types/node": "^10.12.18",
+				"@types/node": "^12.12.6",
 				"got": "9.6.0",
 				"swarm-js": "^0.1.40",
 				"underscore": "1.9.1"
 			}
 		},
 		"web3-core": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.8.tgz",
-			"integrity": "sha512-hvlYWyE1UcLoGa6qF1GoxGgi1quFsZOdwIUIVsAp+sp0plXp/Nqva2lAjJ+FFyWtVKbC7Zq+qwTJ4iP1aN0vTg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.0.tgz",
+			"integrity": "sha512-BwWvAaKJf4KFG9QsKRi3MNoNgzjI6szyUlgme1qNPxUdCkaS3Rdpa0VKYNHP7M/YTk82/59kNE66mH5vmoaXjA==",
 			"dev": true,
 			"requires": {
-				"@types/bn.js": "^4.11.4",
-				"@types/node": "^12.6.1",
+				"@types/bn.js": "^4.11.5",
+				"@types/node": "^12.12.6",
 				"bignumber.js": "^9.0.0",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-core-requestmanager": "1.2.8",
-				"web3-utils": "1.2.8"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-					"integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
-					"dev": true
-				}
+				"web3-core-helpers": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-core-requestmanager": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-core-helpers": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.8.tgz",
-			"integrity": "sha512-Wrl7ZPKn3Xyg0Hl5+shDnJcLP+EtTfThmQ1eCJLcg/BZqvLUR1SkOslNlhEojcYeBwhhymAKs8dfQbtYi+HMnw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.0.tgz",
+			"integrity": "sha512-+MFb1kZCrRctf7UYE7NCG4rGhSXaQJ/KF07di9GVK1pxy1K0+rFi61ZobuV1ky9uQp+uhhSPts4Zp55kRDB5sw==",
 			"dev": true,
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-eth-iban": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-eth-iban": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-core-method": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.8.tgz",
-			"integrity": "sha512-69qbvOgx0Frw46dXvEKzYgtaPXpUaQAlQmczgb0ZUBHsEU2K7jTtFgBy6kVBgAwsXDvoZ99AX4SjpY2dTMwPkw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.0.tgz",
+			"integrity": "sha512-h0yFDrYVzy5WkLxC/C3q+hiMnzxdWm9p1T1rslnuHgOp6nYfqzu/6mUIXrsS4h/OWiGJt+BZ0xVZmtC31HDWtg==",
 			"dev": true,
 			"requires": {
+				"@ethersproject/transactions": "^5.0.0-beta.135",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-promievent": "1.2.8",
-				"web3-core-subscriptions": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core-helpers": "1.3.0",
+				"web3-core-promievent": "1.3.0",
+				"web3-core-subscriptions": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-core-promievent": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.8.tgz",
-			"integrity": "sha512-3EdRieaHpBVVhfGjoREQfdoCM3xC0WwWjXXzT6oTldotfYC38kwk/GW8c8txYiLP/KxhslAN1cJSlXNOJjKSog==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.0.tgz",
+			"integrity": "sha512-blv69wrXw447TP3iPvYJpllkhW6B18nfuEbrfcr3n2Y0v1Jx8VJacNZFDFsFIcgXcgUIVCtOpimU7w9v4+rtaw==",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "3.1.2"
+				"eventemitter3": "4.0.4"
 			}
 		},
 		"web3-core-requestmanager": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.8.tgz",
-			"integrity": "sha512-bwc2ABG6yzgTy28fv4t59g+tf6+UmTRMoF8HqTeiNDffoMKP2akyKFZeu1oD2gE7j/7GA75TAUjwJ7pH9ek1MA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.0.tgz",
+			"integrity": "sha512-3yMbuGcomtzlmvTVqNRydxsx7oPlw3ioRL6ReF9PeNYDkUsZaUib+6Dp5eBt7UXh5X+SIn/xa1smhDHz5/HpAw==",
 			"dev": true,
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.8",
-				"web3-providers-http": "1.2.8",
-				"web3-providers-ipc": "1.2.8",
-				"web3-providers-ws": "1.2.8"
+				"web3-core-helpers": "1.3.0",
+				"web3-providers-http": "1.3.0",
+				"web3-providers-ipc": "1.3.0",
+				"web3-providers-ws": "1.3.0"
 			}
 		},
 		"web3-core-subscriptions": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.8.tgz",
-			"integrity": "sha512-wmsRJ4ipwoF1mlOR+Oo8JdKigpkoVNQtqiRUuyQrTVhJx7GBuSaAIenpBYlkucC+RgByoGybR7Q3tTNJ6z/2tQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.0.tgz",
+			"integrity": "sha512-MUUQUAhJDb+Nz3S97ExVWveH4utoUnsbPWP+q1HJH437hEGb4vunIb9KvN3hFHLB+aHJfPeStM/4yYTz5PeuyQ==",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "3.1.2",
+				"eventemitter3": "4.0.4",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.8"
+				"web3-core-helpers": "1.3.0"
 			}
 		},
 		"web3-eth": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.8.tgz",
-			"integrity": "sha512-CEnVIIR1zZQ9vQh/kPFAUbvbbHYkC84y15jdhRUDDGR6bs4FxO2NNWR2YDtNe038lrz747tZahsC9kEiGkJFZQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.0.tgz",
+			"integrity": "sha512-/bzJcxXPM9EM18JM5kO2JjZ3nEqVo3HxqU93aWAEgJNqaP/Lltmufl2GpvIB2Hvj+FXAjAXquxUdQ2/xP7BzHQ==",
 			"dev": true,
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core": "1.2.8",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-core-subscriptions": "1.2.8",
-				"web3-eth-abi": "1.2.8",
-				"web3-eth-accounts": "1.2.8",
-				"web3-eth-contract": "1.2.8",
-				"web3-eth-ens": "1.2.8",
-				"web3-eth-iban": "1.2.8",
-				"web3-eth-personal": "1.2.8",
-				"web3-net": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-helpers": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-core-subscriptions": "1.3.0",
+				"web3-eth-abi": "1.3.0",
+				"web3-eth-accounts": "1.3.0",
+				"web3-eth-contract": "1.3.0",
+				"web3-eth-ens": "1.3.0",
+				"web3-eth-iban": "1.3.0",
+				"web3-eth-personal": "1.3.0",
+				"web3-net": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-eth-abi": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.8.tgz",
-			"integrity": "sha512-OKp/maLdKHPpQxZhEd0HgnCJFQajsGe42WOG6SVftlgzyR8Jjv4KNm46TKvb3hv5OJTKZWU7nZIxkEG+fyI58w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.0.tgz",
+			"integrity": "sha512-1OrZ9+KGrBeBRd3lO8upkpNua9+7cBsQAgor9wbA25UrcUYSyL8teV66JNRu9gFxaTbkpdrGqM7J/LXpraXWrg==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/abi": "5.0.0-beta.153",
 				"underscore": "1.9.1",
-				"web3-utils": "1.2.8"
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-eth-accounts": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.8.tgz",
-			"integrity": "sha512-QODqSD4SZN/1oWfvlvsuum6Ud9+2FUTW4VTPJh245YTewCpa0M5+Fzug3UTeUZNv88STwC//dV72zReITNh4ZQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.0.tgz",
+			"integrity": "sha512-/Q7EVW4L2wWUbNRtOTwAIrYvJid/5UnKMw67x/JpvRMwYC+e+744P536Ja6SG4X3MnzFvd3E/jruV4qa6k+zIw==",
 			"dev": true,
 			"requires": {
-				"@web3-js/scrypt-shim": "^0.1.0",
 				"crypto-browserify": "3.12.0",
-				"eth-lib": "^0.2.8",
+				"eth-lib": "0.2.8",
 				"ethereumjs-common": "^1.3.2",
 				"ethereumjs-tx": "^2.1.1",
+				"scrypt-js": "^3.0.1",
 				"underscore": "1.9.1",
 				"uuid": "3.3.2",
-				"web3-core": "1.2.8",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-helpers": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-utils": "1.3.0"
 			},
 			"dependencies": {
 				"eth-lib": {
@@ -2723,151 +2772,127 @@
 			}
 		},
 		"web3-eth-contract": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.8.tgz",
-			"integrity": "sha512-EWRLVhZksbzGAyHd7RaOsakjCJBA2BREWiJmBDlrxDBqw8HltXFzKdkRug/mwVNa5ZYMabKSRF/MMh0Sx06CFw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.0.tgz",
+			"integrity": "sha512-3SCge4SRNCnzLxf0R+sXk6vyTOl05g80Z5+9/B5pERwtPpPWaQGw8w01vqYqsYBKC7zH+dxhMaUgVzU2Dgf7bQ==",
 			"dev": true,
 			"requires": {
-				"@types/bn.js": "^4.11.4",
+				"@types/bn.js": "^4.11.5",
 				"underscore": "1.9.1",
-				"web3-core": "1.2.8",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-core-promievent": "1.2.8",
-				"web3-core-subscriptions": "1.2.8",
-				"web3-eth-abi": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-helpers": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-core-promievent": "1.3.0",
+				"web3-core-subscriptions": "1.3.0",
+				"web3-eth-abi": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-eth-ens": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.8.tgz",
-			"integrity": "sha512-zsFXY26BMGkihPkEO5qj9AEqyxPH4mclbzYs1dyrw7sHFmrUvhZc+jLGT9WyQGoujq37RN2l/tlOpCaFVVR8ng==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.0.tgz",
+			"integrity": "sha512-WnOru+EcuM5dteiVYJcHXo/I7Wq+ei8RrlS2nir49M0QpYvUPGbCGgTbifcjJQTWamgORtWdljSA1s2Asdb74w==",
 			"dev": true,
 			"requires": {
 				"content-hash": "^2.5.2",
 				"eth-ens-namehash": "2.0.8",
 				"underscore": "1.9.1",
-				"web3-core": "1.2.8",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-promievent": "1.2.8",
-				"web3-eth-abi": "1.2.8",
-				"web3-eth-contract": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-helpers": "1.3.0",
+				"web3-core-promievent": "1.3.0",
+				"web3-eth-abi": "1.3.0",
+				"web3-eth-contract": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-eth-iban": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.8.tgz",
-			"integrity": "sha512-xgPUOuDOQJYloUS334/wot6jvp6K8JBz8UvQ1tAxU9LO2v2DW+IDTJ5gQ6TdutTmzdDi97KdwhwnQwhQh5Z1PA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.0.tgz",
+			"integrity": "sha512-v9mZWhR4fPF17/KhHLiWir4YHWLe09O3B/NTdhWqw3fdAMJNztzMHGzgHxA/4fU+rhrs/FhDzc4yt32zMEXBZw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"web3-utils": "1.2.8"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-					"dev": true
-				}
+				"bn.js": "^4.11.9",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-eth-personal": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.8.tgz",
-			"integrity": "sha512-sWhxF1cpF9pB1wMISrOSy/i8IB1NWtvoXT9dfkWtvByGf3JfC2DlnllLaA1f9ohyvxnR+QTgPKgOQDknmqDstw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.0.tgz",
+			"integrity": "sha512-2czUhElsJdLpuNfun9GeLiClo5O6Xw+bLSjl3f4bNG5X2V4wcIjX2ygep/nfstLLtkz8jSkgl/bV7esANJyeRA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "^12.6.1",
-				"web3-core": "1.2.8",
-				"web3-core-helpers": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-net": "1.2.8",
-				"web3-utils": "1.2.8"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-					"integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
-					"dev": true
-				}
+				"@types/node": "^12.12.6",
+				"web3-core": "1.3.0",
+				"web3-core-helpers": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-net": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-net": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.8.tgz",
-			"integrity": "sha512-Nsq6qgncvvThOjC+sQ+NfDH8L7jclQCFzLFYa9wsd5J6HJ6f5gJl/mv6rsZQX9iDEYDPKkDfyqHktynOBgKWMQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.0.tgz",
+			"integrity": "sha512-Xz02KylOyrB2YZzCkysEDrY7RbKxb7LADzx3Zlovfvuby7HBwtXVexXKtoGqksa+ns1lvjQLLQGb+OeLi7Sr7w==",
 			"dev": true,
 			"requires": {
-				"web3-core": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-utils": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-utils": "1.3.0"
 			}
 		},
 		"web3-providers-http": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.8.tgz",
-			"integrity": "sha512-Esj4SpgabmBDOR4QD3qYapzwFYWHigcdgdjvt/VWT5/7TD10o52hr+Nsvp3/XV5AFrcCMdY+lzKFLVH24u0sww==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.0.tgz",
+			"integrity": "sha512-cMKhUI6PqlY/EC+ZDacAxajySBu8AzW8jOjt1Pe/mbRQgS0rcZyvLePGTTuoyaA8C21F8UW+EE5jj7YsNgOuqA==",
 			"dev": true,
 			"requires": {
-				"web3-core-helpers": "1.2.8",
+				"web3-core-helpers": "1.3.0",
 				"xhr2-cookies": "1.1.0"
 			}
 		},
 		"web3-providers-ipc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.8.tgz",
-			"integrity": "sha512-ts3/UXCTRADPASdJ27vBVmcfM+lfG9QVBxGedY6+oNIo5EPxBUtsz94R32sfvFd6ofPsz6gOhK/M/ZKiJoi1sg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.0.tgz",
+			"integrity": "sha512-0CrLuRofR+1J38nEj4WsId/oolwQEM6Yl1sOt41S/6bNI7htdkwgVhSloFIMJMDFHtRw229QIJ6wIaKQz0X1Og==",
 			"dev": true,
 			"requires": {
-				"oboe": "2.1.4",
+				"oboe": "2.1.5",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.8"
+				"web3-core-helpers": "1.3.0"
 			}
 		},
 		"web3-providers-ws": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.8.tgz",
-			"integrity": "sha512-Gcm0n82wd/XVeGFGTx+v56UqyrV9EyB2r1QFaBx4mS+VHbW2MCOdiRbNDfoZQslflnCWl8oHsivJ8Tya9kqlTQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.0.tgz",
+			"integrity": "sha512-Im5MthhJnJst8nSoq0TgbyOdaiFQFa5r6sHPOVllhgIgViDqzbnlAFW9sNzQ0Q8VXPNfPIQKi9cOrHlSRNPjRw==",
 			"dev": true,
 			"requires": {
-				"@web3-js/websocket": "^1.0.29",
-				"eventemitter3": "^4.0.0",
+				"eventemitter3": "4.0.4",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.8"
-			},
-			"dependencies": {
-				"eventemitter3": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-					"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-					"dev": true
-				}
+				"web3-core-helpers": "1.3.0",
+				"websocket": "^1.0.32"
 			}
 		},
 		"web3-shh": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.8.tgz",
-			"integrity": "sha512-e29qKSfuZWDmxCG/uB48Nth6DCFFr2h2U+uI/fHEuhEjAEkBHopPNLc3ixrCTc6pqMocfJRPHJq/yET9PYN3oQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.0.tgz",
+			"integrity": "sha512-IZTojA4VCwVq+7eEIHuL1tJXtU+LJDhO8Y2QmuwetEWW1iBgWCGPHZasipWP+7kDpSm/5lo5GRxL72FF/Os/tA==",
 			"dev": true,
 			"requires": {
-				"web3-core": "1.2.8",
-				"web3-core-method": "1.2.8",
-				"web3-core-subscriptions": "1.2.8",
-				"web3-net": "1.2.8"
+				"web3-core": "1.3.0",
+				"web3-core-method": "1.3.0",
+				"web3-core-subscriptions": "1.3.0",
+				"web3-net": "1.3.0"
 			}
 		},
 		"web3-utils": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
-			"integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+			"integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"eth-lib": "0.2.7",
+				"bn.js": "^4.11.9",
+				"eth-lib": "0.2.8",
 				"ethereum-bloom-filters": "^1.0.6",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
@@ -2876,16 +2901,10 @@
 				"utf8": "3.0.0"
 			},
 			"dependencies": {
-				"bn.js": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-					"dev": true
-				},
 				"eth-lib": {
-					"version": "0.2.7",
-					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-					"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+					"version": "0.2.8",
+					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+					"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
 					"dev": true,
 					"requires": {
 						"bn.js": "^4.11.6",
@@ -2893,6 +2912,20 @@
 						"xhr-request-promise": "^0.1.2"
 					}
 				}
+			}
+		},
+		"websocket": {
+			"version": "1.0.32",
+			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+			"integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+			"dev": true,
+			"requires": {
+				"bufferutil": "^4.0.1",
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"typedarray-to-buffer": "^3.1.5",
+				"utf-8-validate": "^5.0.2",
+				"yaeti": "^0.0.6"
 			}
 		},
 		"wrappy": {


### PR DESCRIPTION
This PR adds support for HD accounts to Buidler EVM, and changes the default accounts to ones derived from a mnemonic instead.