### PR TITLE
Enable cache in the windows CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,14 @@ jobs:
         with:
           node-version: 10
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilers
+          key: ${{ runner.os }}-node-10-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: yarn --frozen-lockfile
       - name: Run tests

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -18,8 +18,8 @@ function isErrorResponse(response: any): response is FailedJsonRpcResponse {
   return typeof response.error !== "undefined";
 }
 
-const MAX_RETRIES = 3;
-const MAX_RETRY_AWAIT_SECONDS = 2;
+const MAX_RETRIES = 6;
+const MAX_RETRY_AWAIT_SECONDS = 5;
 
 const TOO_MANY_REQUEST_STATUS = 429;
 


### PR DESCRIPTION
We disabled it some time ago because it was super slow, but apparently they fixed that. Let's see...