### PR TITLE
Remove unused errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This document contains some tips on how to collaborate in this project.
 This repository is a monorepo handled with [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
 
 There's a folder for each subproject in `packages/`. All of them are plugins, except for `/packages/hardhat` which
-is the main project (i.e. the one that's published as [@nomiclabs/hardhat](https://npmjs.com/package/@nomiclabs/hardhat)).
+is the main project (i.e. the one that's published as [hardhat](https://npmjs.com/package/hardhat)).
 
 ## Installing
 
@@ -114,16 +114,18 @@ You can [link](https://classic.yarnpkg.com/en/docs/cli/link/) any package to tes
 `hardhat`, you can follow these steps:
 
 1. Go to `packages/hardhat` and run `yarn link`
-2. Go to some hardhat project and run `yarn link @nomiclabs/hardhat`
+2. Go to some hardhat project and run `yarn link hardhat`
 
 Now any change you make in the code will be reflected in that project.
+
+<!-- TODO-HH this doesn't link the binary though -->
 
 ### Yalc
 
 If for any reason linking doesn't work for you, you can use [`yalc`](https://github.com/whitecolor/yalc).
 
 1. Go to `packages/hardhat` and run `yalc publish`
-2. Go to some hardhat project and run `yalc add @nomiclabs/hardhat`
+2. Go to some hardhat project and run `yalc add hardhat`
 
 Unlike linking, if you make a change in the code, you'll need to repeat the process.
 

--- a/docs/advanced/building-plugins.md
+++ b/docs/advanced/building-plugins.md
@@ -23,13 +23,13 @@ Note that all config extension's have to be optional.
 
 ### Throwing errors from your plugins
 
-To show better stack traces to your users, please consider throwing `HardhatPluginError` errors, which can be found in `@nomiclabs/hardhat/plugins`.
+To show better stack traces to your users, please consider throwing `HardhatPluginError` errors, which can be found in `hardhat/plugins`.
 
 If your error originated in your user's code, like a test or script calling one of your functions, you shouldn't use `HardhatPluginError`.
 
 ### Optimizing your plugin for better startup time
 
-Keeping startup time short is vital to give a good user experience. To do so, Hardhat and its plugins delay any slow import or initialization until the very last moment. To do so, you can use `lazyObject`, and `lazyFunction` from `@nomiclabs/hardhat/plugins`.
+Keeping startup time short is vital to give a good user experience. To do so, Hardhat and its plugins delay any slow import or initialization until the very last moment. To do so, you can use `lazyObject`, and `lazyFunction` from `hardhat/plugins`.
 
 An example on how to use them is present in [`src/index.ts`](https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts).
 

--- a/docs/advanced/hardhat-runtime-environment.md
+++ b/docs/advanced/hardhat-runtime-environment.md
@@ -4,7 +4,7 @@
 
 The Hardhat Runtime Environment, or HRE for short, is an object containing all the functionality that Hardhat exposes when running a task, test or script. In reality, Hardhat _is_ the HRE.
 
-When you require Hardhat (`const hardhat = require("@nomiclabs/hardhat")`) you're getting an instance of the HRE.
+When you require Hardhat (`const hardhat = require("hardhat")`) you're getting an instance of the HRE.
 
 During initialization, the Hardhat configuration file essentially constructs a list of things to be added to the HRE. This includes tasks, configs and plugins. Then when tasks, tests or scripts run, the HRE is always present and available to access anything that is contained in it.
 
@@ -24,18 +24,18 @@ Before running a task, test or script, Hardhat injects the HRE into the global s
 
 Not everyone likes magic global variables, and Hardhat doesn't force you to use them. Everything can be done explicitly in tasks, tests and scripts.
 
-When writing tests or scripts, you can use `require("@nomiclabs/hardhat")` to import the HRE. You can read more about this in [Accessing the HRE from outside a task](#accessing-the-hre-from-outside-a-task).
+When writing tests or scripts, you can use `require("hardhat")` to import the HRE. You can read more about this in [Accessing the HRE from outside a task](#accessing-the-hre-from-outside-a-task).
 
 You can import the config DSL explicitly when defining your tasks, and receive the HRE explicitly as an argument to your actions. You can read more about this in [Creating your own tasks](https://usehardhat.com/guides/create-task.html).
 
 ## Accessing the HRE from outside a task
 
-The HRE can be used from any JavaScript or TypeScript file. To do so, you only have to import it with `require("@nomiclabs/hardhat")`. You can do this to keep more control over your development workflow, create your own tools, or to use Hardhat with other dev tools from the node.js ecosystem.
+The HRE can be used from any JavaScript or TypeScript file. To do so, you only have to import it with `require("hardhat")`. You can do this to keep more control over your development workflow, create your own tools, or to use Hardhat with other dev tools from the node.js ecosystem.
 
 Running test directly with [Mocha](https://www.npmjs.com/package/mocha) instead of `npx hardhat test` can be done by explicitly importing the HRE in them like this:
 
 ```js
-const hre = require("@nomiclabs/hardhat");
+const hre = require("hardhat");
 const assert = require("assert");
 
 describe("Hardhat Runtime Environment", function() {

--- a/docs/guides/create-task.md
+++ b/docs/guides/create-task.md
@@ -157,7 +157,7 @@ And there you have it. Your first fully functional Hardhat task, allowing you to
 
 ## Advanced usage
 
-You can create your own tasks in your `hardhat.config.js` file. The Config DSL will be available in the global environment, with functions for defining tasks. You can also import the DSL with `require("@nomiclabs/hardhat/config")` if you prefer to keep things explicit, and take advantage of your editor's autocomplete.
+You can create your own tasks in your `hardhat.config.js` file. The Config DSL will be available in the global environment, with functions for defining tasks. You can also import the DSL with `require("hardhat/config")` if you prefer to keep things explicit, and take advantage of your editor's autocomplete.
 
 Creating a task is done by calling the `task` function. It will return a `TaskDefinition` object, which can be used to define the task's parameters.
 
@@ -243,7 +243,7 @@ Failing to follow these restrictions will result in an exception being thrown wh
 
 Hardhat takes care of validating and parsing the values provided for each parameter. You can declare the type of a parameter, and Hardhat will get the CLI strings and convert them into your desired type. If this conversion fails, it will print an error message explaining why.
 
-A number of types are available in the Config DSL through a `types` object. This object is injected into the global scope before processing your `hardhat.config.js`, but you can also import it explicitly with `const { types } = require("@nomiclabs/hardhat/config")` and take advantage of your editor's autocomplete.
+A number of types are available in the Config DSL through a `types` object. This object is injected into the global scope before processing your `hardhat.config.js`, but you can also import it explicitly with `const { types } = require("hardhat/config")` and take advantage of your editor's autocomplete.
 
 An example of a task defining a type for one of its parameters is
 

--- a/docs/guides/hardhat-console.md
+++ b/docs/guides/hardhat-console.md
@@ -43,7 +43,7 @@ Anything that has been injected into the [Hardhat Runtime Environment] will be m
 TODO-HH: re-run this
 
 ```
-> const hardhat = require("@nomiclabs/hardhat")
+> const hardhat = require("hardhat")
 undefined
 > hardhat.
 hardhat.__defineGetter__      hardhat.__defineSetter__      hardhat.__lookupGetter__      hardhat.__lookupSetter__      hardhat.__proto__

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -20,7 +20,7 @@ This makes it easy to port scripts that were developed for other tools that inje
 The second option leverages Hardhat's architecture to allow for more flexibility. Hardhat has been designed as a library, allowing you to get creative and build standalone CLI tools that access your development environment. This means that by simply requiring it:
 
 ```js
-const hre = require("@nomiclabs/hardhat");
+const hre = require("hardhat");
 ```
 
 You can get access to all your tasks and plugins. To run these scripts you simply go through node: `node script.js`.
@@ -46,7 +46,7 @@ Inside `scripts/` you will find `sample-script.js`. Read through its comments to
 Done? Before running the script with `node` you need to declare `ethers`. This is needed because Hardhat won't be injecting it on the global scope as it does when calling the `run` task.
 
 ```js{2}
-const hre = require("@nomiclabs/hardhat");
+const hre = require("hardhat");
 const ethers = hre.ethers;
 
 async function main() {

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -63,7 +63,7 @@ module.exports = {};
 into this
 
 ```typescript{1,7,8,15}
-import { task, usePlugin } from "@nomiclabs/hardhat/config";
+import { task, usePlugin } from "hardhat/config";
 
 usePlugin("@nomiclabs/hardhat-waffle");
 
@@ -108,7 +108,7 @@ One of the advantages of using TypeScript, is that you can have an type-safe con
 To do that, you have to write your config in TypeScript in this way:
 
 ```ts
-import { HardhatConfig } from "@nomiclabs/hardhat/config";
+import { HardhatConfig } from "hardhat/config";
 
 const config: HardhatConfig = {
   // Your type-safe config goes here
@@ -148,7 +148,7 @@ When using JavaScript, all the properties in the HRE are injected into the globa
 An example for tests:
 
 ```typescript
-import { ethers } from "@nomiclabs/hardhat";
+import { ethers } from "hardhat";
 import { Signer } from "ethers";
 
 describe("Token", function() {
@@ -168,7 +168,7 @@ describe("Token", function() {
 An example for scripts:
 
 ```typescript
-import { run, ethers } from "@nomiclabs/hardhat";
+import { run, ethers } from "hardhat";
 
 async function main() {
   await run("compile");

--- a/docs/guides/vscode-tests.md
+++ b/docs/guides/vscode-tests.md
@@ -8,7 +8,7 @@ install it and create a file named `.mocharc.json` in your project's root direct
 
 ```json
 {
-  "require": ["@nomiclabs/hardhat/register"],
+  "require": ["hardhat/register"],
   "timeout": 20000,
   "recursive": "test"
 }

--- a/docs/guides/waffle-testing.md
+++ b/docs/guides/waffle-testing.md
@@ -131,7 +131,7 @@ To learn more about `Signer`, you can look at the [Signers documentation](https:
 
 The `ethers` variable is available in the global scope. If you like your code always being explicit, you can add this line at the top:
 ```js
-const { ethers } = require("@nomiclabs/hardhat");
+const { ethers } = require("hardhat");
 ```
 
 Finally, to execute a contract's method from another account, all you need to do is `connect` the `Contract` with the method being executed:

--- a/docs/tutorial/creating-a-new-hardhat-project.md
+++ b/docs/tutorial/creating-a-new-hardhat-project.md
@@ -8,7 +8,7 @@ Open a new terminal and run these commands:
 mkdir hardhat-tutorial 
 cd hardhat-tutorial 
 npm init --yes 
-npm install --save-dev @nomiclabs/hardhat 
+npm install --save-dev hardhat 
 ```
 
 ::: tip

--- a/docs/tutorial/testing-contracts.md
+++ b/docs/tutorial/testing-contracts.md
@@ -50,7 +50,7 @@ A `Signer` in ethers.js is an object that represents an Ethereum account. It's u
 
 The `ethers` variable is available in the global scope. If you like your code always being explicit, you can add this line at the top:
 ```js
-const { ethers } = require("@nomiclabs/hardhat");
+const { ethers } = require("hardhat");
 ```
 
 ::: tip

--- a/packages/hardhat-core/LICENSE
+++ b/packages/hardhat-core/LICENSE
@@ -2,7 +2,7 @@ The Hardhat Network functionality is licensed under the NOMIC LABS DEVELOPER
 LICENSE AGREEMENT as defined below. This includes the source code contained
 in the directories "src/internal/hardhat-network" and "test/internal/hardhat-network"
 as well as the compiled code in the "internal/hardhat-network" directory of the
-"@nomiclabs/hardhat" NPM package. The contents of the "sample-project/" 
+"hardhat" NPM package. The contents of the "sample-project/" 
 directory is licensed under the The Unlicense as defined below. All other 
 Hardhat code is licensed under the MIT License as defined below.
 

--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -1,5 +1,5 @@
 ![](https://user-images.githubusercontent.com/232174/75543992-f1c39e00-5a1a-11ea-8fd4-8933638b5910.png)
-[![NPM Package](https://img.shields.io/npm/v/@nomiclabs/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/@nomiclabs/hardhat)
+[![NPM Package](https://img.shields.io/npm/v/@nomiclabs/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/hardhat)
 ![Build Status](https://github.com/nomiclabs/hardhat/workflows/CI/badge.svg)
 ---------
 Hardhat is a task runner for Ethereum smart contract developers. It facilitates performing frequent tasks, such as running tests, automatically checking code for mistakes or interacting with a smart contract. Check out the [plugin list](https://usehardhat.com/plugins/) to use it with your existing tools.

--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -1,5 +1,5 @@
 ![](https://user-images.githubusercontent.com/232174/75543992-f1c39e00-5a1a-11ea-8fd4-8933638b5910.png)
-[![NPM Package](https://img.shields.io/npm/v/@nomiclabs/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/hardhat)
+[![NPM Package](https://img.shields.io/npm/v/hardhat.svg?style=flat-square)](https://www.npmjs.org/package/hardhat)
 ![Build Status](https://github.com/nomiclabs/hardhat/workflows/CI/badge.svg)
 ---------
 Hardhat is a task runner for Ethereum smart contract developers. It facilitates performing frequent tasks, such as running tests, automatically checking code for mistakes or interacting with a smart contract. Check out the [plugin list](https://usehardhat.com/plugins/) to use it with your existing tools.
@@ -14,7 +14,7 @@ Join our [Hardhat Support Discord server](https://invite.gg/HardhatSupport) to s
 
 The recommended way of using Hardhat is through a local installation in your project. This way your environment will be reproducible and you will avoid future version conflicts. To use it in this way you will need to prepend `npx` to run it (i.e. `npx hardhat`). To install locally initialize your `npm` project using `npm init` and follow the instructions. Once ready run:
 
-    npm install --save-dev @nomiclabs/hardhat
+    npm install --save-dev hardhat
 
 ## Documentation
 

--- a/packages/hardhat-core/src/internal/context.ts
+++ b/packages/hardhat-core/src/internal/context.ts
@@ -57,14 +57,14 @@ export class HardhatContext {
 
   public setHardhatRuntimeEnvironment(env: HardhatRuntimeEnvironment) {
     if (this.environment !== undefined) {
-      throw new HardhatError(ERRORS.GENERAL.CONTEXT_BRE_ALREADY_DEFINED);
+      throw new HardhatError(ERRORS.GENERAL.CONTEXT_HRE_ALREADY_DEFINED);
     }
     this.environment = env;
   }
 
   public getHardhatRuntimeEnvironment(): HardhatRuntimeEnvironment {
     if (this.environment === undefined) {
-      throw new HardhatError(ERRORS.GENERAL.CONTEXT_BRE_NOT_DEFINED);
+      throw new HardhatError(ERRORS.GENERAL.CONTEXT_HRE_NOT_DEFINED);
     }
     return this.environment;
   }

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -129,11 +129,11 @@ Check the error message for details, or go to [documentation](https://usehardhat
     LIB_IMPORTED_FROM_THE_CONFIG: {
       number: 9,
       message: `Error while loading Hardhat's configuration.
-You probably imported @nomiclabs/hardhat instead of @nomiclabs/hardhat/config`,
+You probably imported hardhat instead of hardhat/config`,
       title: "Failed to load config file",
       description: `There was an error while loading your config file. 
 
-The most common source of errors is trying to import \`@nomiclabs/hardhat\` instead of \`@nomiclabs/hardhat/config\`.
+The most common source of errors is trying to import \`hardhat\` instead of \`hardhat/config\`.
 
 Please make sure your config file is correct.`,
       shouldBeReported: false,

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -21,7 +21,7 @@ export const ERROR_RANGES: {
     title: string;
   };
 } = {
-  GENERAL: { min: 0, max: 99, title: "General errors" },
+  GENERAL: { min: 1, max: 99, title: "General errors" },
   NETWORK: { min: 100, max: 199, title: "Network related errors" },
   TASK_DEFINITIONS: {
     min: 200,

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -93,7 +93,7 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,
     },
-    CONTEXT_BRE_NOT_DEFINED: {
+    CONTEXT_HRE_NOT_DEFINED: {
       number: 6,
       message:
         "Hardhat Runtime Environment is not defined in the HardhatContext.",
@@ -103,7 +103,7 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,
     },
-    CONTEXT_BRE_ALREADY_DEFINED: {
+    CONTEXT_HRE_ALREADY_DEFINED: {
       number: 7,
       message:
         "Hardhat Runtime Environment is already defined in the HardhatContext",

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -150,6 +150,7 @@ This is probably a bug in one of your plugins.
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,
     },
+    // TODO-HH: Remove this error
     CONTEXT_CONFIG_PATH_NOT_SET: {
       number: 11,
       message:

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -335,18 +335,8 @@ Please double check your task definitions.`,
 Please double check your task definitions.`,
       shouldBeReported: false,
     },
-    OVERRIDE_NO_PARAMS: {
-      number: 204,
-      message:
-        "Redefinition of task %taskName% failed. You can't change param definitions in an overridden task.",
-      title: "Attempted to add params to an overridden task",
-      description: `You can't change param definitions in an overridden task.
-
-Please, double check your task definitions.`,
-      shouldBeReported: false,
-    },
     ACTION_NOT_SET: {
-      number: 205,
+      number: 204,
       message: "No action set for task %taskName%.",
       title: "Tried to run task without an action",
       description: `A task was run, but it has no action set.  
@@ -355,7 +345,7 @@ Please double check your task definitions.`,
       shouldBeReported: false,
     },
     RUNSUPER_NOT_AVAILABLE: {
-      number: 206,
+      number: 205,
       message:
         "Tried to call runSuper from a non-overridden definition of task %taskName%",
       title: "`runSuper` not available",
@@ -365,7 +355,7 @@ Please use \`runSuper.isDefined\` to make sure that you can call it.`,
       shouldBeReported: false,
     },
     DEFAULT_VALUE_WRONG_TYPE: {
-      number: 207,
+      number: 206,
       message:
         "Default value for param %paramName% of task %taskName% doesn't match the default one, try specifying it.",
       title: "Default value has incorrect type",
@@ -375,7 +365,7 @@ Please double check your task definitions.`,
       shouldBeReported: false,
     },
     DEFAULT_IN_MANDATORY_PARAM: {
-      number: 208,
+      number: 207,
       message:
         "Default value for param %paramName% of task %taskName% shouldn't be set.",
       title: "Required parameter has a default value",
@@ -385,7 +375,7 @@ Please double check your task definitions.`,
       shouldBeReported: false,
     },
     INVALID_PARAM_NAME_CASING: {
-      number: 209,
+      number: 208,
       message:
         "Invalid param name %paramName% in task %taskName%. Param names must be camelCase.",
       title: "Invalid casing in parameter name",
@@ -395,7 +385,7 @@ Please double check your task definitions.`,
       shouldBeReported: false,
     },
     OVERRIDE_NO_MANDATORY_PARAMS: {
-      number: 210,
+      number: 209,
       message:
         "Redefinition of task %taskName% failed. Unsupported operation adding mandatory (non optional) param definitions in an overridden task.",
       title: "Attempted to add mandatory params to an overridden task",
@@ -407,7 +397,7 @@ Please, double check your task definitions.`,
       shouldBeReported: false,
     },
     OVERRIDE_NO_POSITIONAL_PARAMS: {
-      number: 211,
+      number: 210,
       message:
         "Redefinition of task %taskName% failed. Unsupported operation adding positional param definitions in an overridden task.",
       title: "Attempted to add positional params to an overridden task",
@@ -419,7 +409,7 @@ Please, double check your task definitions.`,
       shouldBeReported: false,
     },
     OVERRIDE_NO_VARIADIC_PARAMS: {
-      number: 212,
+      number: 211,
       message:
         "Redefinition of task %taskName% failed. Unsupported operation adding variadic param definitions in an overridden task.",
       title: "Attempted to add variadic params to an overridden task",
@@ -431,7 +421,7 @@ Please, double check your task definitions.`,
       shouldBeReported: false,
     },
     CLI_ARGUMENT_TYPE_REQUIRED: {
-      number: 213,
+      number: 212,
       title: "Invalid argument type",
       message:
         "Task %task% is not a subtask but one of its arguments uses the type %type%, which is not parseable.",

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -191,19 +191,8 @@ Read the [documentation](https://usehardhat.com/config/#networks-configuration) 
 Please make sure you are setting your config correctly.`,
       shouldBeReported: false,
     },
-    /* DEPRECATED: This error only happened because of a misconception in Hardhat */
-    DEPRECATED_INVALID_TX_CHAIN_ID: {
-      number: 102,
-      message:
-        "Trying to send a tx with chain id %txChainId%, but Hardhat is connected to a chain with id %chainId%.",
-      title: "Incorrectly send chainId in a transaction",
-      description: `Hardhat sent the \`chainId\` field in a transaction. 
-
-Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
-      shouldBeReported: false,
-    },
     ETHSIGN_MISSING_DATA_PARAM: {
-      number: 103,
+      number: 102,
       message: 'Missing "data" param when calling eth_sign.',
       title: "Missing `data` param when calling eth_sign.",
       description: `You called \`eth_sign\` with incorrect parameters.
@@ -212,7 +201,7 @@ Please check that you are sending a \`data\` parameter.`,
       shouldBeReported: false,
     },
     NOT_LOCAL_ACCOUNT: {
-      number: 104,
+      number: 103,
       message:
         "Account %account% is not managed by the node you are connected to.",
       title: "Unrecognized account",
@@ -223,7 +212,7 @@ Please double check your accounts and the \`from\` parameter in your RPC calls.`
       shouldBeReported: false,
     },
     MISSING_TX_PARAM_TO_SIGN_LOCALLY: {
-      number: 105,
+      number: 104,
       message: "Missing param %param% from a tx being signed locally.",
       title: "Missing transaction parameter",
       description: `You are trying to send a transaction with a locally managed 
@@ -233,7 +222,7 @@ Please double check your transactions' parameters.`,
       shouldBeReported: false,
     },
     NO_REMOTE_ACCOUNT_AVAILABLE: {
-      number: 106,
+      number: 105,
       message:
         "No local account was set and there are accounts in the remote node.",
       title: "No remote accounts available",
@@ -243,7 +232,7 @@ Please make sure that your Ethereum node has unlocked accounts.`,
       shouldBeReported: false,
     },
     INVALID_HD_PATH: {
-      number: 107,
+      number: 106,
       message:
         "HD path %path% is invalid. Read about BIP32 to know about the valid forms.",
       title: "Invalid HD path",
@@ -253,7 +242,7 @@ Read the [documentation](https://usehardhat.com/config/#hd-wallet-config) to lea
       shouldBeReported: false,
     },
     INVALID_RPC_QUANTITY_VALUE: {
-      number: 108,
+      number: 107,
       message:
         "Received invalid value `%value%` from/to the node's JSON-RPC, but a Quantity was expected.",
       title: "Invalid JSON-RPC value",
@@ -263,7 +252,7 @@ Please double check your calls' parameters and keep your Ethereum node up to dat
       shouldBeReported: false,
     },
     NODE_IS_NOT_RUNNING: {
-      number: 109,
+      number: 108,
       message: `Cannot connect to the network %network%.
 Please make sure your node is running, and check your internet connection and networks config`,
       title: "Cannot connect to the network",
@@ -273,7 +262,7 @@ Please make sure your node is running, and check your internet connection and ne
       shouldBeReported: false,
     },
     NETWORK_TIMEOUT: {
-      number: 110,
+      number: 109,
       message: `Network connection timed-out.
 Please check your internet connection and networks config`,
       title: "Network timeout",
@@ -283,7 +272,7 @@ Please make sure your node is running, and check your internet connection and ne
       shouldBeReported: false,
     },
     INVALID_JSON_RESPONSE: {
-      number: 111,
+      number: 110,
       message: "Invalid JSON-RPC response received: %response%",
       title: "Invalid JSON-RPC response",
       description: `One of your JSON-RPC requests received an invalid response. 
@@ -292,7 +281,7 @@ Please make sure your node is running, and check your internet connection and ne
       shouldBeReported: false,
     },
     CANT_DERIVE_KEY: {
-      number: 112,
+      number: 111,
       message:
         "Cannot derive key %path% from mnemonic '%mnemonic%.\nTry using another mnemonic or deriving less keys.",
       title: "Could not derive an HD key",
@@ -583,29 +572,8 @@ This is not supported. Please run the help task to see the available options.`,
       description: `Tried to resolve a non-existing Solidity file as an entry-point.`,
       shouldBeReported: false,
     },
-    // Deprecated: This error was replaced by one that includes more context
-    FILE_OUTSIDE_PROJECT: {
-      number: 401,
-      message: "File %file% is outside the project.",
-      title: "Tried to import file outside your project",
-      description: `One of your projects tried to import a file that it's outside your Hardhat project. 
-
-This is disabled for security reasons.`,
-      shouldBeReported: false,
-    },
-    // Deprecated: This error was replaced by one that includes more context
-    LIBRARY_FILE_NOT_LOCAL: {
-      number: 402,
-      message:
-        "File %file% belongs to a library but was treated as a local one.",
-      title: "Resolved library file as a local one",
-      description: `One of your libraries' files was treated as a local file. This is a bug. 
-
-Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
-      shouldBeReported: true,
-    },
     LIBRARY_NOT_INSTALLED: {
-      number: 403,
+      number: 401,
       message: "Library %library% is not installed.",
       title: "Solidity library not installed",
       description: `One of your Solidity sources imports a library that is not installed.
@@ -614,7 +582,7 @@ Please double check your imports or install the missing dependency.`,
       shouldBeReported: false,
     },
     LIBRARY_FILE_NOT_FOUND: {
-      number: 404,
+      number: 402,
       message: "File %file% doesn't exist.",
       title: "Missing library file",
       description: `One of your libraries' files was imported but doesn't exist. 
@@ -623,7 +591,7 @@ Please double check your imports or update your libraries.`,
       shouldBeReported: false,
     },
     ILLEGAL_IMPORT: {
-      number: 405,
+      number: 403,
       message: "Illegal import %imported% from %from%",
       title: "Illegal Solidity import",
       description: `One of your libraries tried to use a relative import to import a file outside of its scope. 
@@ -631,19 +599,8 @@ Please double check your imports or update your libraries.`,
 This is disabled for security reasons.`,
       shouldBeReported: false,
     },
-    // Deprecated:  This error was replaced by one with more context
-    FILE_OUTSIDE_LIB: {
-      number: 406,
-      message:
-        "File %file% from %library% is resolved to a path outside of its library.",
-      title: "Illegal Solidity import",
-      description: `One of your libraries tried to use a relative import to import a file outside of its scope. 
-
-This is disabled for security reasons.`,
-      shouldBeReported: false,
-    },
     IMPORTED_FILE_NOT_FOUND: {
-      number: 407,
+      number: 404,
       message: "File %imported%, imported from %from%, not found.",
       title: "Imported file not found",
       description: `One of your source files imported a non-existing one. 
@@ -652,7 +609,7 @@ Please double check your imports.`,
       shouldBeReported: false,
     },
     INVALID_IMPORT_BACKSLASH: {
-      number: 408,
+      number: 405,
       message:
         "Invalid import %imported% from %from%. Imports must use / instead of \\, even in Windows",
       title: "Invalid import: use / instead of \\",
@@ -662,7 +619,7 @@ You must always use slashes (/) in Solidity imports.`,
       shouldBeReported: false,
     },
     INVALID_IMPORT_PROTOCOL: {
-      number: 409,
+      number: 406,
       message:
         "Invalid import %imported% from %from%. Hardhat doesn't support imports via %protocol%.",
       title: "Invalid import: trying to use an unsupported protocol",
@@ -672,7 +629,7 @@ You can only import files thar are available locally or installed through npm.`,
       shouldBeReported: false,
     },
     INVALID_IMPORT_ABSOLUTE_PATH: {
-      number: 410,
+      number: 407,
       message:
         "Invalid import %imported% from %from%. Hardhat doesn't support imports with absolute paths.",
       title: "Invalid import: absolute paths unsupported",
@@ -682,7 +639,7 @@ This is not supported, as it would lead to hard to reproduce compilations.`,
       shouldBeReported: false,
     },
     INVALID_IMPORT_OUTSIDE_OF_PROJECT: {
-      number: 411,
+      number: 408,
       message:
         "Invalid import %imported% from %from%. The file being imported is outside of the project",
       title: "Invalid import: file outside of the project",
@@ -692,7 +649,7 @@ This is not supported by Hardhat.`,
       shouldBeReported: false,
     },
     INVALID_IMPORT_WRONG_CASING: {
-      number: 412,
+      number: 409,
       message:
         "Trying to import %imported% from %from%, but it has an incorrect casing.",
       title: "Invalid import: wrong file casing",
@@ -702,7 +659,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
       shouldBeReported: false,
     },
     WRONG_SOURCE_NAME_CASING: {
-      number: 413,
+      number: 410,
       message:
         "Trying to resolve the file %incorrect% but its correct case-sensitive name is %correct%",
       title: "Incorrect source name casing",
@@ -712,7 +669,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
       shouldBeReported: false,
     },
     IMPORTED_LIBRARY_NOT_INSTALLED: {
-      number: 414,
+      number: 411,
       message:
         "The library %library%, imported from %from%, is not installed. Try installing it using npm.",
       title: "Invalid import: library not installed",
@@ -808,15 +765,8 @@ We recommend not using this kind of dependencies.`,
       description: `There was error while starting the JSON-RPC HTTP server.`,
       shouldBeReported: false,
     },
-    JSONRPC_HANDLER_ERROR: {
-      number: 605,
-      message: "Error handling JSON-RPC request: %error%",
-      title: "Error handling JSON-RPC request",
-      description: `Handling an incoming JSON-RPC request resulted in an error.`,
-      shouldBeReported: false,
-    },
     JSONRPC_UNSUPPORTED_NETWORK: {
-      number: 606,
+      number: 605,
       message:
         "Unsupported network for JSON-RPC server. Only hardhat is currently supported.",
       title: "Unsupported network for JSON-RPC server.",
@@ -826,7 +776,7 @@ To start the JSON-RPC server, retry the command without the --network parameter.
       shouldBeReported: false,
     },
     COMPILATION_JOBS_CREATION_FAILURE: {
-      number: 607,
+      number: 606,
       message: `The project cannot be compiled, see reasons below.
 
 %reasons%`,
@@ -871,49 +821,8 @@ Hardhat's artifact resolution is case sensitive to ensure projects are portable 
     },
   },
   PLUGINS: {
-    NOT_INSTALLED: {
-      number: 800,
-      message: `Plugin %plugin% is not installed.
-%extraMessage%Please run: npm install --save-dev%extraFlags% %plugin%`,
-      title: "Plugin not installed",
-      description: `You are trying to use a plugin that hasn't been installed. 
-
-Please follow Hardhat's instructions to resolve this.`,
-      shouldBeReported: false,
-    },
-    MISSING_DEPENDENCY: {
-      number: 801,
-      message: `Plugin %plugin% requires %dependency% to be installed.
-%extraMessage%Please run: npm install --save-dev%extraFlags% "%dependency%@%versionSpec%"`,
-      title: "Plugin dependencies not installed",
-      description: `You are trying to use a plugin with unmet dependencies. 
-
-Please follow Hardhat's instructions to resolve this.`,
-      shouldBeReported: false,
-    },
-    DEPENDENCY_VERSION_MISMATCH: {
-      number: 802,
-      message: `Plugin %plugin% requires %dependency% version %versionSpec% but got %installedVersion%.
-%extraMessage%If you haven't installed %dependency% manually, please run: npm install --save-dev%extraFlags% "%dependency%@%versionSpec%"
-If you have installed %dependency% yourself, please reinstall it with a valid version.`,
-      title: "Plugin dependencies's version mismatch",
-      description: `You are trying to use a plugin that requires a different version of one of its dependencies. 
-
-Please follow Hardhat's instructions to resolve this.`,
-      shouldBeReported: false,
-    },
-    OLD_STYLE_IMPORT_DETECTED: {
-      number: 803,
-      message: `You are trying to load %pluginNameText% with a require or import statement.
-Please replace it with a call to usePlugin("%pluginNameCode%").`,
-      title: "Importing a plugin with `require`",
-      description: `You are trying to load a plugin with a call to \`require\`. 
-
-Please use \`usePlugin(npm-plugin-package)\` instead.`,
-      shouldBeReported: false,
-    },
     BUIDLER_PLUGIN: {
-      number: 804,
+      number: 800,
       message: `You are using %plugin%, which is a Buidler plugin. Use the equivalent
 Hardhat plugin instead.`,
       title: "Using a buidler plugin",
@@ -923,7 +832,7 @@ Please use the equivalent Hardhat plugin instead.`,
       shouldBeReported: false,
     },
     MISSING_DEPENDENCIES: {
-      number: 805,
+      number: 801,
       message: `Plugin %plugin% requires the following dependencies to be installed: %missingDependencies%.
 %extraMessage%Please run: npm install --save-dev%extraFlags% %missingDependenciesVersions%`,
       title: "Plugin dependencies not installed",

--- a/packages/hardhat-core/test/fixture-projects/plugin-dynamic-import-not-installed/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/plugin-dynamic-import-not-installed/hardhat.config.js
@@ -1,5 +1,5 @@
 require("some-plugin");
 
 module.exports = {
-  solidity: "0.5.15"
-}
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/internal/context.ts
+++ b/packages/hardhat-core/test/internal/context.ts
@@ -58,7 +58,7 @@ describe("Hardhat context", async function () {
       const ctx = HardhatContext.createHardhatContext();
       expectHardhatError(
         () => ctx.getHardhatRuntimeEnvironment(),
-        ERRORS.GENERAL.CONTEXT_BRE_NOT_DEFINED
+        ERRORS.GENERAL.CONTEXT_HRE_NOT_DEFINED
       );
     });
   });
@@ -78,7 +78,7 @@ describe("Hardhat context", async function () {
           HardhatContext.getHardhatContext().setHardhatRuntimeEnvironment(
             this.env
           ),
-        ERRORS.GENERAL.CONTEXT_BRE_ALREADY_DEFINED
+        ERRORS.GENERAL.CONTEXT_HRE_ALREADY_DEFINED
       );
     });
   });

--- a/packages/hardhat-core/test/internal/core/errors.ts
+++ b/packages/hardhat-core/test/internal/core/errors.ts
@@ -204,6 +204,25 @@ describe("Error descriptors", () => {
       }
     }
   });
+
+  it("Should keep the numbers in order, without gaps", () => {
+    for (const errorGroup of unsafeObjectKeys(ERRORS)) {
+      const range = ERROR_RANGES[errorGroup];
+      let expectedErrorNumber = range.min;
+
+      for (const [name, errorDescriptor] of Object.entries<ErrorDescriptor>(
+        ERRORS[errorGroup]
+      )) {
+        assert.equal(
+          errorDescriptor.number,
+          expectedErrorNumber,
+          `ERRORS.${errorGroup}.${name}'s number is out of range`
+        );
+
+        expectedErrorNumber += 1;
+      }
+    }
+  });
 });
 
 describe("HardhatPluginError", () => {

--- a/packages/hardhat-waffle/README.md
+++ b/packages/hardhat-waffle/README.md
@@ -61,7 +61,7 @@ import { deployContract } from "ethereum-waffle";
 you should do
 
 ```typescript
-import { waffle } from "@nomiclabs/hardhat";
+import { waffle } from "hardhat";
 const { deployContract } = waffle;
 ```
 


### PR DESCRIPTION
This PR also replaces usages of `@nomiclabs/hardhat` in the context of
an npm package with the correct plain `hardhat`.