### PR TITLE
Fix native compiler in windows

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -732,6 +732,15 @@ Please check your Internet connection.`,
 Please check your Internet connection.`,
       shouldBeReported: false,
     },
+    CANT_GET_COMPILER: {
+      number: 504,
+      message: "The solc compiler couldn't be obtained for version %version%",
+      title: "The solc compiler couldn't be obtained",
+      description: `Hardhat couldn't obtain a valid solc compiler.
+
+Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
+      shouldBeReported: true,
+    },
   },
   BUILTIN_TASKS: {
     COMPILE_FAILURE: {

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -115,12 +115,14 @@ export class CompilerDownloader {
 
       await this.verifyCompiler(compilerBuild, downloadedFilePath);
 
-      switch (compilerBuild.platform) {
-        case CompilerPlatform.LINUX:
-        case CompilerPlatform.MACOS:
-          fsExtra.chmodSync(downloadedFilePath, 0o755);
-          break;
-        case CompilerPlatform.WINDOWS:
+      if (
+        compilerBuild.platform === CompilerPlatform.LINUX ||
+        compilerBuild.platform === CompilerPlatform.MACOS
+      ) {
+        fsExtra.chmodSync(downloadedFilePath, 0o755);
+      } else if (compilerBuild.platform === CompilerPlatform.WINDOWS) {
+        // some window builds are zipped, some are not
+        if (downloadedFilePath.endsWith(".zip")) {
           const zip = new AdmZip(downloadedFilePath);
           zip.extractAllTo(
             path.join(this._compilersDir, compilerBuild.version)
@@ -130,7 +132,7 @@ export class CompilerDownloader {
             compilerBuild.version,
             "solc.exe"
           );
-          break;
+        }
       }
 
       return {

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import debug from "debug";
 import fsExtra from "fs-extra";
 import os from "os";
@@ -140,8 +141,10 @@ export class CompilerDownloader {
       if (HardhatError.isHardhatError(e)) {
         throw e;
       }
-      log(
-        `There was an unexpected problem downloading the compiler: ${e.message}`
+      console.warn(
+        chalk.yellow(
+          `There was an unexpected problem downloading the compiler: ${e.message}`
+        )
       );
     }
   }

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -319,10 +319,11 @@ describe("Compiler downloader", function () {
         const compilerBin = require.resolve("solc/soljson.js");
         await fsExtra.copy(compilerBin, downloadedPath);
 
-        const { compilerPath } = await mockDownloader.getDownloadedCompilerPath(
+        const compilerPathResult = await mockDownloader.getDownloadedCompilerPath(
           localCompilerBuild.version
         );
-        assert.equal(compilerPath, downloadedPath);
+        assert.isDefined(compilerPathResult);
+        assert.equal(compilerPathResult!.compilerPath, downloadedPath);
       });
 
       it("Should throw and delete it if it doesn't", async function () {

--- a/packages/hardhat-core/test/internal/solidity/compiler/index.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/index.ts
@@ -27,10 +27,10 @@ describe("Compiler", () => {
 
     beforeEach(async function () {
       downloader = new CompilerDownloader(this.tmpDir);
-      const { compilerPath } = await downloader.getDownloadedCompilerPath(
+      const compilerPathResult = await downloader.getDownloadedCompilerPath(
         solcVersion
       );
-      solcPath = compilerPath;
+      solcPath = compilerPathResult!.compilerPath;
     });
 
     it("Should compile contracts correctly", async () => {
@@ -123,10 +123,10 @@ contract A {}
       downloader = new CompilerDownloader(this.tmpDir, {
         forceSolcJs: true,
       });
-      const { compilerPath } = await downloader.getDownloadedCompilerPath(
+      const compilerPathResult = await downloader.getDownloadedCompilerPath(
         solcVersion
       );
-      solcPath = compilerPath;
+      solcPath = compilerPathResult!.compilerPath;
     });
 
     it("Should compile contracts correctly", async () => {


### PR DESCRIPTION
This PR avoids unzipping .exe files in windows. This is necessary
because solc builds for windows are distributed as .exe files from
0.7.2, but were .zip files before that version.

This also tries to handle unexpected errors when the compiler is
obtained: if there was such an error while getting a native compiler,
it tries to fetch the solcjs compiler instead.

One downside of this is that if a problem appears and it's persistent,
then hardhat will try to download the native compiler *every time*, fail
and *then* use solcjs.