### PR TITLE
Upgrade the default version of solc and update the sample project

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -114,7 +114,7 @@
     "resolve": "^1.17.0",
     "semver": "^6.3.0",
     "slash": "^3.0.0",
-    "solc": "0.6.8",
+    "solc": "0.7.3",
     "source-map-support": "^0.5.13",
     "true-case-path": "^2.2.1",
     "ts-essentials": "^2.0.7",

--- a/packages/hardhat-core/sample-project/hardhat.config.js
+++ b/packages/hardhat-core/sample-project/hardhat.config.js
@@ -1,4 +1,4 @@
-usePlugin("@nomiclabs/hardhat-waffle");
+require("@nomiclabs/hardhat-waffle");
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://usehardhat.com/guides/create-task.html
@@ -10,13 +10,13 @@ task("accounts", "Prints the list of accounts", async () => {
   }
 });
 
-// You have to export an object to set up your config
-// This object can have the following optional entries:
-// defaultNetwork, networks, solc, and paths.
+// You need to export an object to set up your config
 // Go to https://usehardhat.com/config/ to learn more
+
+/**
+ * @type import('hardhat/config').HardhatConfig
+ */
 module.exports = {
-  // This is a sample solidity configuration that specifies which version of solc to use
-  solidity: {
-    version: "0.6.8",
-  },
+  solidity: "0.7.3",
 };
+

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 
 import { HARDHAT_NAME } from "../constants";
+import { DEFAULT_SOLC_VERSION } from "../core/config/default-config";
 import { ExecutionMode, getExecutionMode } from "../core/execution-mode";
 import { getRecommendedGitIgnore } from "../core/project-structure";
 import { getPackageJson, getPackageRoot } from "../util/packageInfo";
