### PR TITLE
Always store formatted jsons

### DIFF
--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -217,7 +217,7 @@ export class Artifacts implements IArtifacts {
     );
 
     const buildInfoPath = path.join(buildInfoDir, `${buildInfoName}.json`);
-    await fsExtra.writeJson(buildInfoPath, buildInfo);
+    await fsExtra.writeJson(buildInfoPath, buildInfo, { spaces: 2 });
 
     return buildInfoPath;
   }

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -185,9 +185,13 @@ async function getAction() {
 }
 
 async function createPackageJson() {
-  await fsExtra.writeJson("package.json", {
-    name: "hardhat-project",
-  });
+  await fsExtra.writeJson(
+    "package.json",
+    {
+      name: "hardhat-project",
+    },
+    { spaces: 2 }
+  );
 }
 
 export async function createProject() {

--- a/packages/hardhat-core/src/internal/util/global-dir.ts
+++ b/packages/hardhat-core/src/internal/util/global-dir.ts
@@ -88,7 +88,7 @@ export async function writeAnalyticsId(clientId: string) {
         clientId,
       },
     },
-    { encoding: "utf-8" }
+    { encoding: "utf-8", spaces: 2 }
   );
   log(`Stored clientId ${clientId}`);
 }
@@ -123,5 +123,5 @@ export function writeTelemetryConsent(consent: boolean) {
   const configDir = getConfigDirSync();
   const telemetryConsentPath = path.join(configDir, "telemetry-consent.json");
 
-  fs.writeJSONSync(telemetryConsentPath, { consent });
+  fs.writeJSONSync(telemetryConsentPath, { consent }, { spaces: 2 });
 }

--- a/packages/hardhat-vyper/src/compilation.ts
+++ b/packages/hardhat-vyper/src/compilation.ts
@@ -255,7 +255,9 @@ async function saveLastUpdateCheckDate(image: Image, cachePath: string) {
   updates[HardhatDocker.imageToRepoTag(image)] = +new Date();
 
   await fsExtra.ensureDir(path.dirname(file));
-  await fsExtra.writeJSON(file, updates);
+  await fsExtra.writeJSON(file, updates, {
+    spaces: 2,
+  });
 }
 
 async function compileWithDocker(


### PR DESCRIPTION
This PR jus ensure that we format the jsons we store in the file system. The reason for this is that they are easier to work with.