### PR TITLE
Change docker repo from ethereum/vyper to vyperlang/vyper

### DIFF
--- a/packages/buidler-vyper/src/compilation.ts
+++ b/packages/buidler-vyper/src/compilation.ts
@@ -18,7 +18,7 @@ import path from "path";
 
 import { VyperConfig } from "./types";
 
-const VYPER_DOCKER_REPOSITORY = "ethereum/vyper";
+const VYPER_DOCKER_REPOSITORY = "vyperlang/vyper";
 const LAST_VYPER_VERSION_USED_FILENAME = "last-vyper-version-used.txt";
 const VYPER_DOCKER_IMAGES_LAST_UPDATE_CHECK_FILE = "vyper-docker-updates.json";
 const CHECK_UPDATES_INTERVAL = 3600000;


### PR DESCRIPTION
ethereum/vyper is out of date, new docker repo is vyperlang/vyper

fixes #814