### PR TITLE
HttpProvider: Respect HTTP 429's Retry-After header

### DIFF
--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -130,8 +130,11 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
         }
 
         const url = new URL(this._url);
-        throw new Error(
-          `Too Many Requests error received from ${url.hostname}`
+
+        // tslint:disable-next-line only-buidler-error
+        throw new ProviderError(
+          `Too Many Requests error received from ${url.hostname}`,
+          -32005 // Limit exceeded according to EIP1474
         );
       }
 

--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -21,6 +21,8 @@ function isErrorResponse(response: any): response is FailedJsonRpcResponse {
 const MAX_RETRIES = 3;
 const MAX_RETRY_AWAIT_SECONDS = 2;
 
+const TOO_MANY_REQUEST_STATUS = 429;
+
 export class HttpProvider extends EventEmitter implements EIP1193Provider {
   private _nextRequestId = 1;
 
@@ -181,7 +183,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   }
 
   private _isRateLimitResponse(response: Response) {
-    return response.status === 409;
+    return response.status === TOO_MANY_REQUEST_STATUS;
   }
 
   private _getRetryAfterSeconds(response: Response): number | undefined {

--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -131,7 +131,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
 
         const url = new URL(this._url);
 
-        // tslint:disable-next-line only-buidler-error
+        // tslint:disable-next-line only-hardhat-error
         throw new ProviderError(
           `Too Many Requests error received from ${url.hostname}`,
           -32005 // Limit exceeded according to EIP1474

--- a/packages/buidler-core/src/internal/core/providers/http.ts
+++ b/packages/buidler-core/src/internal/core/providers/http.ts
@@ -128,6 +128,11 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
         if (seconds !== undefined && this._shouldRetry(retryNumber, seconds)) {
           return await this._retry(request, seconds, retryNumber);
         }
+
+        const url = new URL(this._url);
+        throw new Error(
+          `Too Many Requests error received from ${url.hostname}`
+        );
       }
 
       return parseJsonResponse(await response.text());

--- a/packages/buidler-core/test/internal/core/providers/http.ts
+++ b/packages/buidler-core/test/internal/core/providers/http.ts
@@ -1,4 +1,3 @@
-import { isHexPrefixed } from "../../../../src/internal/buidler-evm/provider/utils/isHexPrefixed";
 import { HttpProvider } from "../../../../src/internal/core/providers/http";
 import { ALCHEMY_URL } from "../../../setup";
 

--- a/packages/buidler-core/test/internal/core/providers/http.ts
+++ b/packages/buidler-core/test/internal/core/providers/http.ts
@@ -1,0 +1,29 @@
+import { isHexPrefixed } from "../../../../src/internal/buidler-evm/provider/utils/isHexPrefixed";
+import { HttpProvider } from "../../../../src/internal/core/providers/http";
+import { ALCHEMY_URL } from "../../../setup";
+
+describe("HttpProvider", function () {
+  describe("429 Too many requests - retries", function () {
+    it("Retries are correctly handled for Alchemy", async function () {
+      if (ALCHEMY_URL === undefined) {
+        this.skip();
+        return;
+      }
+
+      const provider = new HttpProvider(ALCHEMY_URL, "Alchemy");
+
+      // We just make a bunch of requests that would otherwise fail
+      const requests = [];
+      for (let i = 0; i < 20; i++) {
+        requests.push(
+          provider.request({
+            method: "eth_getTransactionCount",
+            params: ["0x6b175474e89094c44da98b954eedeac495271d0f", "0x12"],
+          })
+        );
+      }
+
+      await Promise.all(requests);
+    });
+  });
+});

--- a/packages/buidler-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/helpers/providers.ts
@@ -61,6 +61,16 @@ export const FORKED_PROVIDERS: Array<{
 if (ALCHEMY_URL !== undefined) {
   const url = ALCHEMY_URL;
 
+  PROVIDERS.push({
+    name: "Alchemy Forked",
+    isFork: true,
+    networkId: REMOTE_NETWORK_ID,
+    chainId: REMOTE_CHAIN_ID,
+    useProvider: () => {
+      useProvider(false, { jsonRpcUrl: url });
+    },
+  });
+
   FORKED_PROVIDERS.push({
     rpcProvider: "Alchemy",
     jsonRpcUrl: url,
@@ -72,16 +82,6 @@ if (ALCHEMY_URL !== undefined) {
 
 if (INFURA_URL !== undefined) {
   const url = INFURA_URL;
-
-  PROVIDERS.push({
-    name: "Forked",
-    isFork: true,
-    networkId: REMOTE_NETWORK_ID,
-    chainId: REMOTE_CHAIN_ID,
-    useProvider: () => {
-      useProvider(false, { jsonRpcUrl: url });
-    },
-  });
 
   FORKED_PROVIDERS.push({
     rpcProvider: "Infura",

--- a/packages/buidler-core/test/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/jsonrpc/client.ts
@@ -27,14 +27,6 @@ describe("JsonRpcClient", () => {
     describe(`Using ${rpcProvider}`, () => {
       let client: JsonRpcClient;
 
-      before(function () {
-        if (process.env.CI === "true" && rpcProvider === "Alchemy") {
-          // We skip this Alchemy tests in the CI because it normally hits a
-          // rate limit, and we don't handle those yet
-          this.skip();
-        }
-      });
-
       beforeEach(() => {
         client = JsonRpcClient.forUrl(jsonRpcUrl);
       });

--- a/packages/buidler-core/test/internal/hardhat-network/provider/forked-provider.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/provider/forked-provider.ts
@@ -47,14 +47,6 @@ describe("Forked provider", () => {
       setCWD();
       useProvider();
 
-      before(function () {
-        if (process.env.CI === "true" && rpcProvider === "Alchemy") {
-          // We skip this Alchemy tests in the CI because it normally hits a
-          // rate limit, and we don't handle those yet
-          this.skip();
-        }
-      });
-
       const getForkBlockNumber = async () =>
         retrieveForkBlockNumber(this.ctx.hardhatNetworkProvider);
 

--- a/packages/buidler-core/test/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/buidler-core/test/internal/hardhat-network/provider/modules/eth.ts
@@ -1111,9 +1111,14 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getFilterLogs", async function () {
+      describe.only("eth_getFilterLogs", async function () {
+        let firstBlock: number;
+
+        beforeEach(async function () {
+          firstBlock = await getFirstBlock();
+        });
+
         it("Supports get filter logs", async function () {
-          const firstBlock = await getFirstBlock();
           const exampleContract = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`
@@ -1305,7 +1310,7 @@ describe("Eth module", function () {
 
           const filterId = await this.provider.send("eth_newFilter", [
             {
-              fromBlock: "0x0",
+              fromBlock: numberToRpcQuantity(firstBlock),
               address: exampleContract,
               topics: [
                 [
@@ -1334,7 +1339,6 @@ describe("Eth module", function () {
         });
 
         it("Supports get filter logs with toBlock", async function () {
-          const firstBlock = await getFirstBlock();
           const exampleContract = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`
@@ -1383,9 +1387,14 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getLogs", async function () {
+      describe.only("eth_getLogs", async function () {
+        let firstBlock: number;
+
+        beforeEach(async function () {
+          firstBlock = await getFirstBlock();
+        });
+
         it("Supports get logs", async function () {
-          const firstBlock = await getFirstBlock();
           const exampleContract = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`
@@ -1561,7 +1570,7 @@ describe("Eth module", function () {
           assert.lengthOf(
             await this.provider.send("eth_getLogs", [
               {
-                fromBlock: "0x2",
+                fromBlock: numberToRpcQuantity(firstBlock + 2),
                 topics: [
                   [
                     "0x3359f789ea83a10b6e9605d460de1088ff290dd7b3c9a155c896d45cf495ed4d",
@@ -1578,7 +1587,6 @@ describe("Eth module", function () {
         });
 
         it("Supports get logs with fromBlock", async function () {
-          const firstBlock = await getFirstBlock();
           const exampleContract = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`
@@ -1614,7 +1622,6 @@ describe("Eth module", function () {
         });
 
         it("Supports get logs with toBlock", async function () {
-          const firstBlock = await getFirstBlock();
           const exampleContract = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`
@@ -1654,7 +1661,7 @@ describe("Eth module", function () {
           const logs = await this.provider.send("eth_getLogs", [
             {
               address: "0x0000000000000000000000000000000000000000",
-              fromBlock: "0x1111",
+              fromBlock: numberToRpcQuantity(firstBlock + 10000000),
             },
           ]);
           assert.lengthOf(logs, 0);
@@ -1662,7 +1669,8 @@ describe("Eth module", function () {
           const logs2 = await this.provider.send("eth_getLogs", [
             {
               address: "0x0000000000000000000000000000000000000000",
-              toBlock: "0x1111",
+              fromBlock: numberToRpcQuantity(firstBlock),
+              toBlock: numberToRpcQuantity(firstBlock + 1000000),
             },
           ]);
           assert.lengthOf(logs2, 0);


### PR DESCRIPTION
This PR changes the HttpProvider so it makes retries when a 429 is received.