### PR TITLE
Update project creation module

### DIFF
--- a/packages/hardhat-core/sample-project/scripts/sample-script.js
+++ b/packages/hardhat-core/sample-project/scripts/sample-script.js
@@ -11,7 +11,7 @@ async function main() {
   // await hre.run('compile');
 
   // We get the contract to deploy
-  const Greeter = await ethers.getContractFactory("Greeter");
+  const Greeter = await hre.ethers.getContractFactory("Greeter");
   const greeter = await Greeter.deploy("Hello, Hardhat!");
 
   await greeter.deployed();

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -11,7 +11,7 @@ import { HardhatContext } from "../context";
 import { loadConfigAndTasks } from "../core/config/config-loading";
 import { HardhatError, HardhatPluginError } from "../core/errors";
 import { ERRORS, getErrorCode } from "../core/errors-list";
-import { isHardhatInstalledLocally } from "../core/execution-mode";
+import { isHardhatInstalledLocallyOrLinked } from "../core/execution-mode";
 import { getEnvHardhatArguments } from "../core/params/env-variables";
 import { HARDHAT_PARAM_DEFINITIONS } from "../core/params/hardhat-params";
 import { isCwdInsideProject } from "../core/project-structure";
@@ -99,7 +99,7 @@ async function main() {
       return;
     }
 
-    if (!isHardhatInstalledLocally()) {
+    if (!isHardhatInstalledLocallyOrLinked()) {
       throw new HardhatError(ERRORS.GENERAL.NON_LOCAL_INSTALLATION);
     }
 

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -381,6 +381,10 @@ async function isYarnProject() {
 
 async function installRecommendedDependencies(dependencies: Dependencies) {
   console.log("");
+
+  // The reason we don't quote the dependencies here is because they are going
+  // to be used in child_process.sapwn, which doesn't require escaping string,
+  // and can actually fail if you do.
   const installCmd = await getRecommendedDependenciesInstallationCommand(
     dependencies,
     false

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -214,7 +214,7 @@ export async function createProject() {
 
     if (!isInstalled(HARDHAT_PACKAGE_NAME)) {
       console.log("");
-      console.log(`You need to install ${HARDHAT_NAME} to use it. Please run:`);
+      console.log(`You need to install hardhat locally to use it. Please run:`);
       const cmd = await getRecommendedDependenciesInstallationCommand({
         [HARDHAT_PACKAGE_NAME]: `^${(await getPackageJson()).version}`,
       });

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -87,7 +87,7 @@ async function printWelcomeMessage() {
 }
 
 async function copySampleProject(projectRoot: string) {
-  const packageRoot = await getPackageRoot();
+  const packageRoot = getPackageRoot();
 
   await fsExtra.ensureDir(projectRoot);
   await fsExtra.copy(path.join(packageRoot, "sample-project"), projectRoot);

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -10,6 +10,7 @@ import {
   hasConsentedTelemetry,
   writeTelemetryConsent,
 } from "../util/global-dir";
+import { fromEntries } from "../util/lang";
 import { getPackageJson, getPackageRoot } from "../util/packageInfo";
 
 import { emoji } from "./emoji";
@@ -18,7 +19,13 @@ const CREATE_SAMPLE_PROJECT_ACTION = "Create a sample project";
 const CREATE_EMPTY_HARDHAT_CONFIG_ACTION = "Create an empty hardhat.config.js";
 const QUIT_ACTION = "Quit";
 
-const SAMPLE_PROJECT_DEPENDENCIES = {
+interface Dependencies {
+  [name: string]: string;
+}
+
+const HARDHAT_PACKAGE_NAME = "hardhat";
+
+const SAMPLE_PROJECT_DEPENDENCIES: Dependencies = {
   "@nomiclabs/hardhat-waffle": "^2.0.0",
   "ethereum-waffle": "^3.0.0",
   chai: "^4.2.0",
@@ -74,7 +81,7 @@ async function printWelcomeMessage() {
     chalk.cyan(
       `${emoji("👷 ")}Welcome to ${HARDHAT_NAME} v${packageJson.version}${emoji(
         " 👷‍"
-      )}‍\n`
+      )}\n`
     )
   );
 }
@@ -120,7 +127,9 @@ async function printRecommendedDepsInstallationInstructions() {
     `You need to install these dependencies to run the sample project:`
   );
 
-  const cmd = await getRecommendedDependenciesInstallationCommand();
+  const cmd = await getRecommendedDependenciesInstallationCommand(
+    await getDependencies()
+  );
 
   console.log(`  ${cmd.join(" ")}`);
 }
@@ -175,6 +184,12 @@ async function getAction() {
   }
 }
 
+async function createPackageJson() {
+  await fsExtra.writeJson("package.json", {
+    name: "hardhat-project",
+  });
+}
+
 export async function createProject() {
   const { default: enquirer } = await import("enquirer");
   printAsciiLogo();
@@ -187,11 +202,28 @@ export async function createProject() {
     return;
   }
 
+  if (!(await fsExtra.pathExists("package.json"))) {
+    await createPackageJson();
+  }
+
   if (action === CREATE_EMPTY_HARDHAT_CONFIG_ACTION) {
     await writeEmptyHardhatConfig();
     console.log(
       `${emoji("✨ ")}${chalk.cyan(`Config file created`)}${emoji(" ✨")}`
     );
+
+    if (!isInstalled(HARDHAT_PACKAGE_NAME)) {
+      console.log("");
+      console.log(`You need to install ${HARDHAT_NAME} to use it. Please run:`);
+      const cmd = await getRecommendedDependenciesInstallationCommand({
+        [HARDHAT_PACKAGE_NAME]: `^${(await getPackageJson()).version}`,
+      });
+
+      console.log("");
+      console.log(cmd.join(" "));
+      console.log("");
+    }
+
     return;
   }
 
@@ -239,18 +271,30 @@ export async function createProject() {
 
   let shouldShowInstallationInstructions = true;
 
-  // TODO-HH: This should be updated because now hardhat needs to
-  //  be installed locally
   if (await canInstallRecommendedDeps()) {
-    const recommendedDeps = Object.keys(SAMPLE_PROJECT_DEPENDENCIES);
+    const dependencies = await getDependencies();
+
+    const recommendedDeps = Object.keys(dependencies);
+
+    const dependenciesToInstall = fromEntries(
+      Object.entries(dependencies).filter(([name]) => !isInstalled(name))
+    );
+
     const installedRecommendedDeps = recommendedDeps.filter(isInstalled);
+    const installedExceptHardhat = installedRecommendedDeps.filter(
+      (name) => name !== HARDHAT_PACKAGE_NAME
+    );
 
     if (installedRecommendedDeps.length === recommendedDeps.length) {
       shouldShowInstallationInstructions = false;
-    } else if (installedRecommendedDeps.length === 0) {
-      const shouldInstall = await confirmRecommendedDepsInstallation();
+    } else if (installedExceptHardhat.length === 0) {
+      const shouldInstall = await confirmRecommendedDepsInstallation(
+        dependenciesToInstall
+      );
       if (shouldInstall) {
-        const installed = await installRecommendedDependencies();
+        const installed = await installRecommendedDependencies(
+          dependenciesToInstall
+        );
 
         if (!installed) {
           console.warn(
@@ -335,13 +379,18 @@ async function isYarnProject() {
   return fsExtra.pathExists("yarn.lock");
 }
 
-async function installRecommendedDependencies() {
+async function installRecommendedDependencies(dependencies: Dependencies) {
   console.log("");
-  const installCmd = await getRecommendedDependenciesInstallationCommand();
+  const installCmd = await getRecommendedDependenciesInstallationCommand(
+    dependencies,
+    false
+  );
   return installDependencies(installCmd[0], installCmd.slice(1));
 }
 
-async function confirmRecommendedDepsInstallation(): Promise<boolean> {
+async function confirmRecommendedDepsInstallation(
+  depsToInstall: Dependencies
+): Promise<boolean> {
   const { default: enquirer } = await import("enquirer");
 
   let responses: {
@@ -355,7 +404,7 @@ async function confirmRecommendedDepsInstallation(): Promise<boolean> {
       createConfirmationPrompt(
         "shouldInstallPlugin",
         `Do you want to install the sample project's dependencies with ${packageManager} (${Object.keys(
-          SAMPLE_PROJECT_DEPENDENCIES
+          depsToInstall
         ).join(" ")})?`
       ),
     ]);
@@ -368,7 +417,7 @@ async function confirmRecommendedDepsInstallation(): Promise<boolean> {
     throw e;
   }
 
-  return responses.shouldInstallPlugin === true;
+  return responses.shouldInstallPlugin;
 }
 
 export async function confirmTelemetryConsent(): Promise<boolean> {
@@ -420,18 +469,24 @@ async function installDependencies(
   });
 }
 
-async function getRecommendedDependenciesInstallationCommand(): Promise<
-  string[]
-> {
-  const deps = Object.entries(SAMPLE_PROJECT_DEPENDENCIES).map(
-    ([name, version]) => `${name}@${version}`
+async function getRecommendedDependenciesInstallationCommand(
+  dependencies: Dependencies,
+  quoteDependencies = true
+): Promise<string[]> {
+  const deps = Object.entries(dependencies).map(([name, version]) =>
+    quoteDependencies ? `"${name}@${version}"` : `${name}@${version}`
   );
 
   if (await isYarnProject()) {
     return ["yarn", "add", "--dev", ...deps];
   }
 
-  const npmInstall = ["npm", "install"];
+  return ["npm", "install", "--save-dev", ...deps];
+}
 
-  return [...npmInstall, "--save-dev", ...deps];
+async function getDependencies() {
+  return {
+    [HARDHAT_PACKAGE_NAME]: `^${(await getPackageJson()).version}`,
+    ...SAMPLE_PROJECT_DEPENDENCIES,
+  };
 }

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -1,3 +1,5 @@
+import { getPackageJsonPath } from "../util/packageInfo";
+
 /**
  * Returns true if Hardhat is installed locally, by looking for it using the
  * node module resolution logic.
@@ -7,8 +9,13 @@
  */
 export function isHardhatInstalledLocally(configPath?: string) {
   try {
-    require.resolve("hardhat", { paths: [configPath ?? process.cwd()] });
-    return true;
+    const resolvedPackageJson = require.resolve("hardhat/package.json", {
+      paths: [configPath ?? process.cwd()],
+    });
+
+    const thisPackageJson = getPackageJsonPath();
+
+    return resolvedPackageJson === thisPackageJson;
   } catch (_) {
     return false;
   }

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -1,8 +1,8 @@
 import { getPackageJsonPath } from "../util/packageInfo";
 
 /**
- * Returns true if Hardhat is installed locally, by looking for it using the
- * node module resolution logic.
+ * Returns true if Hardhat is installed locally or linked from its repository,
+ * by looking for it using the node module resolution logic.
  *
  * If a config file is provided, we start looking for it from it. Otherwise,
  * we use the current working directory.

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -7,7 +7,7 @@ import { getPackageJsonPath } from "../util/packageInfo";
  * If a config file is provided, we start looking for it from it. Otherwise,
  * we use the current working directory.
  */
-export function isHardhatInstalledLocally(configPath?: string) {
+export function isHardhatInstalledLocallyOrLinked(configPath?: string) {
   try {
     const resolvedPackageJson = require.resolve("hardhat/package.json", {
       paths: [configPath ?? process.cwd()],

--- a/packages/hardhat-core/src/internal/core/project-structure.ts
+++ b/packages/hardhat-core/src/internal/core/project-structure.ts
@@ -31,7 +31,7 @@ export function getUserConfigPath() {
 }
 
 export async function getRecommendedGitIgnore() {
-  const packageRoot = await getPackageRoot();
+  const packageRoot = getPackageRoot();
   const gitIgnorePath = path.join(packageRoot, "recommended-gitignore.txt");
 
   return fsExtra.readFile(gitIgnorePath, "utf-8");

--- a/packages/hardhat-core/src/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/src/internal/util/packageInfo.ts
@@ -2,12 +2,12 @@ import findup from "find-up";
 import fsExtra from "fs-extra";
 import path from "path";
 
-async function getPackageJsonPath(): Promise<string> {
+export function getPackageJsonPath(): string {
   return findClosestPackageJson(__filename)!;
 }
 
 export async function getPackageRoot(): Promise<string> {
-  const packageJsonPath = await getPackageJsonPath();
+  const packageJsonPath = getPackageJsonPath();
 
   return path.dirname(packageJsonPath);
 }

--- a/packages/hardhat-core/src/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/src/internal/util/packageInfo.ts
@@ -6,7 +6,7 @@ export function getPackageJsonPath(): string {
   return findClosestPackageJson(__filename)!;
 }
 
-export async function getPackageRoot(): Promise<string> {
+export function getPackageRoot(): string {
   const packageJsonPath = getPackageJsonPath();
 
   return path.dirname(packageJsonPath);
@@ -25,7 +25,7 @@ export function findClosestPackageJson(file: string): string | null {
 }
 
 export async function getPackageJson(): Promise<PackageJson> {
-  const root = await getPackageRoot();
+  const root = getPackageRoot();
   return fsExtra.readJSON(path.join(root, "package.json"));
 }
 

--- a/packages/hardhat-core/test/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/test/internal/util/packageInfo.ts
@@ -17,6 +17,6 @@ describe("packageInfo", () => {
 
   it("should give the right package root", async () => {
     const root = await fsExtra.realpath(path.join(__dirname, "..", "..", ".."));
-    assert.equal(await getPackageRoot(), root);
+    assert.equal(getPackageRoot(), root);
   });
 });


### PR DESCRIPTION
This PR updates the project creation module:

* It now creates a `package.json` if none is present.
* The empty config creation also instructs you to install hardhat if necessary
* The sample project also installs hardhat if necessary
* We now use double quotes between packages when printing instructions.

It also fix a minor error in the sample project, that prevented its sample script from working as instructed after the sample project is initialized.

Finally, it fixes a bug in how we detect that an installation is not local.