### PR TITLE
Let BuidlerArguments.network be undefined

### DIFF
--- a/packages/buidler-core/src/internal/cli/cli.ts
+++ b/packages/buidler-core/src/internal/cli/cli.ts
@@ -143,12 +143,6 @@ async function main() {
       );
     }
 
-    // TODO: This is here for backwards compatibility
-    // There are very few projects using this.
-    if (buidlerArguments.network === undefined) {
-      buidlerArguments.network = config.defaultNetwork;
-    }
-
     const env = new Environment(
       config,
       buidlerArguments,

--- a/packages/buidler-core/src/internal/lib/buidler-lib.ts
+++ b/packages/buidler-core/src/internal/lib/buidler-lib.ts
@@ -36,12 +36,6 @@ if (BuidlerContext.isCreated()) {
 
   const config = loadConfigAndTasks(buidlerArguments);
 
-  // TODO: This is here for backwards compatibility.
-  // There are very few projects using this.
-  if (buidlerArguments.network === undefined) {
-    buidlerArguments.network = config.defaultNetwork;
-  }
-
   env = new Environment(
     config,
     buidlerArguments,

--- a/packages/buidler-core/src/register.ts
+++ b/packages/buidler-core/src/register.ts
@@ -34,12 +34,6 @@ if (!BuidlerContext.isCreated()) {
 
   const config = loadConfigAndTasks(buidlerArguments);
 
-  // TODO: This is here for backwards compatibility.
-  // There are very few projects using this.
-  if (buidlerArguments.network === undefined) {
-    buidlerArguments.network = config.defaultNetwork;
-  }
-
   const env = new Environment(
     config,
     buidlerArguments,


### PR DESCRIPTION
This introduces a tiny breaking change. Now `bre.buidlerArguments.network` can be `undefined` at runtime.

This was accepted by it's type, but was always set during runtime for backwards compatibility with versions that didn't have a `defaultNetwork` setting.