### PR TITLE
Hardhat-ethers library linking.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,8 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Clean
         run: yarn clean
+      - name: Build
+        run: yarn build
       - name: lint
         run: yarn lint
       - name: Check dependency versions

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -42,7 +42,16 @@ automatically connected to the selected network.
 These helpers are added to the `ethers` object:
 
 ```typescript
-function getContractFactory(name: string, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
+interface LibraryLinks {
+  [libraryName: string]: string;
+}
+
+interface FactoryOptions {
+  signer?: ethers.Signer;
+  libraryLinks?: LibraryLinks;
+}
+
+function getContractFactory(name: string, signerOrFactoryOptions?: ethers.Signer | FactoryOptions): Promise<ethers.ContractFactory>;
 
 
 function getContractAt(nameOrAbi: string | any[], address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
@@ -78,6 +87,25 @@ module.exports = {};
 And then run `npx hardhat blockNumber` to try it.
 
 Read the documentation on the [Hardhat Runtime Environment](https://usehardhat.com/advanced/hardhat-runtime-environment.html) to learn how to access the HRE in different ways to use ethers.js from anywhere the HRE is accessible.
+
+### Library linking
+
+Some contracts need to be linked with libraries before they are deployed. You can pass these library links to the `getContractFactory` function with an object like this:
+
+```js
+const contractFactory = await this.env.ethers.getContractFactory(
+  "Example",
+  {
+    libraryLinks: {
+      ExampleLib: "0x..."
+    }
+  }
+);
+```
+
+This allows you to create a contract factory for the `Example` contract and link its `ExampleLib` library references to the address `"0x..."`.
+
+To create a contract factory, all libraries must be linked. An error will be thrown informing you of any missing library links.
 
 ## TypeScript support
 

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -42,16 +42,20 @@ automatically connected to the selected network.
 These helpers are added to the `ethers` object:
 
 ```typescript
