### PR TITLE
Update how TS is detected and loaded

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import { HARDHAT_NETWORK_NAME } from "../internal/constants";
 import { subtask, task } from "../internal/core/config/config-env";
-import { isTypescriptSupported } from "../internal/core/typescript-support";
+import { isRunningWithTypescript } from "../internal/core/typescript-support";
 import { getForkCacheDirPath } from "../internal/hardhat-network/provider/utils/disk-cache";
 import { showForkRecommendationsBannerIfNecessary } from "../internal/hardhat-network/provider/utils/fork-recomendations-banner";
 import { glob } from "../internal/util/glob";
@@ -31,7 +31,7 @@ subtask(TASK_TEST_GET_TEST_FILES)
 
     const jsFiles = await glob(path.join(config.paths.tests, "**/*.js"));
 
-    if (!isTypescriptSupported()) {
+    if (!isRunningWithTypescript(config)) {
       return jsFiles;
     }
 

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -16,7 +16,7 @@ import { getEnvHardhatArguments } from "../core/params/env-variables";
 import { HARDHAT_PARAM_DEFINITIONS } from "../core/params/hardhat-params";
 import { isCwdInsideProject } from "../core/project-structure";
 import { Environment } from "../core/runtime-environment";
-import { loadTsNodeIfPresent } from "../core/typescript-support";
+import { loadTsNode, willRunWithTypescript } from "../core/typescript-support";
 import { Reporter } from "../sentry/reporter";
 import { getPackageJson, PackageJson } from "../util/packageInfo";
 
@@ -99,7 +99,9 @@ async function main() {
       throw new HardhatError(ERRORS.GENERAL.NON_LOCAL_INSTALLATION);
     }
 
-    loadTsNodeIfPresent();
+    if (willRunWithTypescript(hardhatArguments.config)) {
+      loadTsNode();
+    }
 
     let taskName = parsedTaskName ?? "help";
 

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -19,13 +19,7 @@ function importCsjOrEsModule(filePath: string): any {
   return imported.default !== undefined ? imported.default : imported;
 }
 
-export function loadConfigAndTasks(
-  hardhatArguments?: Partial<HardhatArguments>,
-  { showWarningIfNoSolidityConfig } = { showWarningIfNoSolidityConfig: true }
-): HardhatConfig {
-  let configPath =
-    hardhatArguments !== undefined ? hardhatArguments.config : undefined;
-
+export function resolveConfigPath(configPath: string | undefined) {
   if (configPath === undefined) {
     configPath = getUserConfigPath();
   } else {
@@ -34,6 +28,17 @@ export function loadConfigAndTasks(
       configPath = path.normalize(configPath);
     }
   }
+  return configPath;
+}
+
+export function loadConfigAndTasks(
+  hardhatArguments?: Partial<HardhatArguments>,
+  { showWarningIfNoSolidityConfig } = { showWarningIfNoSolidityConfig: true }
+): HardhatConfig {
+  let configPath =
+    hardhatArguments !== undefined ? hardhatArguments.config : undefined;
+
+  configPath = resolveConfigPath(configPath);
 
   // Before loading the builtin tasks, the default and user's config we expose
   // the config env in the global object.

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -181,6 +181,28 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
 Please install Hardhat locally using npm or Yarn, and try again.`,
       shouldBeReported: false,
     },
+    TS_NODE_NOT_INSTALLED: {
+      number: 14,
+      message: `Your Hardhat project uses typescript, but ts-node is not installed.
+      
+Please run: npm install --save-dev ts-node`,
+      title: "ts-node not installed",
+      description: `You are running a Hardhat project that uses typescript, but you haven't installed ts-node.
+
+Please run this and try again: npm install --save-dev ts-node`,
+      shouldBeReported: false,
+    },
+    TYPESCRIPT_NOT_INSTALLED: {
+      number: 15,
+      message: `Your Hardhat project uses typescript, but it's not installed.
+      
+Please run: npm install --save-dev typescript`,
+      title: "typescript not installed",
+      description: `You are running a Hardhat project that uses typescript, but it's not installed.
+
+Please run this and try again: npm install --save-dev typescript`,
+      shouldBeReported: false,
+    },
   },
   NETWORK: {
     CONFIG_NOT_FOUND: {

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -19,9 +19,9 @@ export function isHardhatInstalledLocally(configPath?: string) {
  */
 export function isLocalDev(): boolean {
   // TODO: This may give a false positive under yarn PnP
-  return isRunningTests() || !__filename.includes("node_modules");
+  return isRunningHardhatCoreTests() || !__filename.includes("node_modules");
 }
 
-export function isRunningTests(): boolean {
+export function isRunningHardhatCoreTests(): boolean {
   return __filename.endsWith(".ts");
 }

--- a/packages/hardhat-core/src/internal/core/project-structure.ts
+++ b/packages/hardhat-core/src/internal/core/project-structure.ts
@@ -6,23 +6,20 @@ import { getPackageRoot } from "../util/packageInfo";
 
 import { HardhatError } from "./errors";
 import { ERRORS } from "./errors-list";
-import { isTypescriptSupported } from "./typescript-support";
 const JS_CONFIG_FILENAME = "hardhat.config.js";
 const TS_CONFIG_FILENAME = "hardhat.config.ts";
 
 export function isCwdInsideProject() {
   return (
-    findUp.sync(JS_CONFIG_FILENAME) !== null ||
-    (isTypescriptSupported() && findUp.sync(TS_CONFIG_FILENAME) !== null)
+    findUp.sync(TS_CONFIG_FILENAME) !== null ||
+    findUp.sync(JS_CONFIG_FILENAME) !== null
   );
 }
 
 export function getUserConfigPath() {
-  if (isTypescriptSupported()) {
-    const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
-    if (tsConfigPath !== null) {
-      return tsConfigPath;
-    }
+  const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
+  if (tsConfigPath !== null) {
+    return tsConfigPath;
   }
 
   const pathToConfigFile = findUp.sync(JS_CONFIG_FILENAME);

--- a/packages/hardhat-core/src/internal/util/scripts-runner.ts
+++ b/packages/hardhat-core/src/internal/util/scripts-runner.ts
@@ -2,7 +2,7 @@ import debug from "debug";
 import path from "path";
 
 import { HardhatArguments } from "../../types";
-import { isRunningTests } from "../core/execution-mode";
+import { isRunningHardhatCoreTests } from "../core/execution-mode";
 import { getEnvVariablesMap } from "../core/params/env-variables";
 
 const log = debug("hardhat:core:scripts-runner");
@@ -97,7 +97,7 @@ function getTsNodeArgsIfNeeded(scriptPath: string): string[] {
 
   // if we are running the tests we only want to transpile, or these tests
   // take forever
-  if (isRunningTests()) {
+  if (isRunningHardhatCoreTests()) {
     return ["--require", "ts-node/register/transpile-only"];
   }
 

--- a/packages/hardhat-core/src/register.ts
+++ b/packages/hardhat-core/src/register.ts
@@ -5,7 +5,10 @@ import { loadConfigAndTasks } from "./internal/core/config/config-loading";
 import { getEnvHardhatArguments } from "./internal/core/params/env-variables";
 import { HARDHAT_PARAM_DEFINITIONS } from "./internal/core/params/hardhat-params";
 import { Environment } from "./internal/core/runtime-environment";
-import { loadTsNodeIfPresent } from "./internal/core/typescript-support";
+import {
+  loadTsNode,
+  willRunWithTypescript,
+} from "./internal/core/typescript-support";
 import {
   disableReplWriterShowProxy,
   isNodeCalledWithoutAScript,
@@ -21,8 +24,6 @@ if (!HardhatContext.isCreated()) {
     disableReplWriterShowProxy();
   }
 
-  loadTsNodeIfPresent();
-
   const hardhatArguments = getEnvHardhatArguments(
     HARDHAT_PARAM_DEFINITIONS,
     process.env
@@ -30,6 +31,10 @@ if (!HardhatContext.isCreated()) {
 
   if (hardhatArguments.verbose) {
     debug.enable("hardhat*");
+  }
+
+  if (willRunWithTypescript(hardhatArguments.config)) {
+    loadTsNode();
   }
 
   const config = loadConfigAndTasks(hardhatArguments);

--- a/packages/hardhat-core/test/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/test/internal/core/typescript-support.ts
@@ -2,16 +2,11 @@ import { assert } from "chai";
 import fsExtra from "fs-extra";
 
 import { TASK_TEST_GET_TEST_FILES } from "../../../src/builtin-tasks/task-names";
-import { isTypescriptSupported } from "../../../src/internal/core/typescript-support";
 import { resetHardhatContext } from "../../../src/internal/reset";
 import { useEnvironment } from "../../helpers/environment";
 import { useFixtureProject } from "../../helpers/project";
 
 describe("Typescript support", function () {
-  describe("helpers", function () {
-    assert.isTrue(isTypescriptSupported());
-  });
-
   describe("strict typescript config", function () {
     useFixtureProject("broken-typescript-config-project");
     it("Should fail if an implicit any is used and the tsconfig forbids them", function () {

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/hardhat.config.ts
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/hardhat.config.ts
@@ -1,6 +1,6 @@
-require("../../../src/index");
+import "../../../src/index";
 
-module.exports = {
+export default {
   defaultNetwork: "ganache",
   networks: {
     ganache: {

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
@@ -2,7 +2,7 @@
 const env = require("hardhat");
 
 async function main() {
-  const customConfigs = require("../hardhat.config.js");
+  const customConfigs = require("../hardhat.config.ts").default;
   const customOptions = customConfigs.networks.ganache;
 
   const accounts = await env.network.provider.send("eth_accounts");

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project/hardhat.config.js
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project/hardhat.config.js
@@ -1,5 +1,0 @@
-require("../../../src/index");
-
-module.exports = {
-  solidity: "0.5.15",
-};

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -1,0 +1,5 @@
+import "../../../src/index";
+
+export default {
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-ganache/test/index.ts
+++ b/packages/hardhat-ganache/test/index.ts
@@ -59,7 +59,8 @@ describe("Ganache plugin with custom configs", function () {
 
   it("Should load custom configs in hardhat's config'", function () {
     assert.isDefined(this.env.config.networks.ganache);
-    const customConfigs = require("./fixture-projects/hardhat-project-with-configs/hardhat.config.js");
+    const customConfigs = require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts")
+      .default;
 
     assert.isDefined(customConfigs.networks.ganache);
     const customOptions = customConfigs.networks.ganache;
@@ -74,7 +75,8 @@ describe("Ganache plugin with custom configs", function () {
 
   it("Should expose merged (custom + defaults) configs in hardhat's config", function () {
     assert.isDefined(this.env.config.networks.ganache);
-    const customConfigs = require("./fixture-projects/hardhat-project-with-configs/hardhat.config.js");
+    const customConfigs = require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts")
+      .default;
     const defaultOptions = GanacheService.getDefaultOptions() as any;
 
     assert.isDefined(customConfigs.networks.ganache);


### PR DESCRIPTION
This PR changes how TS is handled in Hardhat. Now, we consider the typescript mode to be enabled if the config is in ts. 

There's an edge case when testing plugins that use the `script-runner` module (i.e. `run('run', ...)`). Their fixture projects may have a `.js` config, so TS is not loaded in the subrprocess spawn by `script-runner`, and still try to import the plugin sources, which are in ts. This was only present in the ganache plugin, so I fixed it by turning their config files to .ts.