### PR TITLE
Drop restrictions to buidler_impersonate

### DIFF
--- a/packages/buidler-core/src/internal/hardhat-network/provider/errors.ts
+++ b/packages/buidler-core/src/internal/hardhat-network/provider/errors.ts
@@ -107,11 +107,7 @@ export class TransactionExecutionError extends HardhatNetworkProviderError {
 export class MethodNotSupportedError extends HardhatNetworkProviderError {
   public static readonly CODE = -32004;
 
-  constructor(method: string, onlyForked = false) {
-    const message = onlyForked
-      ? `Method ${method} is only supported in forked provider`
-      : `Method ${method} is not supported`;
-
-    super(message, MethodNotSupportedError.CODE);
+  constructor(method: string) {
+    super(`Method ${method} is not supported`, MethodNotSupportedError.CODE);
   }
 }

--- a/packages/buidler-core/src/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/buidler-core/src/internal/hardhat-network/provider/modules/hardhat.ts
@@ -4,7 +4,7 @@ import {
   CompilerInput,
   CompilerOutput,
 } from "../../stack-traces/compiler-types";
-import { MethodNotFoundError, MethodNotSupportedError } from "../errors";
+import { MethodNotFoundError } from "../errors";
 import {
   rpcAddress,
   rpcCompilerInput,
@@ -32,22 +32,20 @@ export class HardhatModule {
         return this._getStackTraceFailuresCountAction(
           ...this._getStackTraceFailuresCountParams(params)
         );
+
       case "hardhat_addCompilationResult":
         return this._addCompilationResultAction(
           ...this._addCompilationResultParams(params)
         );
+
       case "hardhat_impersonate":
-        if (!this._node.isForked) {
-          throw new MethodNotSupportedError(method, true);
-        }
         return this._impersonateAction(...this._impersonateParams(params));
+
       case "hardhat_stopImpersonating":
-        if (!this._node.isForked) {
-          throw new MethodNotSupportedError(method, true);
-        }
         return this._stopImpersonatingAction(
           ...this._stopImpersonatingParams(params)
         );
+
       case "hardhat_reset":
         return this._resetAction(...this._resetParams(params));
     }

--- a/packages/buidler-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/buidler-core/src/internal/hardhat-network/provider/node.ts
@@ -226,10 +226,6 @@ export class HardhatNode extends EventEmitter {
     }
   }
 
-  get isForked(): boolean {
-    return this._blockchain instanceof ForkBlockchain;
-  }
-
   public async getSignedTransaction(
     txParams: TransactionParams
   ): Promise<Transaction> {

--- a/packages/buidler-core/test/internal/hardhat-network/provider/fork/ForkStateManager.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/provider/fork/ForkStateManager.ts
@@ -34,12 +34,11 @@ describe("ForkStateManager", () => {
       this.skip();
       return;
     }
-
-    client = JsonRpcClient.forUrl(INFURA_URL);
-    forkBlockNumber = await client.getLatestBlockNumber();
   });
 
   beforeEach(async () => {
+    client = JsonRpcClient.forUrl(INFURA_URL!);
+    forkBlockNumber = await client.getLatestBlockNumber();
     fsm = new ForkStateManager(client, forkBlockNumber);
   });
 

--- a/packages/buidler-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -1,12 +1,8 @@
 import { assert } from "chai";
 import { bufferToHex } from "ethereumjs-util";
 
-import { MethodNotSupportedError } from "../../../../../src/internal/hardhat-network/provider/errors";
 import { INFURA_URL } from "../../../../setup";
-import {
-  assertHardhatNetworkProviderError,
-  assertInvalidArgumentsError,
-} from "../../helpers/assertions";
+import { assertInvalidArgumentsError } from "../../helpers/assertions";
 import { EMPTY_ACCOUNT_ADDRESS } from "../../helpers/constants";
 import { quantityToNumber } from "../../helpers/conversions";
 import { setCWD } from "../../helpers/cwd";
@@ -18,12 +14,7 @@ describe("Hardhat module", function () {
       setCWD();
       useProvider();
 
-      describe(
-        "hardhat_impersonate",
-        isFork ? testHardhatImpersonateFork : testHardhatImpersonate
-      );
-
-      function testHardhatImpersonateFork() {
+      describe("hardhat_impersonate", function () {
         it("validates input parameter", async function () {
           await assertInvalidArgumentsError(
             this.provider,
@@ -44,26 +35,9 @@ describe("Hardhat module", function () {
           ]);
           assert.isTrue(result);
         });
-      }
+      });
 
-      function testHardhatImpersonate() {
-        it("is not supported", async function () {
-          await assertHardhatNetworkProviderError(
-            this.provider,
-            "hardhat_impersonate",
-            [],
-            `Method hardhat_impersonate is only supported in forked provider`,
-            MethodNotSupportedError.CODE
-          );
-        });
-      }
-
-      describe(
-        "hardhat_stopImpersonating",
-        isFork ? testHardhatStopImpersonatingFork : testHardhatStopImpersonating
-      );
-
-      function testHardhatStopImpersonatingFork() {
+      describe("hardhat_stopImpersonating", function () {
         it("validates input parameter", async function () {
           await assertInvalidArgumentsError(
             this.provider,
@@ -94,19 +68,7 @@ describe("Hardhat module", function () {
           ]);
           assert.isFalse(result);
         });
-      }
-
-      function testHardhatStopImpersonating() {
-        it("is not supported", async function () {
-          await assertHardhatNetworkProviderError(
-            this.provider,
-            "hardhat_stopImpersonating",
-            [],
-            `Method hardhat_stopImpersonating is only supported in forked provider`,
-            MethodNotSupportedError.CODE
-          );
-        });
-      }
+      });
 
       describe("hardhat_reset", function () {
         before(function () {


### PR DESCRIPTION
This PR restricts the restriction of `buidler_impersonate` that prevented it from working in non-forked bevm instances.