### PR TITLE
Add --global flag to clean task

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/clean.ts
+++ b/packages/hardhat-core/src/builtin-tasks/clean.ts
@@ -1,16 +1,23 @@
 import fsExtra from "fs-extra";
 
-import { task } from "../internal/core/config/config-env";
+import { internalTask, task } from "../internal/core/config/config-env";
+import { getCacheDir } from "../internal/util/global-dir";
 
-import { TASK_CLEAN } from "./task-names";
+import { TASK_CLEAN, TASK_CLEAN_GLOBAL } from "./task-names";
 
 export default function () {
-  task(
-    TASK_CLEAN,
-    "Clears the cache and deletes all artifacts",
-    async (_, { config }) => {
+  internalTask(TASK_CLEAN_GLOBAL, async () => {
+    const globalCacheDir = await getCacheDir();
+    await fsExtra.emptyDir(globalCacheDir);
+  });
+
+  task(TASK_CLEAN, "Clears the cache and deletes all artifacts")
+    .addFlag("global", "Clear the global cache")
+    .setAction(async ({ global }: { global: boolean }, { config, run }) => {
+      if (global) {
+        return run(TASK_CLEAN_GLOBAL);
+      }
       await fsExtra.emptyDir(config.paths.cache);
       await fsExtra.remove(config.paths.artifacts);
-    }
-  );
+    });
 }

--- a/packages/hardhat-core/src/builtin-tasks/task-names.ts
+++ b/packages/hardhat-core/src/builtin-tasks/task-names.ts
@@ -1,6 +1,7 @@
 export const TASK_CHECK = "check";
 
 export const TASK_CLEAN = "clean";
+export const TASK_CLEAN_GLOBAL = "clean:global";
 
 export const TASK_COMPILE = "compile";
 export const TASK_COMPILE_GET_COMPILATION_TASKS =

--- a/packages/hardhat-core/src/internal/util/global-dir.ts
+++ b/packages/hardhat-core/src/internal/util/global-dir.ts
@@ -22,7 +22,7 @@ async function getDataDir(): Promise<string> {
   return data;
 }
 
-async function getCacheDir(): Promise<string> {
+export async function getCacheDir(): Promise<string> {
   const { cache } = await generatePaths();
   await fs.ensureDir(cache);
   return cache;


### PR DESCRIPTION
@alcuadrado I'm not sure if this should *only* remove the global cache, or do it *in addition* to the normal `clean` task functionality. Right now it does the former.