-interface LibraryLinks {
+interface Libraries {
   [libraryName: string]: string;
 }
 
 interface FactoryOptions {
   signer?: ethers.Signer;
-  libraryLinks?: LibraryLinks;
+  libraries?: Libraries;
 }
 
-function getContractFactory(name: string, signerOrFactoryOptions?: ethers.Signer | FactoryOptions): Promise<ethers.ContractFactory>;
+function getContractFactory(name: string): Promise<ethers.ContractFactory>;
+
+function getContractFactory(name: string, signer: ethers.Signer): Promise<ethers.ContractFactory>;
+
+function getContractFactory(name: string, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;
 
 
 function getContractAt(nameOrAbi: string | any[], address: string, signer?: ethers.Signer): Promise<ethers.Contract>;
@@ -90,13 +94,13 @@ Read the documentation on the [Hardhat Runtime Environment](https://usehardhat.c
 
 ### Library linking
 
-Some contracts need to be linked with libraries before they are deployed. You can pass these library links to the `getContractFactory` function with an object like this:
+Some contracts need to be linked with libraries before they are deployed. You can pass the addresses of their libraries to the `getContractFactory` function with an object like this:
 
 ```js
 const contractFactory = await this.env.ethers.getContractFactory(
   "Example",
   {
-    libraryLinks: {
+    libraries: {
       ExampleLib: "0x..."
     }
   }
@@ -105,7 +109,7 @@ const contractFactory = await this.env.ethers.getContractFactory(
 
 This allows you to create a contract factory for the `Example` contract and link its `ExampleLib` library references to the address `"0x..."`.
 
-To create a contract factory, all libraries must be linked. An error will be thrown informing you of any missing library links.
+To create a contract factory, all libraries must be linked. An error will be thrown informing you of any missing library.
 
 ## TypeScript support
 

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -1,13 +1,12 @@
 import EthersT from "ethers";
 import { extendEnvironment } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getContractAt, getContractFactory, getSigners } from "./helpers";
 import "./type-extensions";
 
 export default function () {
-  extendEnvironment((hre: HardhatRuntimeEnvironment) => {
+  extendEnvironment((hre) => {
     hre.ethers = lazyObject(() => {
       const { EthersProviderWrapper } = require("./ethers-provider-wrapper");
 

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -7,8 +7,8 @@ import { getContractAt, getContractFactory, getSigners } from "./helpers";
 import "./type-extensions";
 
 export default function () {
-  extendEnvironment((env: HardhatRuntimeEnvironment) => {
-    env.ethers = lazyObject(() => {
+  extendEnvironment((hre: HardhatRuntimeEnvironment) => {
+    hre.ethers = lazyObject(() => {
       const { EthersProviderWrapper } = require("./ethers-provider-wrapper");
 
       const { ethers } = require("ethers") as typeof EthersT;
@@ -18,13 +18,13 @@ export default function () {
 
         // The provider wrapper should be removed once this is released
         // https://github.com/nomiclabs/hardhat/pull/608
-        provider: new EthersProviderWrapper(env.network.provider),
+        provider: new EthersProviderWrapper(hre.network.provider),
 
-        getSigners: async () => getSigners(env),
+        getSigners: async () => getSigners(hre),
         // We cast to any here as we hit a limitation of Function#bind and
         // overloads. See: https://github.com/microsoft/TypeScript/issues/28582
-        getContractFactory: getContractFactory.bind(null, env) as any,
-        getContractAt: getContractAt.bind(null, env),
+        getContractFactory: getContractFactory.bind(null, hre) as any,
+        getContractAt: getContractAt.bind(null, hre),
       };
     });
   });

--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -3,11 +3,11 @@ import "hardhat/types/runtime";
 
 import type {
   FactoryOptions as FactoryOptionsT,
-  LibraryLinks as LibraryLinksT,
+  Libraries as LibrariesT,
 } from "./helpers";
 
 declare module "hardhat/types/runtime" {
-  type LibraryLinks = LibraryLinksT;
+  type Libraries = LibrariesT;
   type FactoryOptions = FactoryOptionsT;
 
   function getContractFactory(

--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -1,10 +1,18 @@
 import * as ethers from "ethers";
 import "hardhat/types/runtime";
 
+import type {
+  FactoryOptions as FactoryOptionsT,
+  LibraryLinks as LibraryLinksT,
+} from "./helpers";
+
 declare module "hardhat/types/runtime" {
+  type LibraryLinks = LibraryLinksT;
+  type FactoryOptions = FactoryOptionsT;
+
   function getContractFactory(
     name: string,
-    signer?: ethers.Signer
+    signerOrOptions?: ethers.Signer | FactoryOptions
   ): Promise<ethers.ContractFactory>;
   function getContractFactory(
     abi: any[],

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.5.0;
 
+import { AmbiguousLibrary as AmbiguousLibrary2 } from "./AmbiguousLibrary2.sol";
+
 library AmbiguousLibrary {
     function libDo(uint256 n) external returns (uint256) {
         return n * 2;
@@ -9,6 +11,7 @@ library AmbiguousLibrary {
 contract TestAmbiguousLib {
     function printNumber(uint256 amount) public returns (uint256) {
         uint result = AmbiguousLibrary.libDo(amount);
+        result = AmbiguousLibrary2.libDo(result);
         return result;
     }
 }

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+library AmbiguousLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+}
+
+contract TestAmbiguousLib {
+    function printNumber(uint256 amount) public returns (uint256) {
+        uint result = AmbiguousLibrary.libDo(amount);
+        return result;
+    }
+}

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary2.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/AmbiguousLibrary2.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library AmbiguousLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+}

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/NonUniqueLibrary.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/NonUniqueLibrary.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+library NonUniqueLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+}

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/TestContractLib.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/TestContractLib.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+library TestLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+}
+
+contract TestContractLib {
+
+    function printNumber(uint256 amount) public returns (uint256) {
+        uint result = TestLibrary.libDo(amount);
+        return result;
+    }
+}

--- a/packages/hardhat-ethers/test/hardhat-project/contracts/TestNonUniqueLib.sol
+++ b/packages/hardhat-ethers/test/hardhat-project/contracts/TestNonUniqueLib.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+library NonUniqueLibrary {
+    function libDo(uint256 n) external returns (uint256) {
+        return n * 2;
+    }
+}
+
+contract TestNonUniqueLib {
+
+    function printNumber(uint256 amount) public returns (uint256) {
+        uint result = NonUniqueLibrary.libDo(amount);
+        return result;
+    }
+}

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -139,8 +139,10 @@ describe("Ethers plugin", function () {
               "getContractFactory should report the ambiguous link as the cause"
             );
             assert.isTrue(
-              reason.message.includes("TestContractLib.sol:TestLibrary"),
-              "getContractFactory should display the ambiguous library link"
+              reason.message.includes(
+                "TestLibrary and contracts/TestContractLib.sol:TestLibrary"
+              ),
+              "getContractFactory should display the ambiguous library links"
             );
             return;
           }
@@ -148,6 +150,22 @@ describe("Ethers plugin", function () {
           // The test shouldn't reach this point
           assert.fail(
             "getContractFactory should fail when the link for one library is ambiguous"
+          );
+        });
+
+        it("should link a library even if there's an identically named library in the project", async function () {
+          const libraryFactory = await this.env.ethers.getContractFactory(
+            "contracts/TestNonUniqueLib.sol:NonUniqueLibrary"
+          );
+          const library = await libraryFactory.deploy();
+
+          const contractFactory = await this.env.ethers.getContractFactory(
+            "TestNonUniqueLib",
+            { libraryLinks: { NonUniqueLibrary: library.address } }
+          );
+          assert.equal(
+            await contractFactory.signer.getAddress(),
+            await signers[0].getAddress()
           );
         });
 

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -79,7 +79,7 @@ describe("Ethers plugin", function () {
               "getContractFactory should fail with a hardhat plugin error"
             );
             assert.isTrue(
-              reason.message.includes("abstract contract"),
+              reason.message.includes("is abstract and can't be deployed"),
               "getContractFactory should report the abstract contract as the cause"
             );
             return;
@@ -99,7 +99,7 @@ describe("Ethers plugin", function () {
 
           const contractFactory = await this.env.ethers.getContractFactory(
             "TestContractLib",
-            { libraryLinks: { TestLibrary: library.address } }
+            { libraries: { TestLibrary: library.address } }
           );
           assert.equal(
             await contractFactory.signer.getAddress(),
@@ -121,7 +121,7 @@ describe("Ethers plugin", function () {
 
           try {
             await this.env.ethers.getContractFactory("TestContractLib", {
-              libraryLinks: {
+              libraries: {
                 TestLibrary: library.address,
                 "contracts/TestContractLib.sol:TestLibrary": library.address,
               },
@@ -161,7 +161,7 @@ describe("Ethers plugin", function () {
 
           const contractFactory = await this.env.ethers.getContractFactory(
             "TestNonUniqueLib",
-            { libraryLinks: { NonUniqueLibrary: library.address } }
+            { libraries: { NonUniqueLibrary: library.address } }
           );
           assert.equal(
             await contractFactory.signer.getAddress(),
@@ -181,7 +181,7 @@ describe("Ethers plugin", function () {
 
           try {
             await this.env.ethers.getContractFactory("TestAmbiguousLib", {
-              libraryLinks: {
+              libraries: {
                 AmbiguousLibrary: library.address,
                 "contracts/AmbiguousLibrary2.sol:AmbiguousLibrary":
                   library2.address,
@@ -247,7 +247,7 @@ describe("Ethers plugin", function () {
           const notAnAddress = "definitely not an address";
           try {
             await this.env.ethers.getContractFactory("TestContractLib", {
-              libraryLinks: { TestLibrary: notAnAddress },
+              libraries: { TestLibrary: notAnAddress },
             });
           } catch (reason) {
             assert.instanceOf(

--- a/packages/hardhat-ethers/test/mocha.env.js
+++ b/packages/hardhat-ethers/test/mocha.env.js
@@ -2,4 +2,4 @@ process.env.TS_NODE_FILES = "true";
 process.env.TS_NODE_TRANSPILE_ONLY = "true";
 
 // Args string to be passed to the Ganache CLI instance for test, splitted by "," or " " (space)
-process.env.GANACHE_CLI_ARGS = "-d";
+process.env.GANACHE_CLI_ARGS = "--deterministic";


### PR DESCRIPTION
This adds an error when creating an `ethers.contractFactory` for an abstract contract and adds an option to link libraries when creating contract factories.