### PR TITLE
Call compile with quiet from other tasks

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -489,7 +489,7 @@ export default function () {
   internalTask(TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS)
     .addParam("output", undefined, undefined, types.any)
     .addParam("quiet", undefined, undefined, types.boolean)
-    .setAction(async ({ output }: { output: any; quiet: boolean }) => {
+    .setAction(async ({ output, quiet }: { output: any; quiet: boolean }) => {
       if (output?.errors === undefined) {
         return;
       }
@@ -498,7 +498,9 @@ export default function () {
         if (error.severity === "error") {
           console.error(chalk.red(error.formattedMessage));
         } else {
-          console.warn(chalk.yellow(error.formattedMessage));
+          if (!quiet) {
+            console.warn(chalk.yellow(error.formattedMessage));
+          }
         }
       }
 

--- a/packages/hardhat-core/src/builtin-tasks/console.ts
+++ b/packages/hardhat-core/src/builtin-tasks/console.ts
@@ -6,7 +6,7 @@ import * as semver from "semver";
 import { task } from "../internal/core/config/config-env";
 import { runScriptWithHardhat } from "../internal/util/scripts-runner";
 
-import { TASK_CONSOLE } from "./task-names";
+import { TASK_COMPILE, TASK_CONSOLE } from "./task-names";
 
 export default function () {
   const log = debug("hardhat:core:tasks:console");
@@ -19,7 +19,7 @@ export default function () {
         { config, run, hardhatArguments }
       ) => {
         if (!noCompile) {
-          await run("compile");
+          await run(TASK_COMPILE, { quiet: true });
         }
 
         await fsExtra.ensureDir(config.paths.cache);

--- a/packages/hardhat-core/src/builtin-tasks/run.ts
+++ b/packages/hardhat-core/src/builtin-tasks/run.ts
@@ -29,7 +29,7 @@ export default function () {
         }
 
         if (!noCompile) {
-          await run(TASK_COMPILE);
+          await run(TASK_COMPILE, { quiet: true });
         }
 
         log(

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -77,7 +77,7 @@ export default function () {
         { run, network }
       ) => {
         if (!noCompile) {
-          await run(TASK_COMPILE);
+          await run(TASK_COMPILE, { quiet: true });
         }
 
         const files = await run(TASK_TEST_GET_TEST_FILES, { testFiles });


### PR DESCRIPTION
I also made it so that compiler warnings are not shown with `--quiet` (errors are still shown). I'm not 100% sure about that though.