### PR TITLE
Show missing solidity warning only for compile task

### DIFF
--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -4,7 +4,7 @@ import debug from "debug";
 import semver from "semver";
 import "source-map-support/register";
 
-import { TASK_HELP } from "../../builtin-tasks/task-names";
+import { TASK_COMPILE, TASK_HELP } from "../../builtin-tasks/task-names";
 import { TaskArguments } from "../../types";
 import { HARDHAT_NAME } from "../constants";
 import { HardhatContext } from "../context";
@@ -98,8 +98,12 @@ async function main() {
 
     let taskName = parsedTaskName ?? "help";
 
+    const showWarningIfNoSolidityConfig = taskName === TASK_COMPILE;
+
     const ctx = HardhatContext.createHardhatContext();
-    const config = loadConfigAndTasks(hardhatArguments, taskName);
+    const config = loadConfigAndTasks(hardhatArguments, {
+      showWarningIfNoSolidityConfig,
+    });
 
     const analytics = await Analytics.getInstance(
       config.paths.root,

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -96,8 +96,10 @@ async function main() {
 
     loadTsNodeIfPresent();
 
+    let taskName = parsedTaskName ?? "help";
+
     const ctx = HardhatContext.createHardhatContext();
-    const config = loadConfigAndTasks(hardhatArguments);
+    const config = loadConfigAndTasks(hardhatArguments, taskName);
 
     const analytics = await Analytics.getInstance(
       config.paths.root,
@@ -109,8 +111,6 @@ async function main() {
 
     const envExtenders = ctx.extendersManager.getExtenders();
     const taskDefinitions = ctx.tasksDSL.getTaskDefinitions();
-
-    let taskName = parsedTaskName !== undefined ? parsedTaskName : "help";
 
     // tslint:disable-next-line: prefer-const
     let [abortAnalytics, hitPromise] = await analytics.sendTaskHit(taskName);

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import path from "path";
 
+import { TASK_COMPILE } from "../../../builtin-tasks/task-names";
 import { HardhatArguments, ResolvedHardhatConfig } from "../../../types";
 import { HardhatContext } from "../../context";
 import { loadPluginFile } from "../plugins";
@@ -16,7 +17,8 @@ function importCsjOrEsModule(filePath: string): any {
 }
 
 export function loadConfigAndTasks(
-  hardhatArguments?: Partial<HardhatArguments>
+  hardhatArguments?: Partial<HardhatArguments>,
+  taskName?: string
 ): ResolvedHardhatConfig {
   let configPath =
     hardhatArguments !== undefined ? hardhatArguments.config : undefined;
@@ -49,7 +51,7 @@ export function loadConfigAndTasks(
   const userConfig = importCsjOrEsModule(configPath);
   validateConfig(userConfig);
 
-  if (userConfig.solidity === undefined) {
+  if (taskName === TASK_COMPILE && userConfig.solidity === undefined) {
     console.warn(
       chalk.yellow(
         `Solidity compiler is not configured. Version ${DEFAULT_SOLC_VERSION} will be used by default. Add a 'solidity' entry to your configuration to supress this warning.

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import path from "path";
 
-import { TASK_COMPILE } from "../../../builtin-tasks/task-names";
 import { HardhatArguments, ResolvedHardhatConfig } from "../../../types";
 import { HardhatContext } from "../../context";
 import { loadPluginFile } from "../plugins";
@@ -18,7 +17,7 @@ function importCsjOrEsModule(filePath: string): any {
 
 export function loadConfigAndTasks(
   hardhatArguments?: Partial<HardhatArguments>,
-  taskName?: string
+  { showWarningIfNoSolidityConfig } = { showWarningIfNoSolidityConfig: true }
 ): ResolvedHardhatConfig {
   let configPath =
     hardhatArguments !== undefined ? hardhatArguments.config : undefined;
@@ -51,7 +50,7 @@ export function loadConfigAndTasks(
   const userConfig = importCsjOrEsModule(configPath);
   validateConfig(userConfig);
 
-  if (taskName === TASK_COMPILE && userConfig.solidity === undefined) {
+  if (userConfig.solidity === undefined && showWarningIfNoSolidityConfig) {
     console.warn(
       chalk.yellow(
         `Solidity compiler is not configured. Version ${DEFAULT_SOLC_VERSION} will be used by default. Add a 'solidity' entry to your configuration to supress this warning.


### PR DESCRIPTION
I'm not sure at all about this approach, it feels like a gradient descent fix.

One alternative I can think is to change `loadConfigAndTasks` so that it returns both the user config and the resolved config, but this is a bigger change.

@alcuadrado wdyt?