@@ -129,7 +130,13 @@ async function printRecommendedDepsInstallationInstructions() {
 async function writeEmptyHardhatConfig() {
   return fsExtra.writeFile(
     "hardhat.config.js",
-    "module.exports = {};\n",
+    `/**
+ * @type import('hardhat/config').HardhatConfig
+ */
+module.exports = {
+  solidity: "${DEFAULT_SOLC_VERSION}",
+};
+`,
     "utf-8"
   );
 }

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -101,24 +101,6 @@ ${content}`;
   await fsExtra.writeFile(gitIgnorePath, content);
 }
 
-async function addGitAttributes(projectRoot: string) {
-  const gitAttributesPath = path.join(projectRoot, ".gitattributes");
-  let content = "*.sol linguist-language=Solidity";
-
-  if (await fsExtra.pathExists(gitAttributesPath)) {
-    const existingContent = await fsExtra.readFile(gitAttributesPath, "utf-8");
-
-    if (existingContent.includes(content)) {
-      return;
-    }
-
-    content = `${existingContent}
-${content}`;
-  }
-
-  await fsExtra.writeFile(gitAttributesPath, content);
-}
-
 function printSuggestedCommands() {
   const npx =
     getExecutionMode() === ExecutionMode.EXECUTION_MODE_GLOBAL_INSTALLATION
@@ -226,10 +208,6 @@ export async function createProject() {
         "shouldAddGitIgnore",
         "Do you want to add a .gitignore?"
       ),
-      createConfirmationPrompt(
-        "shouldAddGitAttributes",
-        "Do you want to add a .gitattributes to enable Soldity highlighting on GitHub?"
-      ),
     ]);
   } catch (e) {
     if (e === "") {
@@ -240,16 +218,12 @@ export async function createProject() {
     throw e;
   }
 
-  const { projectRoot, shouldAddGitIgnore, shouldAddGitAttributes } = responses;
+  const { projectRoot, shouldAddGitIgnore } = responses;
 
   await copySampleProject(projectRoot);
 
   if (shouldAddGitIgnore) {
     await addGitIgnore(projectRoot);
-  }
-
-  if (shouldAddGitAttributes) {
-    await addGitAttributes(projectRoot);
   }
 
   let shouldShowInstallationInstructions = true;

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -1,7 +1,7 @@
 import { HardhatConfig, HardhatNetworkConfig } from "../../../types";
 import { HARDHAT_NETWORK_NAME } from "../../constants";
 
-export const DEFAULT_SOLC_VERSION = "0.5.15";
+export const DEFAULT_SOLC_VERSION = "0.7.3";
 export const HARDHAT_NETWORK_DEFAULT_GAS_PRICE = 8e9;
 const HARDHAT_NETWORK_MNEMONIC =
   "test test test test test test test test test test test junk";

--- a/packages/hardhat-core/test/fixture-projects/default-config-project/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/default-config-project/hardhat.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  solidity: "0.5.15",
-};
+module.exports = {};

--- a/packages/hardhat-core/test/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-resolution.ts
@@ -48,10 +48,7 @@ describe("Config resolution", () => {
         const config = loadConfigAndTasks();
 
         assert.lengthOf(config.solidity.compilers, 1);
-        assert.equal(
-          config.solidity.compilers[0].version,
-          DEFAULT_SOLC_VERSION
-        );
+        assert.equal(config.solidity.compilers[0].version, "0.5.15");
         assert.containsAllKeys(config.networks, ["localhost", "custom"]);
         assert.equal(config.defaultNetwork, "custom");
       });
@@ -59,10 +56,7 @@ describe("Config resolution", () => {
       it("should return the config merged ", () => {
         const config = loadConfigAndTasks();
         assert.lengthOf(config.solidity.compilers, 1);
-        assert.equal(
-          config.solidity.compilers[0].version,
-          DEFAULT_SOLC_VERSION
-        );
+        assert.equal(config.solidity.compilers[0].version, "0.5.15");
         assert.containsAllKeys(config.networks, ["localhost", "custom"]);
         assert.equal(
           (config.networks.localhost as HttpNetworkConfig).url,

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -27,14 +27,15 @@ describe("Compiler downloader", function () {
 
   before(function () {
     localCompilerBuild = {
-      path: "soljson-v0.6.8+commit.0bbfe453.js",
-      version: "0.6.8",
-      build: "commit.0bbfe453",
-      longVersion: "0.6.8+commit.0bbfe453",
+      path: "soljson-v0.7.3+commit.9bfce1f6.js",
+      version: "0.7.3",
+      build: "commit.9bfce1f6",
+      longVersion: "0.7.3+commit.9bfce1f6",
       keccak256:
-        "0x537cefc0579dd9631ec952cae951b3df0a50a3e557b5638107a67275f7aacc07",
+        "0xcf099e7057d6c3d5acac1f4e349798ad5a581b6cb7ffcebdf5b37b86eac4872d",
       urls: [
-        "bzzr://130bff47eed9546c6a4d019c6281896186cf2368b766b16bc49b3d489b6cdb92",
+        "bzzr://2f8ec45d2d7298ab1fa49f3568ada6c6e030c7dd7f490a1505ed9d4713d86dc8",
+        "dweb:/ipfs/QmQMH2o7Nz3DaQ31hNYyHVAgejqTyZouvA35Zzzwe2UBPt",
       ],
       platform: CompilerPlatform.WASM,
     };

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -54,8 +54,7 @@
     "chai": "^4.2.0",
     "ethers": "^5.0.8",
     "hardhat": "^0.1.0-rc.0",
-    "nock": "^10.0.6",
-    "solc": "0.6.8"
+    "nock": "^10.0.6"
   },
   "peerDependencies": {
     "hardhat": "^0.1.0-rc.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8850,20 +8850,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-solc@0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.8.tgz#accf03634554938e166ba9b9853d17ca5c728131"
-  integrity sha512-7URBAisWVjO7dwWNpEkQ5dpRSpSF4Wm0aD5EB82D5BQKh+q7jhOxhgkG4K5gax/geM0kPZUAxnaLcgl2ZXBgMQ==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "3.0.2"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
 solc@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,6 +4778,11 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
+follow-redirects@^1.12.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 for-each@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -8859,6 +8864,21 @@ solc@0.6.8:
     semver "^5.5.0"
     tmp "0.0.33"
 
+solc@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"
+  integrity sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    follow-redirects "^1.12.1"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solc@^0.4.20:
   version "0.4.26"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"
@@ -10849,7 +10869,6 @@ websocket@^1.0.32:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
This PR:

* Upgrades the default version of solc
* Rememoves the .gitattributes & github message
* Uses a fixed solc version in the sample and empty configs, to avoid the warning
* Adds `@types` to the generated config files, as that's working again with the new plugins loading strategy